### PR TITLE
ci: avoid rate limits when downloading the artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,6 +56,7 @@ jobs:
           JAK_PROJ_VERSION: "^0.0.0"
           PLATFORM: ${{ matrix.os }}
           DOWNLOAD_DIR: "./"
+          GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
         run: |
           pushd ./.github/scripts/download-binaries
           npm ci


### PR DESCRIPTION
Ran into this with the most recent release and had to keep re-running it and pray to win the container lottery.