### PR TITLE
DRY the RPC invocations

### DIFF
--- a/src/lib/rpc/binaries.ts
+++ b/src/lib/rpc/binaries.ts
@@ -1,62 +1,35 @@
-import { toastStore } from "$lib/stores/ToastStore";
-import { invoke } from "@tauri-apps/api/tauri";
-import { exceptionLog } from "./logging";
+import { invoke_rpc } from "./rpc";
 
 interface InstallationOutput {
   msg: string | null;
   success: boolean;
 }
 
+function failed(msg: string): InstallationOutput {
+  return { success: false, msg };
+}
+
 export async function updateDataDirectory(
   gameName: string
 ): Promise<InstallationOutput> {
-  try {
-    return await invoke("update_data_directory", {
-      gameName: gameName,
-    });
-  } catch (e) {
-    exceptionLog(
-      "Unexpected error encountered when updating data directory",
-      e
-    );
-    return {
-      msg: "An unexpected error occurred",
-      success: false,
-    };
-  }
+  return await invoke_rpc("update_data_directory", { gameName }, () =>
+    failed("An unexpected error occurred")
+  );
 }
 
 export async function getEndOfLogs(): Promise<string> {
-  try {
-    return await invoke("get_end_of_logs", {});
-  } catch (e) {
-    exceptionLog(
-      "Unexpected error encountered when tail'ing extractor logs",
-      e
-    );
-    return "";
-  }
+  return await invoke_rpc("get_end_of_logs", {}, () => "");
 }
 
 export async function extractAndValidateISO(
   pathToIso: string,
   gameName: string
 ): Promise<InstallationOutput> {
-  try {
-    return await invoke("extract_and_validate_iso", {
-      pathToIso: pathToIso,
-      gameName: gameName,
-    });
-  } catch (e) {
-    exceptionLog(
-      "Unexpected error encountered when extracing and validating the ISO",
-      e
-    );
-    return {
-      msg: "An unexpected error occurred",
-      success: false,
-    };
-  }
+  return await invoke_rpc(
+    "extract_and_validate_iso",
+    { pathToIso, gameName },
+    () => failed("An unexpected error occurred")
+  );
 }
 
 export async function runDecompiler(
@@ -64,19 +37,11 @@ export async function runDecompiler(
   gameName: string,
   truncateLogs: boolean = false
 ): Promise<InstallationOutput> {
-  try {
-    return await invoke("run_decompiler", {
-      pathToIso: pathToIso,
-      gameName: gameName,
-      truncateLogs: truncateLogs,
-    });
-  } catch (e) {
-    exceptionLog("Unexpected error encountered when running the decompiler", e);
-    return {
-      msg: "An unexpected error occurred",
-      success: false,
-    };
-  }
+  return await invoke_rpc(
+    "run_decompiler",
+    { pathToIso, gameName, truncateLogs },
+    () => failed("An unexpected error occurred")
+  );
 }
 
 export async function runCompiler(
@@ -84,43 +49,20 @@ export async function runCompiler(
   gameName: string,
   truncateLogs: boolean = false
 ): Promise<InstallationOutput> {
-  try {
-    return await invoke("run_compiler", {
-      pathToIso: pathToIso,
-      gameName: gameName,
-      truncateLogs: truncateLogs,
-    });
-  } catch (e) {
-    exceptionLog("Unexpected error encountered when running the compiler", e);
-    return {
-      msg: "An unexpected error occurred",
-      success: false,
-    };
-  }
+  return await invoke_rpc(
+    "run_compiler",
+    { pathToIso, gameName, truncateLogs },
+    () => failed("An unexpected error occurred")
+  );
 }
 
 export async function launchGame(
   gameName: string,
-  inDebugMode: boolean
+  inDebug: boolean
 ): Promise<void> {
-  try {
-    return await invoke("launch_game", {
-      gameName: gameName,
-      inDebug: inDebugMode,
-    });
-  } catch (e) {
-    exceptionLog("Unexpected error encountered when launching the game", e);
-    toastStore.makeToast("Unable to launch game", "error");
-  }
+  return await invoke_rpc("launch_game", { gameName, inDebug }, () => {});
 }
 
 export async function openREPL(gameName: string): Promise<void> {
-  try {
-    return await invoke("open_repl", {
-      gameName: gameName,
-    });
-  } catch (e) {
-    exceptionLog("Unexpected error encountered when opening the REPL", e);
-    toastStore.makeToast("Unable to open REPL", "error");
-  }
+  return await invoke_rpc("open_repl", { gameName }, () => {});
 }

--- a/src/lib/rpc/binaries.ts
+++ b/src/lib/rpc/binaries.ts
@@ -13,7 +13,7 @@ export async function updateDataDirectory(
   gameName: string
 ): Promise<InstallationOutput> {
   return await invoke_rpc("update_data_directory", { gameName }, () =>
-    failed("An unexpected error occurred")
+    failed("Failed to update data directory")
   );
 }
 
@@ -28,7 +28,7 @@ export async function extractAndValidateISO(
   return await invoke_rpc(
     "extract_and_validate_iso",
     { pathToIso, gameName },
-    () => failed("An unexpected error occurred")
+    () => failed("Failed to extract and validate ISO")
   );
 }
 
@@ -40,7 +40,7 @@ export async function runDecompiler(
   return await invoke_rpc(
     "run_decompiler",
     { pathToIso, gameName, truncateLogs },
-    () => failed("An unexpected error occurred")
+    () => failed("Failed to run decompiler")
   );
 }
 
@@ -52,7 +52,7 @@ export async function runCompiler(
   return await invoke_rpc(
     "run_compiler",
     { pathToIso, gameName, truncateLogs },
-    () => failed("An unexpected error occurred")
+    () => failed("Failed to run compiler")
   );
 }
 
@@ -60,9 +60,19 @@ export async function launchGame(
   gameName: string,
   inDebug: boolean
 ): Promise<void> {
-  return await invoke_rpc("launch_game", { gameName, inDebug }, () => {});
+  return await invoke_rpc(
+    "launch_game",
+    { gameName, inDebug },
+    () => {},
+    "Unable to launch game"
+  );
 }
 
 export async function openREPL(gameName: string): Promise<void> {
-  return await invoke_rpc("open_repl", { gameName }, () => {});
+  return await invoke_rpc(
+    "open_repl",
+    { gameName },
+    () => {},
+    "Unable to open REPL"
+  );
 }

--- a/src/lib/rpc/config.ts
+++ b/src/lib/rpc/config.ts
@@ -13,7 +13,12 @@ export async function deleteOldDataDirectory(): Promise<void> {
 }
 
 export async function resetLauncherSettingsToDefaults(): Promise<boolean> {
-  const success = await invoke_rpc("reset_to_defaults", {}, () => false);
+  const success = await invoke_rpc(
+    "reset_to_defaults",
+    {},
+    () => false,
+    "Unable to reset settings"
+  );
   return success != false;
 }
 
@@ -29,7 +34,8 @@ export async function setInstallationDirectory(
   const errMsg = await invoke_rpc(
     "set_install_directory",
     { newDir },
-    () => "Unexpected error occurred"
+    () => "Unexpected error occurred",
+    "Invalid installation directory"
   );
 
   if (errMsg !== null) {
@@ -89,7 +95,8 @@ export async function saveActiveVersionChange(
   return invoke_rpc(
     "save_active_version_change",
     { versionFolder, newActiveVersion },
-    () => false
+    () => false,
+    "Couldn't save active version change"
   );
 }
 
@@ -102,6 +109,7 @@ export async function setLocale(locale: string): Promise<void> {
     "set_locale",
     { locale },
     () => {},
+    null, // no toast
     () => {
       svelteLocale.set(locale);
     }

--- a/src/lib/rpc/config.ts
+++ b/src/lib/rpc/config.ts
@@ -1,181 +1,117 @@
 import { toastStore } from "$lib/stores/ToastStore";
-import { invoke } from "@tauri-apps/api/tauri";
-import { errorLog, exceptionLog } from "./logging";
+import { locale as svelteLocale } from "svelte-i18n";
+import { errorLog } from "./logging";
+import { invoke_rpc } from "./rpc";
 import type { VersionFolders } from "./versions";
-import { locale } from "svelte-i18n";
 
 export async function oldDataDirectoryExists(): Promise<boolean> {
-  try {
-    return await invoke("has_old_data_directory", {});
-  } catch (e) {
-    exceptionLog("Unable to check if old data directory exists", e);
-    return false;
-  }
+  return await invoke_rpc("has_old_data_directory", {}, () => false);
 }
 
 export async function deleteOldDataDirectory(): Promise<void> {
-  try {
-    await invoke("delete_old_data_directory", {});
-  } catch (e) {
-    exceptionLog("Unable to delete old data directory", e);
-  }
+  return await invoke_rpc("delete_old_data_directory", {}, () => {});
 }
 
 export async function resetLauncherSettingsToDefaults(): Promise<boolean> {
-  try {
-    await invoke("reset_to_defaults", {});
-    return true;
-  } catch (e) {
-    exceptionLog("Unable to reset launcher settings to defaults", e);
-    toastStore.makeToast("Unable to reset settings", "error");
-    return false;
-  }
+  const success = await invoke_rpc("reset_to_defaults", {}, () => false);
+  return success != false;
 }
 
 export async function getInstallationDirectory(): Promise<string | null> {
-  try {
-    return await invoke("get_install_directory", {});
-  } catch (e) {
-    exceptionLog("Unable to fetch install directory", e);
-    return null;
-  }
+  return await invoke_rpc("get_install_directory", {}, () => null);
 }
 
 export async function setInstallationDirectory(
-  newInstallDir: string
+  newDir: string
 ): Promise<string | null> {
-  try {
-    // TODO - not insanely crazy about this pattern (message in the response instead of the error)
-    // consider changing it
-    const errMsg: string = await invoke("set_install_directory", {
-      newDir: newInstallDir,
-    });
-    if (errMsg !== null) {
-      errorLog("Unable to set install directory");
-      toastStore.makeToast(errMsg, "error");
-    }
-    return errMsg;
-  } catch (e) {
-    exceptionLog("Unable to set install directory", e);
-    toastStore.makeToast("Invalid installation directory", "error");
-    return "Unexpected error occurred";
+  // TODO - not insanely crazy about this pattern (message in the response instead of the error)
+  // consider changing it
+  const errMsg = await invoke_rpc(
+    "set_install_directory",
+    { newDir },
+    () => "Unexpected error occurred"
+  );
+
+  if (errMsg !== null) {
+    // for RPC errors the log and toast are done by invoke_rpc
+    // but this is a successful RPC, so we need to do it here
+    errorLog("Unable to set install directory");
+    toastStore.makeToast(errMsg, "error");
   }
+
+  return errMsg;
 }
 
 export async function isAVXRequirementMet(
   force: boolean
 ): Promise<boolean | undefined> {
-  try {
-    return await invoke("is_avx_requirement_met", { force: force });
-  } catch (e) {
-    exceptionLog("Unable to check if AVX requirement was met", e);
-    return undefined;
-  }
+  return await invoke_rpc("is_avx_requirement_met", { force }, () => undefined);
 }
 
 export async function isOpenGLRequirementMet(
   force: boolean
 ): Promise<boolean | undefined> {
-  try {
-    const result = await invoke("is_opengl_requirement_met", { force: force });
-    if (typeof result === "boolean") {
-      return result;
-    }
-    return undefined;
-  } catch (e) {
-    exceptionLog("Unable to check if OpenGL requirement was met", e);
+  const result = await invoke_rpc(
+    "is_opengl_requirement_met",
+    { force },
+    () => undefined
+  );
+
+  if (typeof result !== "boolean") {
     return undefined;
   }
+
+  return result;
 }
 
 export async function finalizeInstallation(gameName: string): Promise<void> {
-  try {
-    return await invoke("finalize_installation", { gameName: gameName });
-  } catch (e) {
-    exceptionLog("Unable to finalize installation", e);
-  }
+  return await invoke_rpc("finalize_installation", { gameName }, () => {});
 }
 
 export async function isGameInstalled(gameName: string): Promise<boolean> {
-  try {
-    return await invoke("is_game_installed", { gameName: gameName });
-  } catch (e) {
-    exceptionLog("Unable to check if game was installed", e);
-    return false;
-  }
+  return await invoke_rpc("is_game_installed", { gameName }, () => false);
 }
 
 export async function getInstalledVersion(gameName: string): Promise<String> {
-  try {
-    return await invoke("get_installed_version", { gameName: gameName });
-  } catch (e) {
-    exceptionLog("Unable to check what version the game was installed with", e);
-    return null;
-  }
+  return invoke_rpc("get_installed_version", { gameName }, () => null);
 }
 
 export async function getInstalledVersionFolder(
   gameName: string
 ): Promise<String> {
-  try {
-    return await invoke("get_installed_version_folder", { gameName: gameName });
-  } catch (e) {
-    exceptionLog(
-      "Unable to check what version type the game was installed with",
-      e
-    );
-    return null;
-  }
+  return invoke_rpc("get_installed_version_folder", { gameName }, () => null);
 }
 
 export async function saveActiveVersionChange(
-  folder: VersionFolders,
-  newVersion: String
+  versionFolder: VersionFolders,
+  newActiveVersion: String
 ): Promise<boolean> {
-  try {
-    await invoke("save_active_version_change", {
-      versionFolder: folder,
-      newActiveVersion: newVersion,
-    });
-    return true;
-  } catch (e) {
-    exceptionLog("Unable to save version change", e);
-    toastStore.makeToast("Couldn't save version change", "error");
-    return false;
-  }
+  return invoke_rpc(
+    "save_active_version_change",
+    { versionFolder, newActiveVersion },
+    () => false
+  );
 }
 
 export async function getLocale(): Promise<string | null> {
-  try {
-    return await invoke("get_locale", {});
-  } catch (e) {
-    exceptionLog("Unable to get locale", e);
-    return "en-US";
-  }
+  return await invoke_rpc("get_locale", {}, () => "en-US");
 }
 
-export async function setLocale(locale_string: string): Promise<void> {
-  try {
-    await invoke("set_locale", { locale: locale_string });
-    locale.set(locale_string);
-  } catch (e) {
-    exceptionLog("Unable to set locale", e);
-  }
+export async function setLocale(locale: string): Promise<void> {
+  return await invoke_rpc(
+    "set_locale",
+    { locale },
+    () => {},
+    () => {
+      svelteLocale.set(locale);
+    }
+  );
 }
 
 export async function setBypassRequirements(bypass: boolean): Promise<void> {
-  try {
-    await invoke("set_bypass_requirements", { bypass: bypass });
-  } catch (e) {
-    exceptionLog("Unable to set bypress requirements", e);
-  }
+  return await invoke_rpc("set_bypass_requirements", { bypass }, () => {});
 }
 
 export async function getBypassRequirements(): Promise<boolean> {
-  try {
-    return await invoke("get_bypass_requirements", {});
-  } catch (e) {
-    exceptionLog("Unable to get bypress requirements setting", e);
-    return false;
-  }
+  return await invoke_rpc("get_bypass_requirements", {}, () => false);
 }

--- a/src/lib/rpc/game.ts
+++ b/src/lib/rpc/game.ts
@@ -1,26 +1,10 @@
-import { toastStore } from "$lib/stores/ToastStore";
-import { invoke } from "@tauri-apps/api/tauri";
-import { exceptionLog } from "./logging";
+import { invoke_rpc } from "./rpc";
 
 export async function uninstallGame(gameName: string): Promise<void> {
-  try {
-    return await invoke("uninstall_game", {
-      gameName: gameName,
-    });
-  } catch (e) {
-    exceptionLog("Unable to uninstall game", e);
-    toastStore.makeToast("Unable to uninstall game", "error");
-    // TODO - don't assume success
-  }
+  // TODO - don't assume success
+  return await invoke_rpc("uninstall_game", { gameName }, () => {});
 }
 
 export async function resetGameSettings(gameName: string): Promise<void> {
-  try {
-    return await invoke("reset_game_settings", {
-      gameName: gameName,
-    });
-  } catch (e) {
-    exceptionLog("Unable to reset game settings", e);
-    toastStore.makeToast("Unable to reset game settings", "error");
-  }
+  return await invoke_rpc("reset_game_settings", { gameName }, () => {});
 }

--- a/src/lib/rpc/game.ts
+++ b/src/lib/rpc/game.ts
@@ -1,10 +1,19 @@
 import { invoke_rpc } from "./rpc";
 
-export async function uninstallGame(gameName: string): Promise<void> {
-  // TODO - don't assume success
-  return await invoke_rpc("uninstall_game", { gameName }, () => {});
+export async function uninstallGame(gameName: string): Promise<boolean> {
+  return await invoke_rpc(
+    "uninstall_game",
+    { gameName },
+    () => false,
+    "Unable to uninstall game"
+  );
 }
 
 export async function resetGameSettings(gameName: string): Promise<void> {
-  return await invoke_rpc("reset_game_settings", { gameName }, () => {});
+  return await invoke_rpc(
+    "reset_game_settings",
+    { gameName },
+    () => {},
+    "Unable to reset game settings"
+  );
 }

--- a/src/lib/rpc/logging.ts
+++ b/src/lib/rpc/logging.ts
@@ -15,12 +15,16 @@ import { invoke } from "@tauri-apps/api/tauri";
 
 async function genericLog(level: string, log: String): Promise<void> {
   try {
+    // don't use invoke_rpc here because it will cause an infinite loop!
     return await invoke("frontend_log", {
       level: level,
       log: log,
     });
   } catch (e) {
-    console.log("[OG]: Unexpected error encountered when trying to log", e);
+    console.log(
+      "[opengoal_launcher]: Unexpected error encountered when trying to log",
+      e
+    );
   }
 }
 
@@ -46,6 +50,6 @@ export async function exceptionLog(log: String, error: any): Promise<void> {
       `${log} | Exception: ${error.name}:${error.message}, Stack: ${error.stack}, Cause: ${error.cause}`
     );
   } else {
-    errorLog(error);
+    errorLog(`${log} | ${error}`);
   }
 }

--- a/src/lib/rpc/rpc.ts
+++ b/src/lib/rpc/rpc.ts
@@ -14,7 +14,8 @@ import { errorLog, exceptionLog } from "./logging";
 export async function invoke_rpc<T>(
   cmd: string,
   args: InvokeArgs,
-  onError: (error: unknown) => T,
+  handleError: (error: unknown) => T,
+  toastOnError?: string,
   onSuccess?: (result: T) => T
 ): Promise<T> {
   try {
@@ -27,10 +28,11 @@ export async function invoke_rpc<T>(
   } catch (e) {
     if (typeof e === "string") {
       errorLog(`Error calling '${cmd}': ${e}`);
-      toastStore.makeToast(e, "error");
     } else {
       exceptionLog(`Error calling '${cmd}'`, e);
     }
-    return onError(e);
+    const toastMessage = toastOnError ?? "An unexpected error occurred";
+    toastStore.makeToast(toastMessage, "error");
+    return handleError(e);
   }
 }

--- a/src/lib/rpc/rpc.ts
+++ b/src/lib/rpc/rpc.ts
@@ -1,0 +1,36 @@
+import { toastStore } from "$lib/stores/ToastStore";
+import { invoke, type InvokeArgs } from "@tauri-apps/api/tauri";
+import { errorLog, exceptionLog } from "./logging";
+
+/**
+ * Wrapper around Tauri invoke that logs all errors.
+ * If the error is a string, it is also displayed as a toast.
+ *
+ * @param cmd The command to send to the backend
+ * @param args The arguments for the command
+ * @param onError If an error occurs, this is called with the error before returning
+ * @param onSuccess If the call succeeds, this is called with the result before returning
+ */
+export async function invoke_rpc<T>(
+  cmd: string,
+  args: InvokeArgs,
+  onError: (error: unknown) => T,
+  onSuccess?: (result: T) => T
+): Promise<T> {
+  try {
+    // this assumes the call is made in a way that does not trick the type inference
+    const result: T = await invoke(cmd, args);
+    if (onSuccess) {
+      return onSuccess(result);
+    }
+    return result;
+  } catch (e) {
+    if (typeof e === "string") {
+      errorLog(`Error calling '${cmd}': ${e}`);
+      toastStore.makeToast(e, "error");
+    } else {
+      exceptionLog(`Error calling '${cmd}'`, e);
+    }
+    return onError(e);
+  }
+}

--- a/src/lib/rpc/support.ts
+++ b/src/lib/rpc/support.ts
@@ -7,5 +7,10 @@ export async function generateSupportPackage(): Promise<void> {
     ["zip"],
     "opengoal-support-package.zip"
   );
-  return await invoke_rpc("generate_support_package", { userPath }, () => {});
+  return await invoke_rpc(
+    "generate_support_package",
+    { userPath },
+    () => {},
+    "Unable to create support package"
+  );
 }

--- a/src/lib/rpc/support.ts
+++ b/src/lib/rpc/support.ts
@@ -1,18 +1,11 @@
-import { toastStore } from "$lib/stores/ToastStore";
 import { saveFilePrompt } from "$lib/utils/file";
-import { invoke } from "@tauri-apps/api/tauri";
-import { exceptionLog } from "./logging";
+import { invoke_rpc } from "./rpc";
 
-export async function generateSupportPackage(): Promise<boolean> {
-  try {
-    const savePath = await saveFilePrompt(
-      "ZIP",
-      ["zip"],
-      "opengoal-support-package.zip"
-    );
-    return await invoke("generate_support_package", { userPath: savePath });
-  } catch (e) {
-    exceptionLog("Unable to generate support package", e);
-    toastStore.makeToast("Unable to create support package", "error");
-  }
+export async function generateSupportPackage(): Promise<void> {
+  const userPath = await saveFilePrompt(
+    "ZIP",
+    ["zip"],
+    "opengoal-support-package.zip"
+  );
+  return await invoke_rpc("generate_support_package", { userPath }, () => {});
 }

--- a/src/lib/rpc/versions.ts
+++ b/src/lib/rpc/versions.ts
@@ -20,6 +20,7 @@ export async function downloadOfficialVersion(
     "download_version",
     { version, url, versionFolder: "official" },
     () => false,
+    "Unable to download official version",
     () => true
   );
 }
@@ -32,12 +33,18 @@ export async function removeVersion(
     "remove_version",
     { version, versionFolder },
     () => false,
+    "Unable to remove version",
     () => true
   );
 }
 
 export async function openVersionFolder(versionFolder: VersionFolders) {
-  return await invoke_rpc("go_to_version_folder", { versionFolder }, () => {});
+  return await invoke_rpc(
+    "go_to_version_folder",
+    { versionFolder },
+    () => {},
+    "Unable to open version folder"
+  );
 }
 
 export async function getActiveVersion(): Promise<string | null> {
@@ -52,6 +59,7 @@ export async function ensureActiveVersionStillExists(): Promise<boolean> {
   return await invoke_rpc(
     "ensure_active_version_still_exists",
     {},
-    () => false
+    () => false,
+    "Error checking that active version exists"
   );
 }

--- a/src/lib/rpc/versions.ts
+++ b/src/lib/rpc/versions.ts
@@ -1,87 +1,57 @@
-import { toastStore } from "$lib/stores/ToastStore";
-import { invoke } from "@tauri-apps/api/tauri";
-import { exceptionLog } from "./logging";
+import { invoke_rpc } from "./rpc";
 
 export type VersionFolders = null | "official" | "unofficial" | "devel";
 
 export async function listDownloadedVersions(
-  folder: VersionFolders
+  versionFolder: VersionFolders
 ): Promise<string[]> {
-  try {
-    return await invoke("list_downloaded_versions", { versionFolder: folder });
-  } catch (e) {
-    exceptionLog("Unable to list out downloaded versions", e);
-    return [];
-  }
+  return await invoke_rpc(
+    "list_downloaded_versions",
+    { versionFolder },
+    () => []
+  );
 }
 
 export async function downloadOfficialVersion(
   version: String,
   url: String
 ): Promise<boolean> {
-  try {
-    await invoke("download_version", {
-      version: version,
-      versionFolder: "official",
-      url: url,
-    });
-  } catch (e) {
-    exceptionLog("Unable to download official version", e);
-    toastStore.makeToast(e, "error");
-    return false;
-  }
-  return true;
+  return await invoke_rpc(
+    "download_version",
+    { version, url, versionFolder: "official" },
+    () => false,
+    () => true
+  );
 }
 
 export async function removeVersion(
   version: String,
   versionFolder: String
 ): Promise<boolean> {
-  try {
-    await invoke("remove_version", {
-      version: version,
-      versionFolder: versionFolder,
-    });
-  } catch (e) {
-    exceptionLog("Unable to remove version", e);
-    toastStore.makeToast("Unable to remove version", "error");
-    return false;
-  }
-  return true;
+  return await invoke_rpc(
+    "remove_version",
+    { version, versionFolder },
+    () => false,
+    () => true
+  );
 }
 
-export async function openVersionFolder(folder: VersionFolders) {
-  try {
-    return await invoke("go_to_version_folder", { versionFolder: folder });
-  } catch (e) {
-    exceptionLog("Unable to open version folder", e);
-    toastStore.makeToast("Unable to open version folder", "error");
-  }
+export async function openVersionFolder(versionFolder: VersionFolders) {
+  return await invoke_rpc("go_to_version_folder", { versionFolder }, () => {});
 }
 
 export async function getActiveVersion(): Promise<string | null> {
-  try {
-    return await invoke("get_active_tooling_version", {});
-  } catch (e) {
-    exceptionLog("Unable to get active version", e);
-    return null;
-  }
+  return await invoke_rpc("get_active_tooling_version", {}, () => null);
 }
 
 export async function getActiveVersionFolder(): Promise<VersionFolders> {
-  try {
-    return await invoke("get_active_tooling_version_folder", {});
-  } catch (e) {
-    exceptionLog("Unable to get active version type", e);
-    return null;
-  }
+  return await invoke_rpc("get_active_tooling_version_folder", {}, () => null);
 }
 
 export async function ensureActiveVersionStillExists(): Promise<boolean> {
-  try {
-    return await invoke("ensure_active_version_still_exists", {});
-  } catch (e) {
-    exceptionLog("Unable to check or remove broken active version", e);
-    return false;
-  }
+  return await invoke_rpc(
+    "ensure_active_version_still_exists",
+    {},
+    () => false
+  );
 }

--- a/src/lib/rpc/window.ts
+++ b/src/lib/rpc/window.ts
@@ -1,25 +1,9 @@
-import { toastStore } from "$lib/stores/ToastStore";
-import { invoke } from "@tauri-apps/api/tauri";
-import { exceptionLog } from "./logging";
+import { invoke_rpc } from "./rpc";
 
 export async function openDir(directory: string): Promise<void> {
-  try {
-    return await invoke("open_dir_in_os", { directory });
-  } catch (e) {
-    exceptionLog(`Unable to open directory - ${directory}`, e);
-    toastStore.makeToast("Unable to open directory", "error");
-  }
+  return await invoke_rpc("open_dir_in_os", { directory }, () => {});
 }
 
 export async function openMainWindow(): Promise<boolean> {
-  try {
-    invoke("open_main_window");
-    return true;
-  } catch (e) {
-    exceptionLog(
-      "Unexpected error encountered when attempting to open the main window",
-      e
-    );
-  }
-  return false;
+  return await invoke_rpc("open_main_window", {}, () => false);
 }

--- a/src/lib/rpc/window.ts
+++ b/src/lib/rpc/window.ts
@@ -1,7 +1,12 @@
 import { invoke_rpc } from "./rpc";
 
 export async function openDir(directory: string): Promise<void> {
-  return await invoke_rpc("open_dir_in_os", { directory }, () => {});
+  return await invoke_rpc(
+    "open_dir_in_os",
+    { directory },
+    () => {},
+    "Unable to open directory"
+  );
 }
 
 export async function openMainWindow(): Promise<boolean> {


### PR DESCRIPTION
## Why?

Not all RPC failures are shown to the user.

This was discussed on Discord the other day. I'm not usually a strong proponent for DRY, but with 30+ very similar try-catch wraps around `invoke` maybe it's time now.

By adding a helper to be shared for all RPC invocations we can ensure the errors are handled in a similar fashion.

## Notes

I briefly looked at https://github.com/tauri-apps/tauri-bindgen but it requires writing a new definition of the API in the Wasm Interface Type IDL (https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md).

It's not easy to properly test all the changes. But I verified it works by hacking a fake error return in `ensure_active_version_still_exists`.

The current way we serialize `CommandError` means they always show up as strings on the TS side. If we for example used [serde_json](https://github.com/serde-rs/json), the errors could be encoded and the TS side could unpack them as objects with structure. It doesn't seem to me like there is such a requirement anywhere in the code currently, however, when an error arises we just log it and continue with a default. There is no "handling" of different errors on the UI side.