### PR TITLE
b/game: support launching `gk` at version 0.1.35 and above

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2289,6 +2289,7 @@ dependencies = [
  "log",
  "reqwest",
  "rev_buf_reader",
+ "semver",
  "serde",
  "serde_json",
  "sysinfo",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ futures-util = "0.3.26"
 log = "0.4.17"
 reqwest = { version = "0.11", features = ["json"] }
 rev_buf_reader = "0.3.0"
+semver = "1.0.17"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.95"
 sysinfo = "0.28.4"

--- a/src/routes/settings/versions/OfficialVersions.svelte
+++ b/src/routes/settings/versions/OfficialVersions.svelte
@@ -80,7 +80,15 @@
     }
 
     // Sort releases by published date
-    releases = releases.sort((a, b) => b.date.localeCompare(a.date));
+    releases = releases.sort((a, b) => {
+      if (a.date === undefined) {
+        return 1;
+      }
+      if (b.date === undefined) {
+        return -1;
+      }
+      return b.date.localeCompare(a.date);
+    });
     versionsLoaded = true;
   }
 


### PR DESCRIPTION
This works, but creates a coupled released with the launcher.  ie. someone can update to 0.1.35 but not the launcher, causing issues.  Thinking on if it's worth solving or not (attempt with the old format if the execution fails).

It also breaks mods, which are unofficially supported here (unofficially to work out problems like this in the meantime) -- in the future mods need to specify what version they are backed by.  I originally thought this would work by detecting a failure to run with a `--version` flag, but the runtime continues gracefully, ignoring the argument.

The coupled release is unavoidable for issues mentioned here I believe https://github.com/open-goal/jak-project/pull/2532