### PR TITLE
release: add `libglew` to linux dependencies to fix appimage creation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
         if: matrix.platform == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev libglew2.1 patchelf
 
       - name: install app dependencies and build it
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,6 +55,10 @@ jobs:
           popd
           node ./.github/scripts/download-binaries/index.js
 
+      - name: prepare release config
+        run: |
+          npm run prepare-release-config
+
       - name: prepare resources for build
         if: matrix.os == 'windows'
         run: |
@@ -86,6 +90,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
         with:
+          configPath: "./.tauri/release-config.combined.json"
           tagName: "v__VERSION__"
           releaseName: "OpenGOAL Launcher v__VERSION__"
           releaseBody: "See the assets to download this version and install."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
         if: matrix.platform == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev libglew2.1 patchelf
 
       - name: install app dependencies
         run: |

--- a/.tauri/.gitignore
+++ b/.tauri/.gitignore
@@ -1,0 +1,1 @@
+release-config.combined.json

--- a/.tauri/release-config.json
+++ b/.tauri/release-config.json
@@ -1,0 +1,12 @@
+{
+  "tauri": {
+    "updater": {
+      "active": true,
+      "endpoints": [
+        "https://raw.githubusercontent.com/open-goal/launcher/main/.tauri/latest-release.json"
+      ],
+      "dialog": true,
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEJGQjRCQzI1N0I4REZBMzIKUldReStvMTdKYnkwditmb2IvK3hJUm9xdjJMMlN2N2tRejlON0djdE03YnhGOHlaTzVwUy9IY2YK"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "update-bin": "node ./scripts/update-binaries.js && npm run package",
     "lint": "npx prettier --check .",
     "format": "npx prettier --write .",
-    "mock-bin": "node ./scripts/dummy-binaries.js"
+    "mock-bin": "node ./scripts/dummy-binaries.js",
+    "prepare-release-config": "node ./scripts/merge-config.js",
+    "release": "npm run prepare-release-config && npm run tauri build -- --config ./.tauri/release-config.combined.json"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.30",

--- a/scripts/merge-config.js
+++ b/scripts/merge-config.js
@@ -1,0 +1,18 @@
+// The tauri-action for Github Actions doesn't let you merge configs
+// like can be done with --config on the `tauri` command
+// instead it replaces the file
+//
+// So for now, do the merge ourselves, why? because we don't want to maintain two configs
+// that will just end up drifting and breaking on release time.
+
+import { readFileSync, writeFileSync } from "fs";
+
+let releaseOptions = JSON.parse(readFileSync("./.tauri/release-config.json"));
+let existingConfig = JSON.parse(readFileSync("./src-tauri/tauri.conf.json"));
+
+existingConfig.tauri.updater = releaseOptions.tauri.updater;
+
+writeFileSync(
+  "./.tauri/release-config.combined.json",
+  JSON.stringify(existingConfig, null, 2)
+);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "app"
-version = "0.0.1"
+version = "0.2.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -45,14 +45,6 @@
         "timestampUrl": ""
       }
     },
-    "updater": {
-      "active": true,
-      "endpoints": [
-        "https://raw.githubusercontent.com/open-goal/launcher/main/.tauri/latest-release.json"
-      ],
-      "dialog": true,
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEJGQjRCQzI1N0I4REZBMzIKUldReStvMTdKYnkwditmb2IvK3hJUm9xdjJMMlN2N2tRejlON0djdE03YnhGOHlaTzVwUy9IY2YK"
-    },
     "allowlist": {
       "all": true,
       "fs": {


### PR DESCRIPTION
Because we use mock binaries in the normal build to just get things working, it was fine.  But in the release mode, we use the actual binaries.  The AppImage process detects that we need to bundle libglew within it (because we include glewinfo) but that library cant be found in the system.

This fixes that, and should make linux builds work when it comes to release time.

I added the dependency to both builds just to keep things consistent between them.

Closes #35 
Closes #38 