### PR TITLE
frontend: fix frontend styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ glew-cmake/
 TODO.md
 
 vite.config.ts.timestamp*
+.yarn/
+.yarnrc.yml

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ node_modules/
 dist/
 bundle-test/
 out/
+.yarn/

--- a/package.json
+++ b/package.json
@@ -48,5 +48,6 @@
     "@tauri-apps/api": "^1.3.0",
     "country-flag-emoji-polyfill": "^0.1.4",
     "svelte-navigator": "^3.2.2"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ backtrace = "0.3.68"
 chrono = "0.4.26"
 dir-diff = "0.3.2"
 directories = "5.0.1"
-fern = { version = "0.6.1", features = ["date-based","colored"] }
+fern = { version = "0.6.1", features = ["date-based", "colored"] }
 flate2 = "1.0.26"
 fs_extra = "1.3.0"
 futures-util = "0.3.26"

--- a/src/components/background/BackgroundLoading.svelte
+++ b/src/components/background/BackgroundLoading.svelte
@@ -4,6 +4,6 @@
 </script>
 
 <div class="h-screen flex flex-col items-center justify-center bg-black">
-  <img data-tauri-drag-region src={logo} alt="" srcset="" class="w-48" />
+  <img data-tauri-drag-region src={logo} aria-label="" srcset="" class="w-48" />
   <Spinner color="yellow" size={"12"} class="mt-5" />
 </div>

--- a/src/components/games/GameControls.svelte
+++ b/src/components/games/GameControls.svelte
@@ -50,21 +50,21 @@
   </h1>
   <div class="flex flex-row gap-2">
     <Button
-      btnClass="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
+      class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
       on:click={async () => {
         launchGame(getInternalName(activeGame), false);
       }}>{$_("gameControls_button_play")}</Button
     >
     <!-- TODO - texture replacements left out for now, get everything else working end-to-end first -->
     <!-- <Button
-      btnClass="text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center justify-center px-5 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800"
+      class="text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center justify-center px-5 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800"
       ><Chevron placement="top">Features</Chevron></Button
     >
     <Dropdown placement="top-end">
       <DropdownItem>Texture&nbsp;Replacements</DropdownItem>
     </Dropdown> -->
     <Button
-      btnClass="text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center justify-center px-2 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800"
+      class="text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center justify-center px-2 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800"
     >
       {$_("gameControls_button_advanced")}
     </Button>
@@ -108,7 +108,7 @@
       >
     </Dropdown>
     <Button
-      btnClass="text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center justify-center px-2 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800"
+      class="text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center justify-center px-2 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800"
     >
       <Icon icon="material-symbols:settings" width={24} height={24} />
     </Button>

--- a/src/components/games/GameToolsNotSet.svelte
+++ b/src/components/games/GameToolsNotSet.svelte
@@ -11,7 +11,7 @@
     {$_("gameControls_noToolingSet_subheader")}
   </p>
   <Button
-    btnClass="border-solid border-2 border-slate-500 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
+    class="border-solid border-2 border-slate-500 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
     href="/settings/versions"
     >{$_("gameControls_noToolingSet_button_setVersion")}</Button
   >

--- a/src/components/games/job/GameJob.svelte
+++ b/src/components/games/job/GameJob.svelte
@@ -137,7 +137,7 @@
   <div class="flex flex-col justify-end items-end mt-auto">
     <div class="flex flex-row gap-2">
       <Button
-        btnClass="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
+        class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
         on:click={async () => dispatchCompleteJob()}
         >{$_("setup_button_continue")}</Button
       >
@@ -152,7 +152,7 @@
         </span><span class="text-white"> {installationError}</span>
       </Alert>
       <Button
-        btnClass="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
+        class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
         on:click={async () => await generateSupportPackage()}
         >{$_("setup_button_getSupportPackage")}</Button
       >

--- a/src/components/games/setup/GameSetup.svelte
+++ b/src/components/games/setup/GameSetup.svelte
@@ -125,7 +125,7 @@
     <div class="flex flex-col justify-end items-end mt-auto">
       <div class="flex flex-row gap-2">
         <Button
-          btnClass="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
+          class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
           on:click={async () => await dispatchSetupEvent()}
           >{$_("setup_button_continue")}</Button
         >
@@ -140,7 +140,7 @@
           </span><span class="text-white"> {installationError}</span>
         </Alert>
         <Button
