### PR TITLE
Attempt to add caching to our builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,6 +42,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev libglew2.1 patchelf
 
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: npm-${{ matrix.platform }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-${{ matrix.platform }}
+
       - name: install app dependencies and build it
         run: |
           npm ci

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,6 +31,11 @@ jobs:
         with:
           toolchain: stable
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: tauri-build-${{ matrix.platform }}
+          workspaces: src-tauri
+
       - name: install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-latest'
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: npm
 
       - name: Install Rust Stable
         uses: actions-rs/toolchain@v1
@@ -42,13 +43,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev libglew2.1 patchelf
-
-      - name: Cache NPM dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: npm-${{ matrix.platform }}-${{ hashFiles('package-lock.json') }}
-          restore-keys: npm-${{ matrix.platform }}
 
       - name: Install NPM Dependencies and Mock Binaries
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,42 +21,43 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: setup node
+      - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: 16
 
-      - name: install Rust stable
+      - name: Install Rust Stable
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
 
       - uses: Swatinem/rust-cache@v2
+        name: Cache Rust Build
         with:
           shared-key: tauri-build-${{ matrix.platform }}
           workspaces: src-tauri
 
-      - name: install dependencies (ubuntu only)
+      - name: Install Linux Dependencies
         if: matrix.platform == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev libglew2.1 patchelf
 
-      - name: Cache dependencies
+      - name: Cache NPM dependencies
         uses: actions/cache@v3
         with:
           path: ~/.npm
           key: npm-${{ matrix.platform }}-${{ hashFiles('package-lock.json') }}
           restore-keys: npm-${{ matrix.platform }}
 
-      - name: install app dependencies and build it
+      - name: Install NPM Dependencies and Mock Binaries
         run: |
           npm ci
           npm run mock-bin
           npm run build
-          ls ./src-tauri/data/
 
       - uses: tauri-apps/tauri-action@v0
+        name: Build Tauri App
         timeout-minutes: 30
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: npm
 
       - name: Install Rust Stable
         uses: actions-rs/toolchain@v1
@@ -44,13 +45,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev libglew2.1 patchelf
-
-      - name: Cache NPM dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: npm-${{ matrix.platform }}-${{ hashFiles('package-lock.json') }}
-          restore-keys: npm-${{ matrix.platform }}
 
       - name: Install NPM Dependencies
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,28 +23,41 @@ jobs:
         with:
           token: ${{ secrets.BOT_PAT }}
 
-      - name: setup node
+      - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: 16
 
-      - name: install Rust stable
+      - name: Install Rust Stable
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
 
-      - name: install dependencies (ubuntu only)
+      - uses: Swatinem/rust-cache@v2
+        name: Cache Rust Build
+        with:
+          shared-key: tauri-build-${{ matrix.platform }}
+          workspaces: src-tauri
+
+      - name: Install Linux Dependencies
         if: matrix.platform == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev libglew2.1 patchelf
 
-      - name: install app dependencies
+      - name: Cache NPM dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: npm-${{ matrix.platform }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-${{ matrix.platform }}
+
+      - name: Install NPM Dependencies
         run: |
           npm ci
           npm run build
 
-      - name: download jak-project release
+      - name: Download jak-project Release
         env:
           JAK_PROJ_VERSION: latest
           PLATFORM: ${{ matrix.os }}
@@ -55,11 +68,11 @@ jobs:
           popd
           node ./.github/scripts/download-binaries/index.js
 
-      - name: prepare release config
+      - name: Prepare Release Config
         run: |
           npm run prepare-release-config
 
-      - name: prepare resources for build
+      - name: Prepare Resources for Build
         if: matrix.os == 'windows'
         run: |
           mv ./opengoal*.zip ./opengoal.zip
@@ -76,7 +89,7 @@ jobs:
           ls ./src-tauri/bin
           ls ./src-tauri/data
 
-      - name: prepare resources for build
+      - name: Prepare Resources for Build
         if: matrix.os == 'linux'
         run: |
           mv ./opengoal*.tar.gz ./opengoal.tar.gz
@@ -94,6 +107,7 @@ jobs:
           ls ./src-tauri/data
 
       - uses: tauri-apps/tauri-action@v0
+        name: Build Tauri App
         timeout-minutes: 30
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The rust compiler is slow, and the vast majority of our compilation time is on dependencies (like 450+ dependencies).

Try to adding caching so builds aren't a nightmare