### PR TITLE
config: wipe installation settings when the directory is changed

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -220,6 +220,23 @@ impl LauncherConfig {
       _ => (),
     }
 
+    // If the directory changes (it's not a no-op), we need to:
+    // - wipe any installed games (make them reinstall)
+    // - wipe the active version/version types
+    match &self.installation_dir {
+      Some(old_dir) => {
+        if *old_dir != new_dir {
+          self.active_version = None;
+          self.active_version_folder = None;
+          // TODO - when i cleanup the gross code below, also clean this up
+          self.games.jak1.is_installed = false;
+          self.games.jak1.version = None;
+          self.games.jak1.version_folder = None;
+        }
+      }
+      _ => (),
+    }
+
     self.installation_dir = Some(new_dir);
     self.save_config()?;
     Ok(None)

--- a/src/lib/rpc/config.ts
+++ b/src/lib/rpc/config.ts
@@ -1,6 +1,7 @@
 import { toastStore } from "$lib/stores/ToastStore";
 import { invoke } from "@tauri-apps/api/tauri";
 import { errorLog, exceptionLog } from "./logging";
+import type { VersionFolders } from "./versions";
 
 export async function oldDataDirectoryExists(): Promise<boolean> {
   try {
@@ -116,5 +117,22 @@ export async function getInstalledVersionFolder(
       e
     );
     return null;
+  }
+}
+
+export async function saveActiveVersionChange(
+  folder: VersionFolders,
+  newVersion: String
+): Promise<boolean> {
+  try {
+    await invoke("save_active_version_change", {
+      versionFolder: folder,
+      newActiveVersion: newVersion,
+    });
+    return true;
+  } catch (e) {
+    exceptionLog("Unable to save version change", e);
+    toastStore.makeToast("Couldn't save version change", "error");
+    return false;
   }
 }

--- a/src/lib/rpc/versions.ts
+++ b/src/lib/rpc/versions.ts
@@ -59,20 +59,6 @@ export async function openVersionFolder(folder: VersionFolders) {
   }
 }
 
-export async function saveActiveVersionChange(
-  folder: VersionFolders,
-  newVersion: String
-) {
-  try {
-    return await invoke("save_active_version_change", {
-      versionFolder: folder,
-      newActiveVersion: newVersion,
-    });
-  } catch (e) {
-    exceptionLog("Unable to save version change", e);
-  }
-}
-
 export async function getActiveVersion(): Promise<string | null> {
   try {
     return await invoke("get_active_tooling_version", {});

--- a/src/routes/settings/Folders.svelte
+++ b/src/routes/settings/Folders.svelte
@@ -3,6 +3,7 @@
     getInstallationDirectory,
     setInstallationDirectory,
   } from "$lib/rpc/config";
+  import { VersionStore } from "$lib/stores/VersionStore";
   import { folderPrompt } from "$lib/utils/file";
   import { Label, Input } from "flowbite-svelte";
   import { onMount } from "svelte";
@@ -28,6 +29,10 @@
         ) {
           const errMsg = await setInstallationDirectory(newInstallDir);
           if (errMsg === null) {
+            if (currentInstallationDirectory !== newInstallDir) {
+              $VersionStore.activeVersionType = null;
+              $VersionStore.activeVersionName = null;
+            }
             currentInstallationDirectory = newInstallDir;
           }
         }

--- a/src/routes/settings/versions/DevelVersions.svelte
+++ b/src/routes/settings/versions/DevelVersions.svelte
@@ -6,11 +6,11 @@
     listDownloadedVersions,
     openVersionFolder,
     removeVersion,
-    saveActiveVersionChange,
   } from "$lib/rpc/versions";
   import VersionList from "./VersionList.svelte";
   import type { ReleaseInfo } from "$lib/utils/github";
   import { VersionStore } from "$lib/stores/VersionStore";
+  import { saveActiveVersionChange } from "$lib/rpc/config";
 
   let versionsLoaded = false;
 
