### PR TITLE
use unplugin-icons instead of @iconify/svelte

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "devDependencies": {
     "@fullhuman/postcss-purgecss": "^5.0.0",
-    "@iconify/svelte": "^3.1.4",
+    "@iconify-json/ic": "^1.1.13",
+    "@iconify-json/mdi": "^1.1.53",
     "@octokit/plugin-retry": "^3.0.9",
     "@octokit/plugin-throttling": "^7.0.0",
     "@octokit/rest": "^20.0.1",
@@ -47,6 +48,7 @@
     "svelte-preprocess": "^5.0.3",
     "tailwindcss": "^3.3.3",
     "typescript": "^5.1.3",
+    "unplugin-icons": "^0.16.5",
     "vitest": "^0.33.0",
     "vite": "^4.4.4"
   },

--- a/src/components/games/GameControls.svelte
+++ b/src/components/games/GameControls.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { getInternalName, SupportedGame } from "$lib/constants";
   import { openDir } from "$lib/rpc/window";
-  import Icon from "@iconify/svelte";
+  import IconCog from "~icons/mdi/cog";
   import { configDir, join } from "@tauri-apps/api/path";
   import { createEventDispatcher, onMount } from "svelte";
   import { confirm } from "@tauri-apps/api/dialog";
@@ -116,7 +116,7 @@
     <Button
       class="text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center justify-center px-2 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800"
     >
-      <Icon icon="material-symbols:settings" width={24} height={24} />
+      <IconCog />
     </Button>
     <Dropdown placement="top-end" class="!bg-slate-900">
       <!-- TODO - screenshot folder? how do we even configure where those go? -->

--- a/src/components/games/features/texture-packs/TexturePacks.svelte
+++ b/src/components/games/features/texture-packs/TexturePacks.svelte
@@ -19,7 +19,10 @@
     listExtractedTexturePackInfo,
   } from "$lib/rpc/features";
   import { filePrompt } from "$lib/utils/file-dialogs";
-  import Icon from "@iconify/svelte";
+  import IconArrowLeft from "~icons/mdi/arrow-left";
+  import IconArrowUp from "~icons/mdi/arrow-up";
+  import IconArrowDown from "~icons/mdi/arrow-down";
+  import IconDelete from "~icons/mdi/delete";
   import { convertFileSrc } from "@tauri-apps/api/tauri";
   import {
     Accordion,
@@ -228,12 +231,9 @@
           on:click={async () =>
             navigate(`/${getInternalName(activeGame)}`, { replace: true })}
           aria-label="back to game page"
-          ><Icon
-            icon="material-symbols:arrow-left-alt"
-            width="20"
-            height="20"
-          /></Button
         >
+          <IconArrowLeft />
+        </Button>
         <Button
           class="flex-shrink border-solid rounded bg-orange-400 hover:bg-orange-600 text-sm text-slate-900 font-semibold px-5 py-2"
           on:click={addNewTexturePack}
@@ -335,11 +335,7 @@
                         moveTexturePack(packIndex - 1, packIndex);
                       }}
                     >
-                      <Icon
-                        icon="material-symbols:arrow-upward"
-                        width="15"
-                        height="15"
-                      />
+                      <IconArrowUp />
                     </Button>
                   {/if}
                   {#if packIndex !== availablePacks.length - 1}
@@ -351,11 +347,7 @@
                         moveTexturePack(packIndex + 1, packIndex);
                       }}
                     >
-                      <Icon
-                        icon="material-symbols:arrow-downward"
-                        width="15"
-                        height="15"
-                      />
+                      <IconArrowDown />
                     </Button>
                   {/if}
                 {/if}
@@ -368,7 +360,7 @@
                     pack.enabled = false;
                   }}
                 >
-                  <Icon icon="material-symbols:delete" width="15" height="15" />
+                  <IconDelete />
                 </Button>
               </div>
               <!-- double computation, TODO - separate component -->

--- a/src/components/games/features/texture-packs/TexturePacks.svelte
+++ b/src/components/games/features/texture-packs/TexturePacks.svelte
@@ -23,6 +23,7 @@
   import IconArrowUp from "~icons/mdi/arrow-up";
   import IconArrowDown from "~icons/mdi/arrow-down";
   import IconDelete from "~icons/mdi/delete";