-          btnClass="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
+          class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
           on:click={async () => await generateSupportPackage()}
           >{$_("setup_button_getSupportPackage")}</Button
         >
@@ -156,13 +156,13 @@
     </h1>
     <div class="flex flex-row gap-2">
       <Button
-        btnClass="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
+        class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
         on:click={async () => await install(false)}
         >{$_("setup_button_installViaISO")}</Button
       >
       <!-- TODO - disabled for now, needs fixes in the extractor -->
       <!-- <Button
-        btnClass="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
+        class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
         on:click={async () => await install(true)}
         >Install via Folder</Button
       > -->

--- a/src/components/games/setup/GameUpdate.svelte
+++ b/src/components/games/setup/GameUpdate.svelte
@@ -53,7 +53,7 @@
       class="justify-center items-center space-y-4 sm:flex sm:space-y-0 sm:space-x-4"
     >
       <Button
-        btnClass="border-solid border-2 border-slate-500 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
+        class="border-solid border-2 border-slate-500 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
         on:click={async () => {
           dispatch("job", {
             type: "updateGame",
@@ -61,7 +61,7 @@
         }}>{$_("gameUpdate_versionMismatch_button_updateGame")}</Button
       >
       <Button
-        btnClass="border-solid border-2 border-slate-500 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
+        class="border-solid border-2 border-slate-500 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
         href="/settings/versions"
         >{$_("gameUpdate_versionMismatch_button_changeVersion")}</Button
       >

--- a/src/components/games/setup/Requirements.svelte
+++ b/src/components/games/setup/Requirements.svelte
@@ -96,7 +96,7 @@
   </Alert>
   <div>
     <Button
-      btnClass="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
+      class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
       on:click={async () => {
         isAVXMet = await isAVXRequirementMet(true);
         isOpenGLMet = await isOpenGLRequirementMet(true);
@@ -104,7 +104,7 @@
       }}>{$_("requirements_button_recheck")}</Button
     >
     <Button
-      btnClass="border-solid border-2 border-slate-900 rounded bg-orange-800 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
+      class="border-solid border-2 border-slate-900 rounded bg-orange-800 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
       on:click={async () => {
         const confirmed = await confirm(
           `${$_("requirements_button_bypass_warning_1")}\n\n${$_(

--- a/src/components/header/Header.svelte
+++ b/src/components/header/Header.svelte
@@ -101,7 +101,7 @@
   data-tauri-drag-region
 >
   <div class="flex flex-row items-center space-x-2 pointer-events-none">
-    <img class="h-8" src={logo} alt="" />
+    <img class="h-8" src={logo} aria-label="" />
     <p class="font-black text-white tracking-tight text-lg">OpenGOAL</p>
   </div>
 

--- a/src/components/sidebar/Sidebar.svelte
+++ b/src/components/sidebar/Sidebar.svelte
@@ -40,6 +40,16 @@
     }
     return style + " grayscale";
   }
+
+  function modifyGameTitleName(gameName: string): string {
+    // I figured out how to modify the tooltip size, the problem is that we want the tooltip to adjust based on the size
+    // new solution:
+    // - insert non-breaking-spaces to any space in the translated name
+    // - don't insert a nbsp after a `:`
+    return gameName.replace(/(?:[^:])\s/g, (match) =>
+      match.replace(/\s/g, "\u00a0")
+    );
+  }
 </script>
 
 <div class={getNavStyle($location.pathname)}>
@@ -51,8 +61,13 @@
         use:link
       >
         <img src={logoJak1} aria-label="Jak - The Precursor Legacy" />
-        <Tooltip placement="right"
-          >{$_(`gameName_${getInternalName(SupportedGame.Jak1)}`)}</Tooltip
+        <Tooltip
+          placement="right"
+          style="custom"
+          class="text-center py-2 px-3 text-sm font-medium"
+          >{modifyGameTitleName(
+            $_(`gameName_${getInternalName(SupportedGame.Jak1)}`)
+          )}</Tooltip
         >
       </a>
     </li>

--- a/src/components/sidebar/Sidebar.svelte
+++ b/src/components/sidebar/Sidebar.svelte
@@ -50,7 +50,7 @@
         href="/jak1"
         use:link
       >
-        <img src={logoJak1} alt="Jak - The Precursor Legacy" />
+        <img src={logoJak1} aria-label="Jak - The Precursor Legacy" />
         <Tooltip placement="right"
           >{$_(`gameName_${getInternalName(SupportedGame.Jak1)}`)}</Tooltip
         >
@@ -62,7 +62,7 @@
         href="/jak2"
         use:link
       >
-        <img src={logoJak2} alt="Jak 2" />
+        <img src={logoJak2} aria-label="Jak 2" />
         <Tooltip placement="right" style="dark"
           >{$_(`gameName_${getInternalName(SupportedGame.Jak2)}`)}</Tooltip
         >

--- a/src/routes/Help.svelte
+++ b/src/routes/Help.svelte
@@ -22,7 +22,7 @@
   </p>
   <div class="flex flex-row mt-1 gap-2">
     <Button
-      btnClass="border-solid rounded bg-orange-400 hover:bg-orange-600 text-sm text-slate-900 font-semibold px-4 py-2"
+      class="border-solid rounded bg-orange-400 hover:bg-orange-600 text-sm text-slate-900 font-semibold px-4 py-2"
       on:click={async () => {
         downloadingPackage = true;
         await generateSupportPackage();
@@ -36,7 +36,7 @@
     >
     {#if appDir !== undefined}
       <Button
-        btnClass="flex items-center border-solid rounded bg-white hover:bg-orange-400 text-sm text-slate-900 font-semibold px-4 py-2"
+        class="flex items-center border-solid rounded bg-white hover:bg-orange-400 text-sm text-slate-900 font-semibold px-4 py-2"
         on:click={() => {
           openDir(appDir);
         }}>{$_("help_button_openLogFolder")}</Button
@@ -51,7 +51,7 @@
   </p>
   <div class="flex flex-row gap-2">
     <Button
-      btnClass="flex items-center border-solid rounded bg-white hover:bg-orange-400 text-sm text-slate-900 font-semibold px-4 py-2"
+      class="flex items-center border-solid rounded bg-white hover:bg-orange-400 text-sm text-slate-900 font-semibold px-4 py-2"
       href="https://discord.gg/dPRCfsju3N"
       target="_blank"
       rel="noreferrer noopener"
@@ -62,7 +62,7 @@
       />&nbsp;Discord</Button
     >
     <Button
-      btnClass="flex items-center border-solid rounded bg-white hover:bg-orange-400 text-sm text-slate-900 font-semibold px-4 py-2"
+      class="flex items-center border-solid rounded bg-white hover:bg-orange-400 text-sm text-slate-900 font-semibold px-4 py-2"
       href="https://github.com/open-goal/launcher/issues/new/choose"
       target="_blank"
       rel="noreferrer noopener"
@@ -71,7 +71,7 @@
       )}</Button
     >
     <Button
-      btnClass="flex items-center border-solid rounded bg-white hover:bg-orange-400 text-sm text-slate-900 font-semibold px-4 py-2"
+      class="flex items-center border-solid rounded bg-white hover:bg-orange-400 text-sm text-slate-900 font-semibold px-4 py-2"
       href="https://github.com/open-goal/jak-project/issues/new/choose"
       target="_blank"
       rel="noreferrer noopener"

--- a/src/routes/Update.svelte
+++ b/src/routes/Update.svelte
@@ -47,7 +47,7 @@
     </p>
     <div class="flex flex-row mt-1 gap-3">
       <Button
-        btnClass="border-solid rounded bg-orange-400 hover:bg-orange-600 text-sm text-slate-900 font-semibold px-5 py-2"
+        class="border-solid rounded bg-orange-400 hover:bg-orange-600 text-sm text-slate-900 font-semibold px-5 py-2"
         on:click={async () => await updateHandler()}
         disabled={updating}
       >
@@ -57,7 +57,7 @@
         {$_("update_button_doUpdate")}
       </Button>
       <Button
-        btnClass="flex-shrink border-solid rounded bg-white hover:bg-orange-400 text-sm text-slate-900 font-semibold px-5 py-2"
+        class="flex-shrink border-solid rounded bg-white hover:bg-orange-400 text-sm text-slate-900 font-semibold px-5 py-2"
         on:click={() => (showChanges = !showChanges)}
         >{$_("update_button_viewChangelog")}</Button
       >

--- a/src/routes/settings/General.svelte
+++ b/src/routes/settings/General.svelte
@@ -86,7 +86,7 @@
   </div>
   <div>
     <Button
-      btnClass="flex-shrink border-solid rounded bg-white hover:bg-orange-400 text-sm text-slate-900 font-semibold px-5 py-2"
+      class="flex-shrink border-solid rounded bg-white hover:bg-orange-400 text-sm text-slate-900 font-semibold px-5 py-2"
       on:click={async () => {
         const confirmed = await confirm(
           $_("settings_general_button_resetSettings_confirmation")

--- a/src/routes/settings/versions/VersionList.svelte
+++ b/src/routes/settings/versions/VersionList.svelte
@@ -65,7 +65,7 @@
       <div class="flex">
         {#if changesPending($VersionStore)}
           <Button
-            btnClass="!p-2 mr-2 rounded-md dark:bg-green-500 hover:dark:bg-green-600 text-slate-900"
+            class="!p-2 mr-2 rounded-md dark:bg-green-500 hover:dark:bg-green-600 text-slate-900"
             on:click={() => dispatch("versionChange")}
           >
             <Icon
@@ -77,7 +77,7 @@
           </Button>
         {/if}
         <Button
-          btnClass="!p-2 mr-2 rounded-md dark:bg-orange-500 hover:dark:bg-orange-600 text-slate-900"
+          class="!p-2 mr-2 rounded-md dark:bg-orange-500 hover:dark:bg-orange-600 text-slate-900"
           on:click={() => dispatch("refreshVersions")}
         >
           <Icon
@@ -88,7 +88,7 @@
           />
         </Button>
         <Button
-          btnClass="!p-2 rounded-md dark:bg-orange-500 hover:dark:bg-orange-600  text-slate-900"
+          class="!p-2 rounded-md dark:bg-orange-500 hover:dark:bg-orange-600  text-slate-900"
           on:click={() => dispatch("openVersionFolder")}
         >
           <Icon
@@ -137,7 +137,7 @@
               style="line-height: 0;"
             >
               <Button
-                btnClass="dark:bg-transparent hover:dark:bg-transparent focus:ring-0 focus:ring-offset-0 disabled:opacity-50"
+                class="dark:bg-transparent hover:dark:bg-transparent focus:ring-0 focus:ring-offset-0 disabled:opacity-50"
                 disabled={release.pendingAction}
                 on:click={async () => {
                   if (release.isDownloaded) {
@@ -172,7 +172,7 @@
               </Button>
               {#if release.isDownloaded && release.releaseType == "official"}
                 <Button
-                  btnClass="dark:bg-transparent hover:dark:bg-transparent focus:ring-0 focus:ring-offset-0 disabled:opacity-50"
+                  class="dark:bg-transparent hover:dark:bg-transparent focus:ring-0 focus:ring-offset-0 disabled:opacity-50"
                   disabled={release.pendingAction}
                   on:click={async () => {
                     dispatch("redownloadVersion", {

--- a/src/routes/settings/versions/VersionList.svelte
+++ b/src/routes/settings/versions/VersionList.svelte
@@ -72,7 +72,7 @@
               icon="material-symbols:save"
               width="20"
               height="20"
-              alt={$_("settings_versions_icon_save_altText")}
+              aria-label={$_("settings_versions_icon_save_altText")}
             />
           </Button>
         {/if}
@@ -84,7 +84,7 @@
             icon="material-symbols:refresh"
             width="20"
             height="20"
-            alt={$_("settings_versions_icon_refresh_altText")}
+            aria-label={$_("settings_versions_icon_refresh_altText")}
           />
         </Button>
         <Button
@@ -95,7 +95,7 @@
             icon="material-symbols:folder-open-rounded"
             width="20"
             height="20"
-            alt={$_("settings_versions_icon_openFolder_altText")}
+            aria-label={$_("settings_versions_icon_openFolder_altText")}
           />
         </Button>
       </div>
@@ -156,7 +156,7 @@
                     width="24"
                     height="24"
                     color="red"
-                    alt={$_("settings_versions_icon_removeVersion_altText")}
+                    aria-label={$_("settings_versions_icon_removeVersion_altText")}
                   />
                 {:else if release.pendingAction}
                   <Spinner color="yellow" size={"6"} />
@@ -166,7 +166,7 @@
                     color="#00d500"
                     width="24"
                     height="24"
-                    alt={$_("settings_versions_icon_downloadVersion_altText")}
+                    aria-label={$_("settings_versions_icon_downloadVersion_altText")}
                   />
                 {/if}
               </Button>
@@ -215,7 +215,7 @@
                     icon="mdi:github"
                     width="24"
                     height="24"
-                    alt={$_("settings_versions_icon_githubRelease_altText")}
+                    aria-label={$_("settings_versions_icon_githubRelease_altText")}
                   /></a
                 >
               {/if}

--- a/src/routes/settings/versions/VersionList.svelte
+++ b/src/routes/settings/versions/VersionList.svelte
@@ -121,7 +121,7 @@
       <TableBody tableBodyClass="divide-y">
         {#each releaseList as release (release.version)}
           <TableBodyRow>
-            <TableBodyCell tdClass="px-6 py-2 whitespace-nowrap font-medium">
+            <TableBodyCell class="px-6 py-2 whitespace-nowrap font-medium">
               {#if release.isDownloaded}
                 <Radio
                   class="disabled:cursor-not-allowed p-0"
@@ -133,11 +133,11 @@
               {/if}
             </TableBodyCell>
             <TableBodyCell
-              tdClass="px-6 py-2 whitespace-nowrap font-medium"
+              class="px-6 py-2 whitespace-nowrap font-medium"
               style="line-height: 0;"
             >
               <Button
-                class="dark:bg-transparent hover:dark:bg-transparent focus:ring-0 focus:ring-offset-0 disabled:opacity-50"
+                class="py-0 dark:bg-transparent hover:dark:bg-transparent focus:ring-0 focus:ring-offset-0 disabled:opacity-50"
                 disabled={release.pendingAction}
                 on:click={async () => {
                   if (release.isDownloaded) {
@@ -156,7 +156,9 @@
                     width="24"
                     height="24"
                     color="red"
-                    aria-label={$_("settings_versions_icon_removeVersion_altText")}
+                    aria-label={$_(
+                      "settings_versions_icon_removeVersion_altText"
+                    )}
                   />
                 {:else if release.pendingAction}
                   <Spinner color="yellow" size={"6"} />
@@ -166,13 +168,15 @@
                     color="#00d500"
                     width="24"
                     height="24"
-                    aria-label={$_("settings_versions_icon_downloadVersion_altText")}
+                    aria-label={$_(
+                      "settings_versions_icon_downloadVersion_altText"
+                    )}
                   />
                 {/if}
               </Button>
               {#if release.isDownloaded && release.releaseType == "official"}
                 <Button
-                  class="dark:bg-transparent hover:dark:bg-transparent focus:ring-0 focus:ring-offset-0 disabled:opacity-50"
+                  class="py-0 dark:bg-transparent hover:dark:bg-transparent focus:ring-0 focus:ring-offset-0 disabled:opacity-50"
                   disabled={release.pendingAction}
                   on:click={async () => {
                     dispatch("redownloadVersion", {
@@ -195,15 +199,15 @@
                 </Button>
               {/if}
             </TableBodyCell>
-            <TableBodyCell tdClass="px-6 py-2 whitespace-nowrap font-medium"
+            <TableBodyCell class="px-6 py-2 whitespace-nowrap font-medium"
               >{release.version}</TableBodyCell
             >
-            <TableBodyCell tdClass="px-6 py-2 whitespace-nowrap font-medium">
+            <TableBodyCell class="px-6 py-2 whitespace-nowrap font-medium">
               {#if release.date}
                 {new Date(release.date).toLocaleDateString()}
               {/if}
             </TableBodyCell>
-            <TableBodyCell tdClass="px-6 py-2 whitespace-nowrap font-medium">
+            <TableBodyCell class="px-6 py-2 whitespace-nowrap font-medium">
               {#if release.githubLink}
                 <a
                   class="inline-block"
@@ -215,7 +219,9 @@
                     icon="mdi:github"
                     width="24"
                     height="24"
-                    aria-label={$_("settings_versions_icon_githubRelease_altText")}
+                    aria-label={$_(
+                      "settings_versions_icon_githubRelease_altText"
+                    )}
                   /></a
                 >
               {/if}

--- a/src/splash/Splash.svelte
+++ b/src/splash/Splash.svelte
@@ -78,7 +78,7 @@
 
 <div class="content" data-tauri-drag-region>
   <div class="splash-logo no-pointer-events">
-    <img src={logo} alt="" draggable="false" />
+    <img src={logo} aria-label="" draggable="false" />
   </div>
   <div class="splash-contents no-pointer-events">
     {#if selectLocale}


### PR DESCRIPTION
A recent dependency update broke some styling, for the better.  Seems like you can style `Button`s via the `class` prop instead of the `btnClass` prop.

Also fixes #225 