### PR TITLE
Fix log flushing and add `await` to `confirm`ation dialog calls

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,7 +112,7 @@ jobs:
           releaseName: "OpenGOAL Launcher v__VERSION__"
           releaseBody: "See the assets to download this version and install."
           releaseDraft: true
-          prerelease: true
+          prerelease: false
 
   update-release-meta:
     if: github.repository == 'open-goal/launcher'

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -22,7 +22,7 @@
     // For now, we'll just handle all close events ourselves
     await appWindow.listen("tauri://close-requested", async () => {
       if ($isInstalling) {
-        const confirmed = confirm(
+        const confirmed = await confirm(
           "Installation still in progress, are you sure you want to exit?"
         );
         if (confirmed) {

--- a/src/components/games/GameControls.svelte
+++ b/src/components/games/GameControls.svelte
@@ -35,7 +35,7 @@
   }
 
   async function onClickUninstall() {
-    const confirmed = confirm("Are you sure you want to uninstall?");
+    const confirmed = await confirm("Are you sure you want to uninstall?");
     if (confirmed) {
       await launcherConfig.setInstallStatus(activeGame, false);
       dispatch("change");


### PR DESCRIPTION
The types file for the `confirm` call is wrong, the call definitely returns a `Promise` so `await` was needed

This also simplifies and fixes the log flushing, before logs weren't flushing until subsequent calls were made, this should make the logs flush either immediately (in the case of install ones) or periodically in the background (for all others)