+  import IconInfo from "~icons/mdi/information";
   import { convertFileSrc } from "@tauri-apps/api/tauri";
   import {
     Accordion,
@@ -371,18 +372,7 @@
                       slot="header"
                       class="flex gap-2 text-yellow-300 text-sm"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="w-5 h-5"
-                        fill="currentColor"
-                        viewBox="0 0 20 20"
-                        xmlns="http://www.w3.org/2000/svg"
-                        ><path
-                          fill-rule="evenodd"
-                          d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
-                          clip-rule="evenodd"
-                        /></svg
-                      >
+                      <IconInfo aria-hidden="true" />
                       <span> {$_("features_textures_conflictsDetected")}</span>
                     </span>
                     <div slot="arrowup" />

--- a/src/components/games/setup/LogViewer.svelte
+++ b/src/components/games/setup/LogViewer.svelte
@@ -1,6 +1,6 @@
 <script>
   import { progressTracker } from "$lib/stores/ProgressStore";
-  import Icon from "@iconify/svelte";
+  import IconDocument from "~icons/mdi/file-document-outline";
   import { Accordion, AccordionItem } from "flowbite-svelte";
   import { ansiSpan } from "ansi-to-span";
   import escapeHtml from "escape-html";
@@ -14,7 +14,7 @@
 <Accordion class="log-accordian" defaultClass="p-0">
   <AccordionItem class="bg-slate-900 rounded p-[1rem]">
     <span slot="header" class="text-sm font-semibold text-white flex gap-2">
-      <Icon icon="mdi:file-document-outline" width={18} />
+      <IconDocument />
       <span>{$_("setup_logs_header")}</span>
     </span>
     <div

--- a/src/components/games/setup/Progress.svelte
+++ b/src/components/games/setup/Progress.svelte
@@ -3,7 +3,7 @@
     progressTracker,
     type ProgressStatus,
   } from "$lib/stores/ProgressStore";
-  import Icon from "@iconify/svelte";
+  import ProgressIcon from "./ProgressIcon.svelte";
 
   $: progress = $progressTracker;
 
@@ -12,37 +12,6 @@
   const stepLabelStyle = "text-center text-outline font-semibold";
   const progressBarContainerStyle =
     "w-full rounded items-center align-middle align-center flex-1";
