### PR TITLE
release: improve tag finding to respect caret ranges

### DIFF
--- a/.github/scripts/download-binaries/index.js
+++ b/.github/scripts/download-binaries/index.js
@@ -38,14 +38,12 @@ const octokit = new Octokit({
 });
 
 async function getAllReleases() {
-  return await octokit
-    .paginate(octokit.rest.repos.listReleases, {
-      owner: "open-goal",
-      repo: "jak-project",
-      per_page: 100
-    });
+  return await octokit.paginate(octokit.rest.repos.listReleases, {
+    owner: "open-goal",
+    repo: "jak-project",
+    per_page: 100,
+  });
 }
-
 
 let requestedVersion = process.env.JAK_PROJ_VERSION;
 let release = undefined;
@@ -58,14 +56,20 @@ if (requestedVersion === "latest") {
 } else {
   if (requestedVersion.startsWith("^")) {
     // Caret syntax, search for the maximum minor/patch without changing major
-    let [major, minor, patch] = requestedVersion.replace("^", "").split(".").map(str => parseInt(str));
+    let [major, minor, patch] = requestedVersion
+      .replace("^", "")
+      .split(".")
+      .map((str) => parseInt(str));
     // Releases are not guaranteed to be in order, so we have to get them all and find the max
     let highestMinor = -1;
     let highestPatch = -1;
     let pickedRelease = undefined;
     let releases = await getAllReleases();
     for (const release of releases) {
-      let [tagMajor, tagMinor, tagPatch] = release.tag_name.replace("v", "").split(".").map(str => parseInt(str));
+      let [tagMajor, tagMinor, tagPatch] = release.tag_name
+        .replace("v", "")
+        .split(".")
+        .map((str) => parseInt(str));
       if (tagMajor != major) {
         continue;
       }
@@ -73,8 +77,7 @@ if (requestedVersion === "latest") {
         highestMinor = tagMinor;
         highestPatch = tagPatch;
         pickedRelease = release;
-      }
-      else if (tagPatch > highestPatch && tagMinor == highestMinor) {
+      } else if (tagPatch > highestPatch && tagMinor == highestMinor) {
         highestPatch = tagPatch;
         pickedRelease = release;
       }

--- a/.github/scripts/download-binaries/index.js
+++ b/.github/scripts/download-binaries/index.js
@@ -3,6 +3,7 @@ import { throttling } from "@octokit/plugin-throttling";
 import { retry } from "@octokit/plugin-retry";
 import * as fs from "fs";
 import * as path from "path";
+import { exit } from "process";
 
 Octokit.plugin(throttling);
 Octokit.plugin(retry);
@@ -36,6 +37,16 @@ const octokit = new Octokit({
   },
 });
 
+async function getAllReleases() {
+  return await octokit
+    .paginate(octokit.rest.repos.listReleases, {
+      owner: "open-goal",
+      repo: "jak-project",
+      per_page: 100
+    });
+}
+
+
 let requestedVersion = process.env.JAK_PROJ_VERSION;
 let release = undefined;
 if (requestedVersion === "latest") {
@@ -44,15 +55,50 @@ if (requestedVersion === "latest") {
     repo: "jak-project",
   });
   release = releaseData;
-  requestedVersion = releaseData.tag_name;
 } else {
-  const { data: releaseData } = await octokit.rest.repos.getReleaseByTag({
-    owner: "open-goal",
-    repo: "jak-project",
-    tag: requestedVersion,
-  });
-  release = releaseData;
+  if (requestedVersion.startsWith("^")) {
+    // Caret syntax, search for the maximum minor/patch without changing major
+    let [major, minor, patch] = requestedVersion.replace("^", "").split(".").map(str => parseInt(str));
+    // Releases are not guaranteed to be in order, so we have to get them all and find the max
+    let highestMinor = -1;
+    let highestPatch = -1;
+    let pickedRelease = undefined;
+    let releases = await getAllReleases();
+    for (const release of releases) {
+      let [tagMajor, tagMinor, tagPatch] = release.tag_name.replace("v", "").split(".").map(str => parseInt(str));
+      if (tagMajor != major) {
+        continue;
+      }
+      if (tagMinor > highestMinor) {
+        highestMinor = tagMinor;
+        highestPatch = tagPatch;
+        pickedRelease = release;
+      }
+      else if (tagPatch > highestPatch && tagMinor == highestMinor) {
+        highestPatch = tagPatch;
+        pickedRelease = release;
+      }
+    }
+    if (pickedRelease !== undefined) {
+      release = pickedRelease;
+    }
+  } else if (requestedVersion.startsWith("v")) {
+    // Given a specific tag, go fetch it
+    const { data: releaseData } = await octokit.rest.repos.getReleaseByTag({
+      owner: "open-goal",
+      repo: "jak-project",
+      tag: requestedVersion,
+    });
+    release = releaseData;
+  }
 }
+
+if (release === undefined) {
+  console.log(`Couldn't find a release with ${requestedVersion}`);
+  exit(1);
+}
+
+console.log(`Using - ${release.tag_name}`);
 
 let platform = process.env.PLATFORM;
 
@@ -68,7 +114,7 @@ const { data: releaseAssets } = await octokit.rest.repos.listReleaseAssets({
 let downloadDir = process.env.DOWNLOAD_DIR;
 for (var i = 0; i < releaseAssets.length; i++) {
   const asset = releaseAssets[i];
-  if (asset.name.toLowerCase().includes(platform)) {
+  if (asset.name.toLowerCase().startsWith(`opengoal-${platform}`)) {
     const assetDownload = await octokit.rest.repos.getReleaseAsset({
       owner: "open-goal",
       repo: "jak-project",
@@ -86,7 +132,7 @@ for (var i = 0; i < releaseAssets.length; i++) {
 
 // Write out the version we grabbed
 const binaryBundleMeta = {
-  version: requestedVersion,
+  version: release.tag_name,
 };
 fs.writeFileSync(
   "./metadata.json",

--- a/.github/scripts/download-binaries/package-lock.json
+++ b/.github/scripts/download-binaries/package-lock.json
@@ -5,13 +5,13 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "download-binaries",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "@octokit/plugin-retry": "^3.0.9",
         "@octokit/plugin-throttling": "^3.5.2",
-        "@octokit/rest": "^18.12.0",
-        "glob": "^7.2.0"
+        "@octokit/rest": "^18.12.0"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -155,11 +155,6 @@
         "@octokit/openapi-types": "^11.2.0"
       }
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
     "node_modules/before-after-hook": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
@@ -170,62 +165,10 @@
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
     },
-    "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
     "node_modules/deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "node_modules/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/is-plain-object": {
       "version": "5.0.0",
@@ -233,17 +176,6 @@
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/node-fetch": {
@@ -271,14 +203,6 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/tr46": {
@@ -442,11 +366,6 @@
         "@octokit/openapi-types": "^11.2.0"
       }
     },
-    "balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
     "before-after-hook": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
@@ -457,69 +376,15 @@
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
     },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
     "deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
     "is-plain-object": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
-    },
-    "minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -536,11 +401,6 @@
       "requires": {
         "wrappy": "1"
       }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "tr46": {
       "version": "0.0.3",

--- a/.github/scripts/update-release-metadata/index.js
+++ b/.github/scripts/update-release-metadata/index.js
@@ -96,7 +96,7 @@ for (var i = 0; i < releaseAssets.length; i++) {
 // TODO - no macOS yet
 const releaseMeta = {
   name: release.tag_name,
-  notes: "UPDATE",
+  notes: "Release Notes TODO",
   pub_date: release.created_at,
   platforms: {
     "linux-x86_64": {

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Download jak-project Release
         env:
-          JAK_PROJ_VERSION: latest
+          JAK_PROJ_VERSION: "^0.0.0"
           PLATFORM: ${{ matrix.os }}
           DOWNLOAD_DIR: "./"
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test/out/
 *.tar.gz
 glewinfo.txt
 /metadata.json
+.svelte-kit/


### PR DESCRIPTION
This guards us against breaking changes if they are properly given a major tag.  Better than just using `latest`

This is one of the two things I wanted to get in before we fully enable automated releases.