### PR TITLE
add logging for top-level crashes and fix window management

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "svelte": "^3.58.0",
     "svelte-preprocess": "^5.0.3",
     "tailwindcss": "^3.2.7",
-    "typescript": "^4.9.5",
+    "typescript": "^5.0.3",
     "vite": "^4.1.4"
   },
   "dependencies": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -776,6 +776,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74be3be809c18e089de43bdc504652bb2bc473fca8756131f8689db8cf079ba9"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +792,17 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
+dependencies = [
+ "libc",
+ "redox_users",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2260,6 +2280,7 @@ version = "2.0.6"
 dependencies = [
  "chrono",
  "dir-diff",
+ "directories",
  "fern",
  "flate2",
  "fs_extra",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2257,6 +2257,7 @@ dependencies = [
 name = "opengoal-launcher"
 version = "2.0.4"
 dependencies = [
+ "backtrace",
  "chrono",
  "dir-diff",
  "fern",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,26 +15,27 @@ rust-version = "1.61"
 tauri-build = { version = "1.2.1", features = [] }
 
 [dependencies]
-fs_extra = "1.3.0"
-serde_json = "1.0.95"
-serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.2.4", features = ["api-all", "devtools", "reqwest-client"] }
-zip-extract = "0.1.1"
-zip = { version = "0.6.2" }
-fern = { version = "0.6.1", features = ["date-based","colored"] }
 chrono = "0.4.23"
+dir-diff = "0.3.2"
+directories = "5.0.0"
+fern = { version = "0.6.1", features = ["date-based","colored"] }
+flate2 = "1.0.25"
+fs_extra = "1.3.0"
+futures-util = "0.3.26"
 log = "0.4.17"
 reqwest = { version = "0.11", features = ["json"] }
-tokio = { version = "1", features = ["full"] }
-futures-util = "0.3.26"
-sysinfo = "0.28.4"
-wgpu = "0.15.1"
-walkdir = "2.3.2"
-dir-diff = "0.3.2"
-thiserror = "1.0.40"
 rev_buf_reader = "0.3.0"
-flate2 = "1.0.25"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.95"
+sysinfo = "0.28.4"
 tar = "0.4.38"
+tauri = { version = "1.2.4", features = ["api-all", "devtools", "reqwest-client"] }
+thiserror = "1.0.40"
+tokio = { version = "1", features = ["full"] }
+walkdir = "2.3.2"
+wgpu = "0.15.1"
+zip = { version = "0.6.2" }
+zip-extract = "0.1.1"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,7 @@ thiserror = "1.0.38"
 rev_buf_reader = "0.3.0"
 flate2 = "1.0.25"
 tar = "0.4.38"
+backtrace = "0.3.67"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -27,6 +27,8 @@ pub enum CommandError {
   #[error("{0}")]
   OSOperation(String),
   #[error("{0}")]
+  WindowManagement(String),
+  #[error("{0}")]
   BinaryExecution(String),
   #[error("{0}")]
   Support(String),

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -5,14 +5,45 @@ use tauri::Manager;
 use super::CommandError;
 
 #[tauri::command]
-pub async fn close_splashscreen(window: tauri::Window) {
+pub async fn open_main_window(handle: tauri::AppHandle) {
+  // NOTE:
+  // When you create multiple static windows (inside the conf file)
+  // they are actually all running in the background
+  //
+  // This seemed to sometimes create a race condition where the app was not fully setup
+  // and when a panic hook was added that exited the process, the app would crash.
+  //
+  // So instead we make the main window at runtime, and close the splashscreen
+
+  // Create main window
+  // {
+  //   "title": "OpenGOAL Launcher",
+  //   "label": "main",
+  //   "width": 800,
+  //   "height": 600,
+  //   "resizable": false,
+  //   "fullscreen": false,
+  //   "visible": false,
+  //   "center": true,
+  //   "decorations": false
+  // },
+  tauri::WindowBuilder::new(
+    &handle,
+    "main", /* the unique window label */
+    tauri::WindowUrl::App("index.html".parse().unwrap()),
+  )
+  .title("OpenGOAL Launcher")
+  .resizable(false)
+  .fullscreen(false)
+  .visible(true)
+  .center()
+  .decorations(false)
+  .build()
+  .unwrap();
   // Close splashscreen
-  if let Some(splashscreen) = window.get_window("splashscreen") {
+  if let Some(splashscreen) = handle.app_handle().get_window("splashscreen") {
     splashscreen.close().unwrap();
   }
-  // Show main window
-  // TODO - cleanup this, return an error if we can't close it
-  window.get_window("main").unwrap().show().unwrap();
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -5,7 +5,7 @@ use tauri::Manager;
 use super::CommandError;
 
 #[tauri::command]
-pub async fn open_main_window(handle: tauri::AppHandle) {
+pub async fn open_main_window(handle: tauri::AppHandle) -> Result<(), CommandError> {
   // NOTE:
   // When you create multiple static windows (inside the conf file)
   // they are actually all running in the background
@@ -27,6 +27,7 @@ pub async fn open_main_window(handle: tauri::AppHandle) {
   //   "center": true,
   //   "decorations": false
   // },
+  log::info!("Creating main window");
   tauri::WindowBuilder::new(
     &handle,
     "main", /* the unique window label */
@@ -39,11 +40,15 @@ pub async fn open_main_window(handle: tauri::AppHandle) {
   .center()
   .decorations(false)
   .build()
-  .unwrap();
+  .map_err(|_| CommandError::WindowManagement(format!("Unable to create main launcher window")))?;
+  log::info!("Closing splash window");
   // Close splashscreen
   if let Some(splashscreen) = handle.app_handle().get_window("splashscreen") {
-    splashscreen.close().unwrap();
+    splashscreen
+      .close()
+      .map_err(|_| CommandError::WindowManagement(format!("Unable to close splash window")))?;
   }
+  Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,6 +3,7 @@
   windows_subsystem = "windows"
 )]
 
+use directories::UserDirs;
 use fern::colors::{Color, ColoredLevelConfig};
 use tauri::{Manager, RunEvent};
 use util::file::create_dir;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -65,17 +65,8 @@
     },
     "windows": [
       {
-        "title": "OpenGOAL Launcher",
-        "width": 800,
-        "height": 600,
-        "resizable": false,
-        "fullscreen": false,
-        "visible": false,
-        "center": true,
-        "decorations": false
-      },
-      {
         "title": "OpenGOAL Launcher - Splash",
+        "label": "splashscreen",
         "width": 200,
         "height": 300,
         "center": true,
@@ -84,8 +75,8 @@
         "resizable": false,
         "fullscreen": false,
         "url": "./src/splash/index.html",
-        "label": "splashscreen",
-        "visible": true
+        "visible": true,
+        "focus": true
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -69,6 +69,7 @@
     "windows": [
       {
         "title": "OpenGOAL Launcher",
+        "label": "main",
         "width": 800,
         "height": 600,
         "resizable": false,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,10 +38,7 @@
       "windows": {
         "certificateThumbprint": null,
         "digestAlgorithm": "sha256",
-        "timestampUrl": "",
-        "webviewInstallMode": {
-          "type": "embedBootstrapper"
-        }
+        "timestampUrl": ""
       }
     },
     "allowlist": {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -20,14 +20,9 @@
 
   // Events
   onMount(async () => {
-    // TODO - tauri doesn't seem to handle this event being unlistented to properly (go back to closing the window)
-    // - need to make an issue
-    // For now, we'll just handle all close events ourselves
-    await appWindow.listen("tauri://close-requested", async () => {
-      // TODO - confirm during an install
-      await appWindow.close();
-    });
     // Temporary fix related to https://github.com/open-goal/launcher/issues/110
+    // TODO - this doesn't feel required anymore after i fixed the window switching
+    // but let's keep it for now because im paranoid about the issue cropping up again...
     if (window.sessionStorage.getItem("refreshHack") !== "true") {
       location.reload();
       window.sessionStorage.setItem("refreshHack", "true");

--- a/src/lib/rpc/window.ts
+++ b/src/lib/rpc/window.ts
@@ -11,13 +11,13 @@ export async function openDir(directory: string): Promise<void> {
   }
 }
 
-export async function closeSplashScreen(): Promise<boolean> {
+export async function openMainWindow(): Promise<boolean> {
   try {
-    invoke("close_splashscreen");
+    invoke("open_main_window");
     return true;
   } catch (e) {
     exceptionLog(
-      "Unexpected error encountered when closing the splash screen",
+      "Unexpected error encountered when attempting to open the main window",
       e
     );
   }

--- a/src/splash/Splash.svelte
+++ b/src/splash/Splash.svelte
@@ -61,7 +61,7 @@
     currentProgress = 100;
     await new Promise((res) => setTimeout(res, 500));
     const errorClosing = await closeSplashScreen();
-    if (errorClosing) {
+    if (!errorClosing) {
       currentStatusText = "Problem closing Splash";
     }
   }

--- a/src/splash/Splash.svelte
+++ b/src/splash/Splash.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { closeSplashScreen } from "$lib/rpc/window";
+  import { openMainWindow } from "$lib/rpc/window";
   import { onMount } from "svelte";
   import logo from "$assets/images/icon.webp";
   import { folderPrompt } from "$lib/utils/file";
@@ -60,7 +60,7 @@
     await new Promise((res) => setTimeout(res, 1000));
     currentProgress = 100;
     await new Promise((res) => setTimeout(res, 500));
-    const errorClosing = await closeSplashScreen();
+    const errorClosing = await openMainWindow();
     if (errorClosing) {
       currentStatusText = "Problem closing Splash";
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4385,10 +4385,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.3.tgz#fe976f0c826a88d0a382007681cbb2da44afdedf"
+  integrity sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==
 
 unbzip2-stream@^1.0.9:
   version "1.4.3"


### PR DESCRIPTION
The original code to log these top-level crashes, ended up causing some crashes of it's own.  This was because I made the application exit if a panic was hit.

It seems like these panics were being hit due to a timing problem related to tauri's state management.  I realized that hiding a window doesn't mean it isn't running in the background, so the main window was always actually running.

This appears to be fixed now that I instead create the main window at runtime when the splash closes, so #110 is probably fine now, but I'm too paranoid to remove the hack.

This also fixed a problem where if you closed the splash window, the application would still be running in the background.