-
-  // TODO - this pattern indicates these should probably be their own components...
-  function progressIcon(currentStatus: ProgressStatus) {
-    if (currentStatus === "success") {
-      return "material-symbols:check";
-    } else if (currentStatus === "pending") {
-      return "mdi:dots-horizontal";
-    } else if (currentStatus === "failed") {
-      return "mdi:stop-alert";
-    }
-    return "mdi:hourglass";
-  }
-
-  function progressIconStyle(currentStatus: ProgressStatus) {
-    let style = "";
-    if (currentStatus === "pending") {
-      style += " animate-pulse";
-    }
-    return style;
-  }
-
-  function progressIconColor(currentStatus: ProgressStatus) {
-    if (currentStatus === "success") {
-      return "#22c55e";
-    } else if (currentStatus === "pending") {
-      return "#facc15";
-    } else if (currentStatus === "failed") {
-      return "#ef4444";
-    }
-    return "#737373";
-  }
 
   function progressBarStyle(currentStatus: ProgressStatus) {
     let style = "w-full py-1 rounded";
@@ -78,13 +47,7 @@
           {/if}
           <!-- ICON -->
           <div class={iconContainerStyle}>
-            <Icon
-              class={progressIconStyle(step.status)}
-              icon={progressIcon(step.status)}
-              color={progressIconColor(step.status)}
-              width={28}
-              height={28}
-            />
+            <ProgressIcon status={step.status} />
           </div>
         </div>
         <!-- LABEL -->

--- a/src/components/games/setup/ProgressIcon.svelte
+++ b/src/components/games/setup/ProgressIcon.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import {type ProgressStatus} from "$lib/stores/ProgressStore";
+  import { type ProgressStatus } from "$lib/stores/ProgressStore";
   import IconCheck from "~icons/mdi/check";
   import IconDots from "~icons/mdi/dots-horizontal";
   import IconAlert from "~icons/mdi/stop-alert";
@@ -9,11 +9,11 @@
 </script>
 
 {#if status === "success"}
-  <IconCheck color="#22c55e"/>
+  <IconCheck color="#22c55e" />
 {:else if status === "pending"}
-  <IconDots class="animate-pulse" color="#facc15"/>
+  <IconDots class="animate-pulse" color="#facc15" />
 {:else if status === "failed"}
-  <IconAlert color="#ef4444"/>
+  <IconAlert color="#ef4444" />
 {:else}
-  <IconHourglass color="#737373"/>
+  <IconHourglass color="#737373" />
 {/if}

--- a/src/components/games/setup/ProgressIcon.svelte
+++ b/src/components/games/setup/ProgressIcon.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import {type ProgressStatus} from "$lib/stores/ProgressStore";
+  import IconCheck from "~icons/mdi/check";
+  import IconDots from "~icons/mdi/dots-horizontal";
+  import IconAlert from "~icons/mdi/stop-alert";
+  import IconHourglass from "~icons/mdi/hourglass";
+
+  export let status: ProgressStatus = "pending";
+</script>
+
+{#if status === "success"}
+  <IconCheck color="#22c55e"/>
+{:else if status === "pending"}
+  <IconDots class="animate-pulse" color="#facc15"/>
+{:else if status === "failed"}
+  <IconAlert color="#ef4444"/>
+{:else}
+  <IconHourglass color="#737373"/>
+{/if}

--- a/src/components/header/Header.svelte
+++ b/src/components/header/Header.svelte
@@ -4,7 +4,8 @@
   import { onMount } from "svelte";
   import { getVersion } from "@tauri-apps/api/app";
   import { Link } from "svelte-navigator";
-  import Icon from "@iconify/svelte";
+  import IconWindowMinimize from "~icons/mdi/window-minimize";
+  import IconWindowClose from "~icons/mdi/window-close";
   import { UpdateStore } from "$lib/stores/AppStore";
   import { checkUpdate } from "@tauri-apps/api/updater";
   import { isInDebugMode } from "$lib/utils/common";
@@ -153,10 +154,10 @@
 
   <div class="flex space-x-4 text-xl ml-auto">
     <button class="hover:text-amber-600" on:click={() => appWindow.minimize()}>
-      <Icon icon="material-symbols:chrome-minimize" width="24" height="24" />
+      <IconWindowMinimize />
     </button>
     <button class="hover:text-red-600" on:click={() => appWindow.close()}>
-      <Icon icon="ic:baseline-close" width="24" height="24" />
+      <IconWindowClose />
     </button>
   </div>
 </header>

--- a/src/components/sidebar/Sidebar.svelte
+++ b/src/components/sidebar/Sidebar.svelte
@@ -97,7 +97,7 @@
         href="/settings/general"
         use:link
       >
-        <IconCog style="font-size: 36px"/>
+        <IconCog style="font-size: 36px" />
         <Tooltip placement="right" style="dark"
           >{$_("sidebar_settings")}</Tooltip
         >
@@ -110,7 +110,7 @@
         href="/faq"
         use:link
       >
-        <IconChatQuestion style="font-size: 36px"/>
+        <IconChatQuestion style="font-size: 36px" />
         <Tooltip placement="right" style="dark">{$_("sidebar_help")}</Tooltip>
       </a>
     </li>

--- a/src/components/sidebar/Sidebar.svelte
+++ b/src/components/sidebar/Sidebar.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import logoJak1 from "$assets/images/jak-tpl.webp";
   import logoJak2 from "$assets/images/jak-2.webp";
-  import Icon from "@iconify/svelte";
+  import IconCog from "~icons/mdi/cog";
+  import IconChatQuestion from "~icons/mdi/chat-question";
   import { link, useLocation } from "svelte-navigator";
   import { Tooltip } from "flowbite-svelte";
   import { SupportedGame, getInternalName } from "$lib/constants";
@@ -96,7 +97,7 @@
         href="/settings/general"
         use:link
       >
-        <Icon icon="material-symbols:settings" width={36} height={36} />
+        <IconCog style="font-size: 36px"/>
         <Tooltip placement="right" style="dark"
           >{$_("sidebar_settings")}</Tooltip
         >
@@ -109,7 +110,7 @@
         href="/faq"
         use:link
       >
-        <Icon icon="material-symbols:contact-support" width={36} height={36} />
+        <IconChatQuestion style="font-size: 36px"/>
         <Tooltip placement="right" style="dark">{$_("sidebar_help")}</Tooltip>
       </a>
     </li>

--- a/src/routes/Help.svelte
+++ b/src/routes/Help.svelte
@@ -65,9 +65,7 @@
       target="_blank"
       rel="noreferrer noopener"
     >
-      <IconGitHub />&nbsp;{$_(
-        "help_button_reportLauncherIssue"
-      )}
+      <IconGitHub />&nbsp;{$_("help_button_reportLauncherIssue")}
     </Button>
     <Button
       class="flex items-center border-solid rounded bg-white hover:bg-orange-400 text-sm text-slate-900 font-semibold px-4 py-2"
@@ -75,9 +73,7 @@
       target="_blank"
       rel="noreferrer noopener"
     >
-      <IconGitHub />&nbsp;{$_(
-        "help_button_reportGameIssue"
-      )}
+      <IconGitHub />&nbsp;{$_("help_button_reportGameIssue")}
     </Button>
   </div>
   <div class="flex mt-auto justify-end">

--- a/src/routes/Help.svelte
+++ b/src/routes/Help.svelte
@@ -1,6 +1,7 @@
 <script>
   import { Button, Spinner } from "flowbite-svelte";
-  import Icon from "@iconify/svelte";
+  import IconDiscord from "~icons/ic/baseline-discord";
+  import IconGitHub from "~icons/mdi/github";
   import { generateSupportPackage } from "$lib/rpc/support";
   import { openDir } from "$lib/rpc/window";
   import { onMount } from "svelte";
@@ -55,30 +56,29 @@
       href="https://discord.gg/dPRCfsju3N"
       target="_blank"
       rel="noreferrer noopener"
-      ><Icon
-        class="inline-block"
-        icon="ic:baseline-discord"
-        width={20}
-      />&nbsp;Discord</Button
     >
+      <IconDiscord />&nbsp;Discord
+    </Button>
     <Button
       class="flex items-center border-solid rounded bg-white hover:bg-orange-400 text-sm text-slate-900 font-semibold px-4 py-2"
       href="https://github.com/open-goal/launcher/issues/new/choose"
       target="_blank"
       rel="noreferrer noopener"
-      ><Icon class="inline-block" icon="mdi:github" width={20} />&nbsp;{$_(
-        "help_button_reportLauncherIssue"
-      )}</Button
     >
+      <IconGitHub />&nbsp;{$_(
+        "help_button_reportLauncherIssue"
+      )}
+    </Button>
     <Button
       class="flex items-center border-solid rounded bg-white hover:bg-orange-400 text-sm text-slate-900 font-semibold px-4 py-2"
       href="https://github.com/open-goal/jak-project/issues/new/choose"
       target="_blank"
       rel="noreferrer noopener"
-      ><Icon class="inline-block" icon="mdi:github" width={20} />&nbsp;{$_(
-        "help_button_reportGameIssue"
-      )}</Button
     >
+      <IconGitHub />&nbsp;{$_(
+        "help_button_reportGameIssue"
+      )}
+    </Button>
   </div>
   <div class="flex mt-auto justify-end">
     <p class="text-gray-500 text-xs text-center">

--- a/src/routes/Update.svelte
+++ b/src/routes/Update.svelte
@@ -13,7 +13,7 @@
     Toggle,
   } from "flowbite-svelte";
   import { UpdateStore } from "$lib/stores/AppStore";
-  import Icon from "@iconify/svelte";
+  import IconGitHub from "~icons/mdi/github";
   import { _ } from "svelte-i18n";
 
   $: launcherUpdateInfo = $UpdateStore?.launcher;
@@ -106,13 +106,9 @@
                   href={note.pullRequestUrl}
                   target="_blank"
                   rel="noreferrer"
-                  ><Icon
-                    class="inline"
-                    icon="mdi:github"
-                    width="24"
-                    height="24"
-                  /></a
                 >
+                  <IconGitHub />
+                </a>
               </TableBodyCell>
             </TableBodyRow>
           {/each}

--- a/src/routes/settings/versions/VersionList.svelte
+++ b/src/routes/settings/versions/VersionList.svelte
@@ -5,7 +5,12 @@
     type VersionStoreIFace,
   } from "$lib/stores/VersionStore";
   import type { ReleaseInfo } from "$lib/utils/github";
-  import Icon from "@iconify/svelte";
+  import IconSave from "~icons/mdi/content-save";
+  import IconRefresh from "~icons/mdi/refresh";
+  import IconFolderOpen from "~icons/mdi/folder-open";
+  import IconGitHub from "~icons/mdi/github";
+  import IconDownload from "~icons/mdi/download";
+  import IconDeleteForever from "~icons/mdi/delete-forever";
   import {
     Button,
     Radio,
@@ -68,10 +73,7 @@
             class="!p-2 mr-2 rounded-md dark:bg-green-500 hover:dark:bg-green-600 text-slate-900"
             on:click={() => dispatch("versionChange")}
           >
-            <Icon
-              icon="material-symbols:save"
-              width="20"
-              height="20"
+            <IconSave
               aria-label={$_("settings_versions_icon_save_altText")}
             />
           </Button>
@@ -80,10 +82,7 @@
           class="!p-2 mr-2 rounded-md dark:bg-orange-500 hover:dark:bg-orange-600 text-slate-900"
           on:click={() => dispatch("refreshVersions")}
         >
-          <Icon
-            icon="material-symbols:refresh"
-            width="20"
-            height="20"
+          <IconRefresh
             aria-label={$_("settings_versions_icon_refresh_altText")}
           />
         </Button>
@@ -91,10 +90,7 @@
           class="!p-2 rounded-md dark:bg-orange-500 hover:dark:bg-orange-600  text-slate-900"
           on:click={() => dispatch("openVersionFolder")}
         >
-          <Icon
-            icon="material-symbols:folder-open-rounded"
-            width="20"
-            height="20"
+          <IconFolderOpen
             aria-label={$_("settings_versions_icon_openFolder_altText")}
           />
         </Button>
@@ -151,10 +147,7 @@
                 }}
               >
                 {#if release.isDownloaded}
-                  <Icon
-                    icon="ic:baseline-delete-forever"
-                    width="24"
-                    height="24"
+                  <IconDeleteForever
                     color="red"
                     aria-label={$_(
                       "settings_versions_icon_removeVersion_altText"
@@ -163,11 +156,8 @@
                 {:else if release.pendingAction}
                   <Spinner color="yellow" size={"6"} />
                 {:else if release.releaseType === "official" && release.downloadUrl !== undefined}
-                  <Icon
-                    icon="ic:baseline-download"
+                  <IconDownload
                     color="#00d500"
-                    width="24"
-                    height="24"
                     aria-label={$_(
                       "settings_versions_icon_downloadVersion_altText"
                     )}
@@ -188,11 +178,7 @@
                   {#if release.pendingAction}
                     <Spinner color="yellow" size={"6"} />
                   {:else}
-                    <Icon
-                      icon="ic:baseline-refresh"
-                      color="#f5c842"
-                      width="24"
-                      height="24"
+                    <IconRefresh
                       aria-label="Redownload Version"
                     />
                   {/if}
@@ -214,16 +200,13 @@
                   href={release.githubLink}
                   target="_blank"
                   rel="noreferrer"
-                  ><Icon
-                    class="inline"
-                    icon="mdi:github"
-                    width="24"
-                    height="24"
+                >
+                  <IconGitHub
                     aria-label={$_(
                       "settings_versions_icon_githubRelease_altText"
                     )}
-                  /></a
-                >
+                  />
+                </a>
               {/if}
             </TableBodyCell>
           </TableBodyRow>

--- a/src/routes/settings/versions/VersionList.svelte
+++ b/src/routes/settings/versions/VersionList.svelte
@@ -73,9 +73,7 @@
             class="!p-2 mr-2 rounded-md dark:bg-green-500 hover:dark:bg-green-600 text-slate-900"
             on:click={() => dispatch("versionChange")}
           >
-            <IconSave
-              aria-label={$_("settings_versions_icon_save_altText")}
-            />
+            <IconSave aria-label={$_("settings_versions_icon_save_altText")} />
           </Button>
         {/if}
         <Button
@@ -178,9 +176,7 @@
                   {#if release.pendingAction}
                     <Spinner color="yellow" size={"6"} />
                   {:else}
-                    <IconRefresh
-                      aria-label="Redownload Version"
-                    />
+                    <IconRefresh aria-label="Redownload Version" />
                   {/if}
                 </Button>
               {/if}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="svelte" />
 /// <reference types="vite/client" />
+/// <reference types="unplugin-icons/types/svelte" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,11 +10,11 @@ export default defineConfig({
   },
   plugins: [
     svelte({
-      hot: !process.env.VITEST
+      hot: !process.env.VITEST,
     }),
     Icons({
       compiler: "svelte",
-    })
+    }),
   ],
   resolve: {
     alias: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
+import Icons from "unplugin-icons/vite";
 import { fileURLToPath, URL } from "url";
 
 // https://vitejs.dev/config/
@@ -7,7 +8,14 @@ export default defineConfig({
   server: {
     port: 3000, // The port the server will listen on.
   },
-  plugins: [svelte({ hot: !process.env.VITEST })],
+  plugins: [
+    svelte({
+      hot: !process.env.VITEST
+    }),
+    Icons({
+      compiler: "svelte",
+    })
+  ],
   resolve: {
     alias: {
       $lib: fileURLToPath(new URL("./src/lib", import.meta.url)),

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,19 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@antfu/install-pkg@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@antfu/install-pkg/-/install-pkg-0.1.1.tgz#157bb04f0de8100b9e4c01734db1a6c77e98bbb5"
+  integrity sha512-LyB/8+bSfa0DFGC06zpCEfs89/XoWZwws5ygEa5D+Xsm3OfI+aXQ86VgVG7Acyef+rSZ5HE7J8rrxzrQeM3PjQ==
+  dependencies:
+    execa "^5.1.1"
+    find-up "^5.0.0"
+
+"@antfu/utils@^0.7.4", "@antfu/utils@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@antfu/utils/-/utils-0.7.5.tgz#c36f37add92a7de57b9c29ae0c1f399706bff345"
+  integrity sha512-dlR6LdS+0SzOAPx/TPRhnoi7hE251OVeT2Snw0RguNbBSbjUHdWr0l3vcUUDg26rEysT89kCbtw1lVorBXLLCg==
+
 "@babel/code-frame@^7.10.4":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.5.tgz#234d98e1551960604f1246e6475891a570ad5658"
@@ -217,17 +230,36 @@
   dependencies:
     purgecss "^5.0.0"
 
-"@iconify/svelte@^3.1.4":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@iconify/svelte/-/svelte-3.1.4.tgz#728fa18ea03da8541a64565c1b2b0c2b8dc0d417"
-  integrity sha512-YDwQlN46ka8KPRayDb7TivmkAPizfTXi6BSRNqa1IV0+byA907n8JcgQafA7FD//pW5XCuuAhVx6uRbKTo+CfA==
+"@iconify-json/ic@^1.1.13":
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/@iconify-json/ic/-/ic-1.1.13.tgz#f5405e6ec65c1ac5b85e2d1ea1adde9093b199bd"
+  integrity sha512-5i5zal/VRwTrs99iMTnG1Zu97bgX9Mkiu9TzR1U1rHBylUnBW+HkOweoQVEPgQITGG024/lNbZxU+3Aa2xuDww==
   dependencies:
-    "@iconify/types" "^2.0.0"
+    "@iconify/types" "*"
 
-"@iconify/types@^2.0.0":
+"@iconify-json/mdi@^1.1.53":
+  version "1.1.53"
+  resolved "https://registry.yarnpkg.com/@iconify-json/mdi/-/mdi-1.1.53.tgz#633588d1d56780192c0dc55e9d92d976e6a5e6bf"
+  integrity sha512-qG72Tc9Bd4w7fha+kMEySVTbH4Obgb9xA1mQl+WReFhtZ3PjcVpIWLgZGTewuIfZY8RAbd8zfAqhZ7qEYZWrhg==
+  dependencies:
+    "@iconify/types" "*"
+
+"@iconify/types@*", "@iconify/types@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@iconify/types/-/types-2.0.0.tgz#ab0e9ea681d6c8a1214f30cd741fe3a20cc57f57"
   integrity sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==
+
+"@iconify/utils@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@iconify/utils/-/utils-2.1.7.tgz#f6be175e08194925bf2cb091a8a3e36c88b8b636"
+  integrity sha512-P8S3z/L1LcV4Qem9AoCfVAaTFGySEMzFEY4CHZLkfRj0Fv9LiR+AwjDgrDrzyI93U2L2mg9JHsbTJ52mF8suNw==
+  dependencies:
+    "@antfu/install-pkg" "^0.1.1"
+    "@antfu/utils" "^0.7.4"
+    "@iconify/types" "^2.0.0"
+    debug "^4.3.4"
+    kolorist "^1.8.0"
+    local-pkg "^0.4.3"
 
 "@istanbuljs/schema@^0.1.2":
   version "0.1.3"
@@ -2271,6 +2303,21 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
+  integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.0"
+    human-signals "^2.1.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.1"
+    onetime "^5.1.2"
+    signal-exit "^3.0.3"
+    strip-final-newline "^2.0.0"
+
 execa@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-7.1.1.tgz#3eb3c83d239488e7b409d48e8813b76bb55c9c43"
@@ -2445,6 +2492,14 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
 find-versions@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/find-versions/-/find-versions-3.2.0.tgz#10297f98030a786829681690545ef659ed1d254e"
@@ -2591,7 +2646,7 @@ get-stream@^5.1.0:
   dependencies:
     pump "^3.0.0"
 
-get-stream@^6.0.1:
+get-stream@^6.0.0, get-stream@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
@@ -2937,6 +2992,11 @@ https-proxy-agent@^5.0.1:
   dependencies:
     agent-base "6"
     debug "4"
+
+human-signals@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
+  integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
 human-signals@^4.3.0:
   version "4.3.1"
@@ -3320,6 +3380,11 @@ is-stream@^1.0.0, is-stream@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==
 
+is-stream@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
+  integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
 is-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
@@ -3548,6 +3613,11 @@ kleur@^4.1.5:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.5.tgz#95106101795f7050c6c650f350c683febddb1780"
   integrity sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==
 
+kolorist@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/kolorist/-/kolorist-1.8.0.tgz#edddbbbc7894bc13302cdf740af6374d4a04743c"
+  integrity sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==
+
 latest-version@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face"
@@ -3594,6 +3664,13 @@ local-pkg@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.3.tgz#0ff361ab3ae7f1c19113d9bb97b98b905dbc4963"
   integrity sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==
+
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
 
 locate-path@^7.1.0:
   version "7.2.0"
@@ -4023,6 +4100,13 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
+npm-run-path@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
+  integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
+  dependencies:
+    path-key "^3.0.0"
+
 npm-run-path@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-5.1.0.tgz#bc62f7f3f6952d9894bd08944ba011a6ee7b7e00"
@@ -4085,7 +4169,7 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-onetime@^5.1.0:
+onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
@@ -4178,12 +4262,26 @@ p-is-promise@^1.1.0:
   resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
   integrity sha512-zL7VE4JVS2IFSkR2GQKDSPEVxkoH43/p7oEnwpdCndKYJO0HVeRB7fA8TJwuLOTBREtK0ea8eHaxdwcpob5dmg==
 
+p-limit@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
 p-limit@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-4.0.0.tgz#914af6544ed32bfa54670b061cafcbd04984b644"
   integrity sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==
   dependencies:
     yocto-queue "^1.0.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
 
 p-locate@^6.0.0:
   version "6.0.0"
@@ -4290,6 +4388,11 @@ path-exists@^2.0.0:
   dependencies:
     pinkie-promise "^2.0.0"
 
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
 path-exists@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-5.0.0.tgz#a6aad9489200b21fab31e49cf09277e5116fb9e7"
@@ -4305,7 +4408,7 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==
 
-path-key@^3.1.0:
+path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
@@ -5018,7 +5121,7 @@ siginfo@^2.0.0:
   resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
   integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
 
-signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.7:
+signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
@@ -5212,6 +5315,11 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==
+
+strip-final-newline@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
+  integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
 strip-final-newline@^3.0.0:
   version "3.0.0"
@@ -5658,6 +5766,29 @@ universalify@^2.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
+unplugin-icons@^0.16.5:
+  version "0.16.5"
+  resolved "https://registry.yarnpkg.com/unplugin-icons/-/unplugin-icons-0.16.5.tgz#1f84bc1ee0b8dabfe2728bb9e01fbc3491fe9d70"
+  integrity sha512-laCCqMWfng1XZgB9yowGfjBdDhtmz8t8zVnhzRNEMhBNdy26QrVewVmdXk/zsiAQYnEWvIxTjvW1nQXrxdd2+w==
+  dependencies:
+    "@antfu/install-pkg" "^0.1.1"
+    "@antfu/utils" "^0.7.5"
+    "@iconify/utils" "^2.1.7"
+    debug "^4.3.4"
+    kolorist "^1.8.0"
+    local-pkg "^0.4.3"
+    unplugin "^1.3.2"
+
+unplugin@^1.3.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/unplugin/-/unplugin-1.4.0.tgz#b771373aa1bc664f50a044ee8009bd3a7aa04d85"
+  integrity sha512-5x4eIEL6WgbzqGtF9UV8VEC/ehKptPXDS6L2b0mv4FRMkJxRtjaJfOWDd6a8+kYbqsjklix7yWP0N3SUepjXcg==
+  dependencies:
+    acorn "^8.9.0"
+    chokidar "^3.5.3"
+    webpack-sources "^3.2.3"
+    webpack-virtual-modules "^0.5.0"
+
 update-browserslist-db@^1.0.11:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz#9a2a641ad2907ae7b3616506f4b977851db5b940"
@@ -5823,6 +5954,16 @@ webidl-conversions@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
+webpack-sources@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
+  integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
+
+webpack-virtual-modules@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz#362f14738a56dae107937ab98ea7062e8bdd3b6c"
+  integrity sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==
 
 whatwg-encoding@^2.0.0:
   version "2.0.0"
@@ -6004,6 +6145,11 @@ yauzl@^2.4.2:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
 yocto-queue@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Closes #281

This is what it looked like before on my computer:

![Skärmavbild 2023-07-22 kl  15 39 44](https://github.com/open-goal/launcher/assets/33322/72cc704d-1907-4627-9028-343dd01c21e8)

This is what it looks like after these changes (I tried to use only Material Design Icons instead of mixing icon sets, but had to dip into "ic" for the Discord icon):

![Skärmavbild 2023-07-22 kl  15 50 13](https://github.com/open-goal/launcher/assets/33322/a08cdcae-7fc4-4567-97c5-c9ddf78532d6)

Below are more comparisons to showcase any changes to icons as I picked from the MDI set.

## Texture packs before
![Skärmavbild 2023-07-22 kl  15 41 19](https://github.com/open-goal/launcher/assets/33322/c0d3c5d6-feec-4a5d-9ba5-8b8e899e45c6)

## Texture packs after
(note the info icon which replaces an inlined SVG)
![Skärmavbild 2023-07-22 kl  16 01 02](https://github.com/open-goal/launcher/assets/33322/f21fedbf-4959-40f8-b787-cbd310c17823)

## Progress before
![Skärmavbild 2023-07-22 kl  15 47 39](https://github.com/open-goal/launcher/assets/33322/7bbf8edd-606c-45e2-8cc0-382de8666157)
![Skärmavbild 2023-07-22 kl  15 48 53](https://github.com/open-goal/launcher/assets/33322/d410886e-6365-489b-a5ef-57cb5fca5552)

## Progress after
![Skärmavbild 2023-07-22 kl  14 48 27](https://github.com/open-goal/launcher/assets/33322/4cd6287d-ef69-4654-a355-2eba1fe32bbe)
![Skärmavbild 2023-07-22 kl  14 49 39](https://github.com/open-goal/launcher/assets/33322/f6a5ab9c-b007-4259-9cd1-88ee88bd0fe5)

## Help after
![Skärmavbild 2023-07-22 kl  15 15 09](https://github.com/open-goal/launcher/assets/33322/3e9d59fe-e4fa-45ed-a545-1792faf3a197)

## Version list after
![Skärmavbild 2023-07-22 kl  15 26 19](https://github.com/open-goal/launcher/assets/33322/6c43713c-e156-498c-bf9b-ada0d1c11df5)
![Skärmavbild 2023-07-22 kl  15 28 25](https://github.com/open-goal/launcher/assets/33322/11e1f7e6-022b-4f22-a7a1-f16ea2e35ba0)
