### PR TITLE
b/logs: do some things to try to log panics on startups

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2257,6 +2257,7 @@ dependencies = [
 name = "opengoal-launcher"
 version = "2.0.4"
 dependencies = [
+ "backtrace",
  "chrono",
  "dir-diff",
  "fern",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,7 @@ thiserror = "1.0.38"
 rev_buf_reader = "0.3.0"
 flate2 = "1.0.25"
 tar = "0.4.38"
+backtrace = "0.3.67"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,10 +38,7 @@
       "windows": {
         "certificateThumbprint": null,
         "digestAlgorithm": "sha256",
-        "timestampUrl": "",
-        "webviewInstallMode": {
-          "type": "embedBootstrapper"
-        }
+        "timestampUrl": ""
       }
     },
     "allowlist": {


### PR DESCRIPTION
Used this to help figure out why some people had issues launching the app.  It's useful enough to remain and it also cleans up some of the error handling in the `main.rs` file.