### PR TITLE
b/window: fix window size on non-100% scaling

### DIFF
--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -39,6 +39,8 @@ pub async fn open_main_window(handle: tauri::AppHandle) -> Result<(), CommandErr
   .visible(true)
   .center()
   .decorations(false)
+  .inner_size(800.0, 600.0)
+  .focused(true)
   .build()
   .map_err(|_| CommandError::WindowManagement(format!("Unable to create main launcher window")))?;
   log::info!("Closing splash window");


### PR DESCRIPTION
Forgot to provide the window size, so on non-100% scaling the window would not be the intended size.