### PR TITLE
release: fetch changes when creating release for better notes

### DIFF
--- a/.github/scripts/download-binaries/index.js
+++ b/.github/scripts/download-binaries/index.js
@@ -4,6 +4,7 @@ import { retry } from "@octokit/plugin-retry";
 import * as fs from "fs";
 import * as path from "path";
 import { exit } from "process";
+import * as core from "@actions/core";
 
 Octokit.plugin(throttling);
 Octokit.plugin(retry);
@@ -141,3 +142,5 @@ fs.writeFileSync(
   "./metadata.json",
   JSON.stringify(binaryBundleMeta, null, 2) + "\n"
 );
+// Set the output in the github actions step as well
+core.setOutput("jak_project_tag", release.tag_name);

--- a/.github/scripts/download-binaries/package-lock.json
+++ b/.github/scripts/download-binaries/package-lock.json
@@ -9,9 +9,27 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@actions/core": "^1.9.1",
         "@octokit/plugin-retry": "^3.0.9",
         "@octokit/plugin-throttling": "^3.5.2",
         "@octokit/rest": "^18.12.0"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
+      "dependencies": {
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+      "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+      "dependencies": {
+        "tunnel": "^0.0.6"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -210,10 +228,26 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/universal-user-agent": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
       "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -236,6 +270,23 @@
     }
   },
   "dependencies": {
+    "@actions/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
+      "requires": {
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@actions/http-client": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+      "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+      "requires": {
+        "tunnel": "^0.0.6"
+      }
+    },
     "@octokit/auth-token": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
@@ -407,10 +458,20 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+    },
     "universal-user-agent": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
       "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/.github/scripts/download-binaries/package.json
+++ b/.github/scripts/download-binaries/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@actions/core": "^1.9.1",
     "@octokit/plugin-retry": "^3.0.9",
     "@octokit/plugin-throttling": "^3.5.2",
     "@octokit/rest": "^18.12.0"

--- a/.github/scripts/update-release-metadata/index.js
+++ b/.github/scripts/update-release-metadata/index.js
@@ -84,12 +84,23 @@ function changesFromBody(releaseBody) {
       i++;
     }
     description = description.join(" ");
-    // Create the change
-    changes.push({
-      description: description,
-      contributor: contributor,
-      pullRequestUrl: pullRequestUrl,
-    });
+
+    // Check if the pull request has already been added
+    let duplicate = false;
+    for (const entry of changes) {
+      if (entry.pullRequestUrl === pullRequestUrl) {
+        duplicate = true;
+        break;
+      }
+    }
+    if (!duplicate) {
+      // Create the change
+      changes.push({
+        description: description,
+        contributor: contributor,
+        pullRequestUrl: pullRequestUrl,
+      });
+    }
   }
   return changes;
 }

--- a/.github/scripts/update-release-metadata/index.js
+++ b/.github/scripts/update-release-metadata/index.js
@@ -35,32 +35,116 @@ const octokit = new Octokit({
   },
 });
 
-let tagToSearchFor = process.env.TAG_VALUE.split("refs/tags/")[1];
+// Parse out changes from the markdown body
+/*
 
-const { data: recentReleases } = await octokit.rest.repos.listReleases({
-  owner: "open-goal",
-  repo: "launcher",
-  per_page: 100,
-});
+## What's Changed
+* jak1/speedruns: Some final touches for speedrunning in jak 1 by @xTVaser in https://github.com/open-goal/jak-project/pull/1830
 
-let release = undefined;
-for (var i = 0; i < recentReleases.length; i++) {
-  if (recentReleases[i].tag_name == tagToSearchFor) {
-    release = recentReleases[i];
-    break;
+**Full Changelog**: https://github.com/open-goal/jak-project/compare/v0.1.28...v0.1.29
+
+*/
+// Releases take the following format, if there is no `What's Changed` then it's a superfluous release, no changes
+function changesFromBody(releaseBody) {
+  // Simple parsing to try and stay as little tied to the auto-format as possible
+  // Iterate through the lines, grab all github pull request links
+  let changes = [];
+  const lines = releaseBody.split("\r\n");
+  for (const line of lines) {
+    // check if the string contains a pull request link
+    if (!line.toLowerCase().match(/.*github.com\/[^/]*\/[^/]*\/pull.*/)) {
+      continue;
+    }
+    // Parse out the critical parts of the line
+    let description = [];
+    let contributor = null;
+    let pullRequestUrl = null;
+    const words = line.replace(/^(\* )/, "").split(" ");
+    let i = 0;
+    while (i < words.length) {
+      const word = words[i];
+      if (word == "by") {
+        // found contributor, the next word should be the contributor
+        if (i + 1 < words.length) {
+          contributor = words[i + 1].replace(/^(@)/, "");
+          i++;
+        }
+        continue;
+      }
+      if (word == "in") {
+        // found url, the next word should be the link
+        if (i + 1 < words.length) {
+          pullRequestUrl = words[i + 1];
+          i++;
+        }
+        continue;
+      }
+      // Otherwise, just add it to the description
+      description.push(word);
+      i++;
+    }
+    description = description.join(" ");
+    // Create the change
+    changes.push({
+      description: description,
+      contributor: contributor,
+      pullRequestUrl: pullRequestUrl,
+    });
   }
+  return changes;
 }
 
