### PR TITLE
ci: adjust release kickoff when coming from `jak-project`

### DIFF
--- a/.github/workflows/kickoff-release.yaml
+++ b/.github/workflows/kickoff-release.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           token: ${{ secrets.BOT_PAT }}
 
-      - name: setup node
+      - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: 16
@@ -35,8 +35,9 @@ jobs:
         with:
           toolchain: stable
 
-      - name: bump versions with new tag value
+      - name: Bump Version - Manual Kickoff
         id: version-bump
+        if: github.event_name != 'repository_dispatch'
         run: |
           npm version ${{ github.event.inputs.bump }} --no-git-tag-version
           NEW_VERSION=$(awk '/version/{gsub(/("|",)/,"",$2);print $2}' package.json)
@@ -46,7 +47,19 @@ jobs:
           cargo generate-lockfile
           echo "##[set-output name=new_version;]${NEW_VERSION}"
 
-      - name: commit version bump
+      - name: Bump Minor Version - Jak Project Release
+        id: version-bump
+        if: github.event_name == 'repository_dispatch'
+        run: |
+          npm version minor --no-git-tag-version
+          NEW_VERSION=$(awk '/version/{gsub(/("|",)/,"",$2);print $2}' package.json)
+          sed -i "/APP_VERSION/c\version = \""$NEW_VERSION"\" # APP_VERSION" ./src-tauri/Cargo.toml
+          sed -i "/\"version\":/c\    \"version\": \""$NEW_VERSION"\"" ./src-tauri/tauri.conf.json
+          cd ./src-tauri
+          cargo generate-lockfile
+          echo "##[set-output name=new_version;]${NEW_VERSION}"
+
+      - name: Commit Version Bump
         uses: EndBug/add-and-commit@v9
         with:
           default_author: github_actor

--- a/.github/workflows/kickoff-release.yaml
+++ b/.github/workflows/kickoff-release.yaml
@@ -47,8 +47,18 @@ jobs:
           cargo generate-lockfile
           echo "##[set-output name=new_version;]${NEW_VERSION}"
 
+      - name: Commit Version Bump
+        uses: EndBug/add-and-commit@v9
+        if: github.event_name != 'repository_dispatch'
+        with:
+          default_author: github_actor
+          author_name: "OpenGOALBot"
+          author_email: "OpenGOALBot@users.noreply.github.com"
+          message: "release: bump to version - ${{ steps.version-bump.outputs.new_version }}"
+          tag: "v${{ steps.version-bump.outputs.new_version }}"
+
       - name: Bump Minor Version - Jak Project Release
-        id: version-bump
+        id: version-bump-jak-prj
         if: github.event_name == 'repository_dispatch'
         run: |
           npm version minor --no-git-tag-version
@@ -61,9 +71,10 @@ jobs:
 
       - name: Commit Version Bump
         uses: EndBug/add-and-commit@v9
+        if: github.event_name == 'repository_dispatch'
         with:
           default_author: github_actor
           author_name: "OpenGOALBot"
           author_email: "OpenGOALBot@users.noreply.github.com"
-          message: "release: bump to version - ${{ steps.version-bump.outputs.new_version }}"
-          tag: "v${{ steps.version-bump.outputs.new_version }}"
+          message: "release: bump to version - ${{ steps.version-bump-jak-prj.outputs.new_version }}"
+          tag: "v${{ steps.version-bump-jak-prj.outputs.new_version }}"


### PR DESCRIPTION
Two reasons:
- we want jak-project updates to be minor versions just to add some semantic meaning to the numbers
- right now the scripts depend on the value from the `workflow_dispatch` which won't be available for the repo dispatch.