@@ -49,15 +49,16 @@
   }
 
   async function onSaveVersionChange(evt: any) {
-    await saveActiveVersionChange(
+    const success = await saveActiveVersionChange(
       "devel",
       $VersionStore.selectedVersions.devel
     );
-    // TODO if save was successful
-    $VersionStore.activeVersionType = "devel";
-    $VersionStore.activeVersionName = $VersionStore.selectedVersions.devel;
-    $VersionStore.selectedVersions.official = null;
-    $VersionStore.selectedVersions.unofficial = null;
+    if (success) {
+      $VersionStore.activeVersionType = "devel";
+      $VersionStore.activeVersionName = $VersionStore.selectedVersions.devel;
+      $VersionStore.selectedVersions.official = null;
+      $VersionStore.selectedVersions.unofficial = null;
+    }
   }
 
   async function onOpenVersionFolder(evt: any) {

--- a/src/routes/settings/versions/OfficialVersions.svelte
+++ b/src/routes/settings/versions/OfficialVersions.svelte
@@ -7,12 +7,12 @@
     listDownloadedVersions,
     openVersionFolder,
     removeVersion,
-    saveActiveVersionChange,
   } from "$lib/rpc/versions";
   import { listOfficialReleases, type ReleaseInfo } from "$lib/utils/github";
   import VersionList from "./VersionList.svelte";
   import { VersionStore } from "$lib/stores/VersionStore";
   import { UpdateStore } from "$lib/stores/AppStore";
+  import { saveActiveVersionChange } from "$lib/rpc/config";
 
   let versionsLoaded = false;
   let releases: ReleaseInfo[] = [];
@@ -85,15 +85,16 @@
   }
 
   async function saveOfficialVersionChange(evt) {
-    await saveActiveVersionChange(
+    const success = await saveActiveVersionChange(
       "official",
       $VersionStore.selectedVersions.official
     );
-    // TODO if save was successful
-    $VersionStore.activeVersionType = "official";
-    $VersionStore.activeVersionName = $VersionStore.selectedVersions.official;
-    $VersionStore.selectedVersions.unofficial = null;
-    $VersionStore.selectedVersions.devel = null;
+    if (success) {
+      $VersionStore.activeVersionType = "official";
+      $VersionStore.activeVersionName = $VersionStore.selectedVersions.official;
+      $VersionStore.selectedVersions.unofficial = null;
+      $VersionStore.selectedVersions.devel = null;
+    }
   }
 
   async function openOfficialVersionFolder(evt) {

--- a/src/routes/settings/versions/UnofficialVersions.svelte
+++ b/src/routes/settings/versions/UnofficialVersions.svelte
@@ -6,11 +6,11 @@
     listDownloadedVersions,
     openVersionFolder,
     removeVersion,
-    saveActiveVersionChange,
   } from "$lib/rpc/versions";
   import VersionList from "./VersionList.svelte";
   import type { ReleaseInfo } from "$lib/utils/github";
   import { VersionStore } from "$lib/stores/VersionStore";
+  import { saveActiveVersionChange } from "$lib/rpc/config";
 
   let versionsLoaded = false;
 
@@ -51,15 +51,17 @@
   }
 
   async function onSaveVersionChange(evt: any) {
-    await saveActiveVersionChange(
+    const success = await saveActiveVersionChange(
       "unofficial",
       $VersionStore.selectedVersions.unofficial
     );
-    // TODO if save was successful
-    $VersionStore.activeVersionType = "unofficial";
-    $VersionStore.activeVersionName = $VersionStore.selectedVersions.unofficial;
-    $VersionStore.selectedVersions.official = null;
-    $VersionStore.selectedVersions.devel = null;
+    if (success) {
+      $VersionStore.activeVersionType = "unofficial";
+      $VersionStore.activeVersionName =
+        $VersionStore.selectedVersions.unofficial;
+      $VersionStore.selectedVersions.official = null;
+      $VersionStore.selectedVersions.devel = null;
+    }
   }
 
   async function onOpenVersionFolder(evt: any) {


### PR DESCRIPTION
Related to #109 

If the user changes their install directory via the launcher -- it will be handled gracefully.  But this still doesn't account for a manual folder deletion.

Also cleaned up some error handling around tooling version changing