### PR TITLE
f/hack: temporary hack to fix spinner issue upon opening the launcher

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -27,6 +27,11 @@
       // TODO - confirm during an install
       await appWindow.close();
     });
+    // Temporary fix related to https://github.com/open-goal/launcher/issues/110
+    if (window.sessionStorage.getItem("refreshHack") !== "true") {
+      location.reload();
+      window.sessionStorage.setItem("refreshHack", "true");
+    }
   });
 
   if (!isInDebugMode()) {


### PR DESCRIPTION
Related to #110 

This will reload the page once, on initial startup.  I launched the app like 20 times in a row without issue so this atleast is a decent interim solution.