### PR TITLE
fix the macos release name check

### DIFF
--- a/src/lib/utils/github.ts
+++ b/src/lib/utils/github.ts
@@ -17,7 +17,8 @@ async function getDownloadLinkForCurrentPlatform(
   const archName = await arch();
   for (const asset of release.assets) {
     if (
-      platformName === "darwin" && archName === "x86_64" &&
+      platformName === "darwin" &&
+      archName === "x86_64" &&
       asset.name.startsWith("opengoal-macos-intel-v")
       // macOS doesn't have the old naming scheme
     ) {

--- a/src/lib/utils/github.ts
+++ b/src/lib/utils/github.ts
@@ -1,4 +1,4 @@
-import { platform } from "@tauri-apps/api/os";
+import { arch, platform } from "@tauri-apps/api/os";
 
 export interface ReleaseInfo {
   releaseType: "official" | "unofficial" | "devel";
@@ -14,8 +14,13 @@ async function getDownloadLinkForCurrentPlatform(
   release
 ): Promise<string | undefined> {
   const platformName = await platform();
+  const archName = await arch();
   for (const asset of release.assets) {
-    if (platformName === "darwin" && asset.name.includes("opengoal-macos-v")) {
+    if (
+      platformName === "darwin" && archName === "x86_64" &&
+      asset.name.startsWith("opengoal-macos-intel-v")
+      // macOS doesn't have the old naming scheme
+    ) {
       return asset.browser_download_url;
     } else if (
       platformName === "win32" &&


### PR DESCRIPTION
macOS releases always have the architecture in the name

Compare for https://github.com/open-goal/jak-project/pull/2817

I tried locally to use the "linux" check, and as far as I can tell the launcher happily downloaded and then even let me try to extract from an ISO (but failed to run the linux executable).