### PR TITLE
app: disable refreshing and right-clicking in release mode

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,23 +1,49 @@
 <script>
+  import { onMount } from "svelte";
   import { Router, Link, Route } from "svelte-routing";
   import Jak1 from "/src/routes/Jak1.svelte";
   import Jak1_Setup from "/src/routes/setup/Jak1.svelte";
   import Settings from "/src/routes/Settings.svelte";
   import Sidebar from "/src/components/Sidebar.svelte";
+  import { initConfig } from "/src/lib/config";
+  import { isInDebugMode } from "/src/lib/setup";
 
   export let url = "";
 
-  // TODO - setup tauri app / initialize config
+  // Events
+  onMount(async () => {
+    await initConfig();
+  });
+
+  if (!isInDebugMode()) {
+    // Disable Right Click
+    document.addEventListener("contextmenu", (event) => event.preventDefault());
+    // Disable Refreshing (F5 / Ctrl+R)
+    document.addEventListener("keydown", (e) => {
+      if (e.code == "F5") {
+        e.preventDefault();
+      }
+      if (e.code == "KeyR" && e.ctrlKey) {
+        e.preventDefault();
+      }
+    });
+  }
 </script>
 
-<Router url={url}>
+<Router {url}>
   <main>
     <div class="video-container">
-      <div class="overlay"></div>
-      <video id="backgroundVideo" src="/src/assets/videos/background.mp4" autoplay muted loop></video>
+      <div class="overlay" />
+      <video
+        id="backgroundVideo"
+        src="/src/assets/videos/background.mp4"
+        autoplay
+        muted
+        loop
+      />
     </div>
     <div class="container">
-      <Sidebar></Sidebar>
+      <Sidebar />
       <div id="main">
         <Route path="/" component={Jak1} />
         <Route path="/jak1" component={Jak1} />
@@ -26,4 +52,3 @@
     </div>
   </main>
 </Router>
-

--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -9,7 +9,7 @@ export class InstallationStatus {
 }
 
 // TODO - is this set to `production` properly in release mode?
-function isInDebugMode() {
+export function isInDebugMode() {
   return process.env.NODE_ENV === "development";
 }
 

--- a/src/routes/setup/Jak1.svelte
+++ b/src/routes/setup/Jak1.svelte
@@ -83,7 +83,6 @@
 
   async function installProcess() {
     await clearInstallLogs(SupportedGame.Jak1);
-    // TODO - forbid refreshing
     setupInProgress = true;
     installSteps[currStep].status = InstallationStatus.InProgress;
     let output = await extractISO(isoPath);


### PR DESCRIPTION
Disables right click menu and refreshing when not in debug mode.

Also disables refreshing, this eliminates edge-cases like someone refreshing in the middle of installation.

Closes #6 