-if (release === undefined) {
-  console.log(`Could not find release with tag name: ${tagToSearchFor}`);
+// Get all values from workflow
+const releaseId = process.env.RELEASE_ID;
+const jakProjectTag = process.env.JAK_PROJ_TAG;
+
+if (releaseId === undefined || releaseId === "") {
+  console.log("You didn't provide RELEASE_ID");
   process.exit(1);
+}
+
+if (jakProjectTag === undefined || jakProjectTag === "") {
+  console.log("You didn't provide JAK_PROJ_TAG");
+  process.exit(1);
+}
+
+// Pull down the `launcher` release metadata
+const launcherRelease = await octokit.rest.repos.release({
+  owner: "open-goal",
+  repo: "launcher",
+  release_id: releaseId,
+});
+
+if (launcherRelease === undefined) {
+  console.log(`Couldn't find launcher release with id ${releaseId}`);
+  process.exit(1);
+}
+
+// Get changes for the launcher
+const launcherChanges = changesFromBody(launcherRelease.body);
+
+// Let's see if we've updated the jak-project version by looking at what we currently have in the file
+const currentReleaseNotes = JSON.parse(
+  JSON.parse(fs.readFileSync("./.tauri/latest-release.json")).notes
+);
+let jakProjectChanges = [];
+if (currentReleaseNotes.jak_proj_tag !== jakProjectTag) {
+  // we've changed versions, let's go grab the release notes from there and prepare them
+  // this check is done so we don't add jak-project release notes to releases that havn't actually changed anything
+  // it'd be possible to skip these in the launcher's frontend but better to absorb that pain here
+  const jakProjectRelease = await octokit.rest.repos.getReleaseByTag({
+    owner: "open-goal",
+    repo: "jak-project",
+    tag: jakProjectTag,
+  });
+  jakProjectChanges = changesFromBody(jakProjectRelease.body);
 }
 
 // Retrieve linux and windows signatures
 const { data: releaseAssets } = await octokit.rest.repos.listReleaseAssets({
   owner: "open-goal",
   repo: "launcher",
-  release_id: release.id,
+  release_id: releaseId,
   per_page: 100,
 });
 
@@ -68,7 +152,6 @@ let linuxSignature = "";
 let windowsSignature = "";
 for (var i = 0; i < releaseAssets.length; i++) {
   const asset = releaseAssets[i];
-  console.log(asset.name);
   if (asset.name.toLowerCase().endsWith("appimage.tar.gz.sig")) {
     const assetDownload = await octokit.rest.repos.getReleaseAsset({
       owner: "open-goal",
@@ -95,14 +178,20 @@ for (var i = 0; i < releaseAssets.length; i++) {
 
 // TODO - no macOS yet
 const releaseMeta = {
-  name: release.tag_name,
-  notes: "Release Notes TODO",
-  pub_date: release.created_at,
+  name: launcherRelease.tag_name,
+  notes: JSON.stringify({
+    jak_proj_tag: jakProjectTag,
+    changes: {
+      jak_project: jakProjectChanges,
+      launcher: launcherChanges,
+    },
+  }),
+  pub_date: launcherRelease.created_at,
   platforms: {
     "linux-x86_64": {
       signature: linuxSignature,
       url: `https://github.com/open-goal/launcher/releases/download/${
-        release.tag_name
+        launcherRelease.tag_name
       }/OpenGOAL-Launcher_${tagToSearchFor.replace(
         "v",
         ""
@@ -111,7 +200,7 @@ const releaseMeta = {
     "windows-x86_64": {
       signature: windowsSignature,
       url: `https://github.com/open-goal/launcher/releases/download/${
-        release.tag_name
+        launcherRelease.tag_name
       }/OpenGOAL-Launcher_${tagToSearchFor.replace("v", "")}_x64_en-US.msi.zip`,
     },
   },
@@ -121,9 +210,10 @@ fs.writeFileSync(
   JSON.stringify(releaseMeta, null, 2) + "\n"
 );
 
+// Publish the release
 await octokit.rest.repos.updateRelease({
   owner: "open-goal",
   repo: "launcher",
-  release_id: release.id,
+  release_id: launcherRelease.id,
   draft: false,
 });

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-20.04, windows-latest]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -40,7 +40,7 @@ jobs:
           workspaces: src-tauri
 
       - name: Install Linux Dependencies
-        if: matrix.platform == 'ubuntu-latest'
+        if: matrix.platform == 'ubuntu-20.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev libglew2.1 patchelf

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,17 +6,40 @@ on:
       - v*
 
 jobs:
-  publish-tauri:
+  create-release:
     if: github.repository == 'open-goal/launcher'
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.get_release_id.outputs.release_id }}
+    steps:
+      # Create the release, use `gh` CLI so we can auto generate the notes
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
+        run: |
+          TAG_VAL=$(echo ${{ github.REF }} | awk -F'refs/tags/' '{print $2}')
+          gh release create ${TAG_VAL} --generate-notes --draft --repo open-goal/launcher
+      # Get the internal ID of the release so that Tauri's action can use it to upload assets
+      - name: Get Release ID
+        id: get_release_id
+        run: |
+          TAG_VAL=$(echo ${{ github.REF }} | awk -F'refs/tags/' '{print $2}')
+          RELEASE_ID=$(gh release view "$TAG_VAL" --repo open-goal/launcher --json id --template '{{.id}}')
+          echo "##[set-output name=release_id;]${RELEASE_ID}"
+
+  build-app:
+    if: github.repository == 'open-goal/launcher'
+    needs: [create-release]
+    outputs:
+      jak_project_tag: ${{ steps.download_jak_project_binaries.outputs.jak_project_tag }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - platform: ubuntu-latest
+          - platform: ubuntu-20.04
             os: linux
-          - platform: windows-latest
+          - platform: ubuntu-20.04
             os: windows
-
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
@@ -52,6 +75,7 @@ jobs:
           npm run build
 
       - name: Download jak-project Release
+        id: download_jak_project_binaries
         env:
           JAK_PROJ_VERSION: "^0.0.0"
           PLATFORM: ${{ matrix.os }}
@@ -76,7 +100,7 @@ jobs:
           ls ./artifact-out/data
           mkdir -p ./src-tauri/bin/
           cp ./artifact-out/*.exe ./src-tauri/bin || true
-          cp ./third-party/glew_2.1.0/windows/glewinfo.exe ./src-tauri/bin
+          cp ./third-party/glew_2.2.0/windows/glewinfo.exe ./src-tauri/bin
           cp -r ./artifact-out/data ./src-tauri
           mv ./metadata.json ./src-tauri/data/metadata.json
           ls ./src-tauri
@@ -93,7 +117,7 @@ jobs:
           ls ./artifact-out/data
           mkdir -p ./src-tauri/bin/
           cp ./artifact-out/* ./src-tauri/bin || true
-          cp ./third-party/glew_2.1.0/linux/glewinfo ./src-tauri/bin
+          cp ./third-party/glew_2.2.0/linux/glewinfo ./src-tauri/bin
           cp -r ./artifact-out/data ./src-tauri
           mv ./metadata.json ./src-tauri/data/metadata.json
           ls ./src-tauri
@@ -108,20 +132,12 @@ jobs:
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
         with:
           configPath: "./.tauri/release-config.combined.json"
-          tagName: "v__VERSION__"
-          releaseName: "OpenGOAL Launcher v__VERSION__"
-          releaseBody: "See the assets to download this version and install."
-          releaseDraft: true
-          prerelease: false
+          releaseId: ${{needs.create-release.outputs.release_id}}
 
-  update-release-meta:
+  publish-release:
     if: github.repository == 'open-goal/launcher'
-    needs: publish-tauri
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [ubuntu-latest]
-    runs-on: ${{ matrix.platform }}
+    needs: [create-release, build-app]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -132,11 +148,13 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: npm
 
       - name: update release metadata and publish the release
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
-          TAG_VALUE: ${{ github.REF }}
+          RELEASE_ID: ${{needs.create-release.outputs.release_id}}
+          JAK_PROJ_TAG: ${{needs.build-app.outputs.jak_project_tag}}
         run: |
           pushd ./.github/scripts/update-release-metadata
           npm ci

--- a/.tauri/latest-release.json
+++ b/.tauri/latest-release.json
@@ -1,6 +1,6 @@
 {
   "name": "v1.5.0",
-  "notes": "Release Notes TODO",
+  "notes": "{\"jak_proj_tag\":\"v0.1.29\",\"changes\":{\"jak_project\":[],\"launcher\":[]}}",
   "pub_date": "2022-09-07T23:08:16Z",
   "platforms": {
     "linux-x86_64": {


### PR DESCRIPTION
This should fetch changes from `jak-project` and from this repo itself to create a JSON string to be consumed by the frontend to provide better patch notes.

This should probably be tested but it's not _too_ drastic of a change.

Related to #8