### PR TITLE
config: properly verify access to the installation directory

### DIFF
--- a/src-tauri/src/util/file.rs
+++ b/src-tauri/src/util/file.rs
@@ -54,3 +54,14 @@ pub fn read_last_lines_from_file(path: &PathBuf, lines: usize) -> Result<String,
       .join("\n"),
   )
 }
+
+pub fn touch_file(path: &PathBuf) -> std::io::Result<()> {
+  match std::fs::OpenOptions::new()
+    .create(true)
+    .write(true)
+    .open(path)
+  {
+    Ok(_) => Ok(()),
+    Err(e) => Err(e),
+  }
+}

--- a/src/lib/rpc/window.ts
+++ b/src/lib/rpc/window.ts
@@ -11,13 +11,15 @@ export async function openDir(directory: string): Promise<void> {
   }
 }
 
-export async function closeSplashScreen() {
+export async function closeSplashScreen(): Promise<boolean> {
   try {
     invoke("close_splashscreen");
+    return true;
   } catch (e) {
     exceptionLog(
       "Unexpected error encountered when closing the splash screen",
       e
     );
   }
+  return false;
 }

--- a/src/routes/settings/Folders.svelte
+++ b/src/routes/settings/Folders.svelte
@@ -26,8 +26,10 @@
           newInstallDir !== undefined &&
           newInstallDir !== currentInstallationDirectory
         ) {
-          await setInstallationDirectory(newInstallDir);
-          currentInstallationDirectory = newInstallDir;
+          const errMsg = await setInstallationDirectory(newInstallDir);
+          if (errMsg === null) {
+            currentInstallationDirectory = newInstallDir;
+          }
         }
       }}
     />

--- a/src/splash/Splash.svelte
+++ b/src/splash/Splash.svelte
@@ -60,7 +60,10 @@
     await new Promise((res) => setTimeout(res, 1000));
     currentProgress = 100;
     await new Promise((res) => setTimeout(res, 500));
-    await closeSplashScreen();
+    const errorClosing = await closeSplashScreen();
+    if (errorClosing) {
+      currentStatusText = "Problem closing Splash";
+    }
   }
 </script>
 


### PR DESCRIPTION
The original way I was checking if the installation directory was writable was wrong.
- https://doc.rust-lang.org/std/fs/struct.Permissions.html is just on _files_ not directories, and can easily be manipulated:
> On Windows this returns [FILE_ATTRIBUTE_READONLY](https://docs.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants). If FILE_ATTRIBUTE_READONLY is set then writes to the file will fail but the user may still have permission to change this flag.

So instead I now try to touch a file, and if it fails -- I assume the directory is not writable.  This is still technically a little fragile (the directory may become restricted _later_ -- imagine someone originally launches with admin privledges, then later as another user).  But this is atleast a lot better.

Fixes #125 

Need to follow up by improving things when changing the directory before cutting a release.  As this is a more legit way of encountering this issue https://github.com/open-goal/launcher/issues/109