### PR TITLE
logs: improve the logs around update checking

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Build
+name: 🔨 Build
 
 on:
   push:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: Linter
+name: 📝 Linter
 
 on:
   push:
@@ -11,7 +11,7 @@ on:
 
 jobs:
   frontend:
-    name: 📝 Formatting
+    name: Frontend
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -27,7 +27,7 @@ jobs:
           yarn install --frozen-lockfile
           yarn lint
   backend:
-    name: 📝 Formatting
+    name: Backend
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/src/components/header/Header.svelte
+++ b/src/components/header/Header.svelte
@@ -15,7 +15,7 @@
   } from "$lib/rpc/versions";
   import { getLatestOfficialRelease } from "$lib/utils/github";
   import { VersionStore } from "$lib/stores/VersionStore";
-  import { exceptionLog } from "$lib/rpc/logging";
+  import { exceptionLog, infoLog } from "$lib/rpc/logging";
   import { _ } from "svelte-i18n";
 
   let launcherVerison = null;
@@ -39,7 +39,9 @@
           changeLog = JSON.parse(updateResult.manifest.body);
         } catch (e) {
           exceptionLog(
-            "Could not parse changelog JSON from release metadata",
+            `Could not parse changelog JSON from release metadata - ${JSON.stringify(
+              updateResult
+            )}`,
             e
           );
         }
@@ -49,7 +51,7 @@
           date: updateResult.manifest.date,
           changeLog: changeLog,
         };
-        console.log("OG: Launcher Update Available");
+        infoLog(`Launcher Update Available`);
       } else {
         $UpdateStore.launcher = {
           updateAvailable: false,
@@ -57,7 +59,7 @@
           date: null,
           changeLog: [],
         };
-        console.log("OG: Launcher is up to date");
+        infoLog(`Launcher is up to date - ${JSON.stringify(updateResult)}`);
       }
     }
 


### PR DESCRIPTION
there were some left over `console.log`s here instead of `infoLog`s which end up in the log file for the launcher.  This should make it easier to debug "why didn't I get an update prompt" in the future (if that problem occurs again).