### PR TITLE
backend: conditionally add `--game` flag to binaries based on version

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^1.5.1",
+    "@types/semver": "^7.5.4",
     "country-flag-emoji-polyfill": "^0.1.4",
+    "semver": "^7.5.4",
     "svelte-navigator": "^3.2.2"
   },
   "packageManager": "yarn@1.22.19"

--- a/src-tauri/src/commands/binaries.rs
+++ b/src-tauri/src/commands/binaries.rs
@@ -289,8 +289,6 @@ pub async fn extract_and_validate_iso(
 
   let mut args = vec![
     path_to_iso.clone(),
-    "--game".to_string(),
-    game_name.clone(),
     "--extract".to_string(),
     "--validate".to_string(),
     "--proj-path".to_string(),
@@ -298,6 +296,11 @@ pub async fn extract_and_validate_iso(
   ];
   if Path::new(&path_to_iso.clone()).is_dir() {
     args.push("--folder".to_string());
+  }
+  // Add new --game argument
+  if config_info.tooling_version.minor >= 1 && config_info.tooling_version.patch >= 44 {
+    args.push("--game".to_string());
+    args.push(game_name.clone());
   }
 
   // This is the first install step, reset the file
@@ -386,15 +389,21 @@ pub async fn run_decompiler(
 
   let log_file = create_log_file(&app_handle, "extractor.log", !truncate_logs)?;
   let mut command = Command::new(exec_info.executable_path);
+
+  let mut args = vec![
+    source_path,
+    "--decompile".to_string(),
+    "--proj-path".to_string(),
+    data_folder.to_string_lossy().into_owned(),
+  ];
+  // Add new --game argument
+  if config_info.tooling_version.minor >= 1 && config_info.tooling_version.patch >= 44 {
+    args.push("--game".to_string());
+    args.push(game_name.clone());
+  }
+
   command
-    .args([
-      source_path,
-      "--game".to_string(),
-      game_name.clone(),
-      "--decompile".to_string(),
-      "--proj-path".to_string(),
-      data_folder.to_string_lossy().into_owned(),
-    ])
+    .args(args)
     .stdout(log_file.try_clone()?)
     .stderr(log_file)
     .current_dir(exec_info.executable_dir);
@@ -473,16 +482,20 @@ pub async fn run_compiler(
   }
 
   let log_file = create_log_file(&app_handle, "extractor.log", !truncate_logs)?;
+  let mut args = vec![
+    source_path,
+    "--compile".to_string(),
+    "--proj-path".to_string(),
+    data_folder.to_string_lossy().into_owned(),
+  ];
+  // Add new --game argument
+  if config_info.tooling_version.minor >= 1 && config_info.tooling_version.patch >= 44 {
+    args.push("--game".to_string());
+    args.push(game_name.clone());
+  }
   let mut command = Command::new(exec_info.executable_path);
   command
-    .args([
-      source_path,
-      "--game".to_string(),
-      game_name.clone(),
-      "--compile".to_string(),
-      "--proj-path".to_string(),
-      data_folder.to_string_lossy().into_owned(),
-    ])
+    .args(args)
     .stdout(log_file.try_clone().unwrap())
     .stderr(log_file)
     .current_dir(exec_info.executable_dir);
@@ -663,14 +676,18 @@ fn generate_launch_game_string(
   } else {
     args = vec![
       "-v".to_string(),
-      "--game".to_string(),
-      game_name,
       "--proj-path".to_string(),
       data_folder.to_string_lossy().into_owned(),
-      "--".to_string(),
-      "-boot".to_string(),
-      "-fakeiso".to_string(),
     ];
+    // Add new --game argument
+    if config_info.tooling_version.minor >= 1 && config_info.tooling_version.patch >= 44 {
+      args.push("--game".to_string());
+      args.push(game_name.clone());
+    }
+    // passthru args
+    args.push("--".to_string());
+    args.push("-boot".to_string());
+    args.push("-fakeiso".to_string());
     if in_debug {
       args.push("-debug".to_string());
     }

--- a/src/lib/utils/github.ts
+++ b/src/lib/utils/github.ts
@@ -1,4 +1,6 @@
+import { getVersion } from "@tauri-apps/api/app";
 import { arch, platform } from "@tauri-apps/api/os";
+import semver from "semver";
 
 export interface ReleaseInfo {
   releaseType: "official" | "unofficial" | "devel";
@@ -89,9 +91,22 @@ async function parseGithubRelease(githubRelease: any): Promise<ReleaseInfo> {
       releaseInfo.invalidationReasons = line.split("|");
     } catch (err) {
       // do nothing, bad formatting
+      releaseInfo.invalidationReasons = ["Release invalid for unknown reasons"];
+    }
+  } else if (githubRelease.body.includes("<!-- requires-launcher-version:")) {
+    // Check the current semver and compare
+    const launcherVersion = await getVersion();
+    const requiredMinimumVersion = githubRelease.body
+      .split("<!-- requires-launcher-version:")[1]
+      .split("-->")[0]
+      .trim();
+    if (!semver.gte(launcherVersion, requiredMinimumVersion)) {
+      releaseInfo.invalid = true;
+      releaseInfo.invalidationReasons = [
+        `This version requires the launcher to be updated to atleast: ${requiredMinimumVersion}`,
+      ];
     }
   }
-  console.log(releaseInfo);
   return releaseInfo;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1145,6 +1145,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/semver@^7.5.4":
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.4.tgz#0a41252ad431c473158b22f9bfb9a63df7541cff"
+  integrity sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==
+
 "@vitest/coverage-v8@^0.34.6":
   version "0.34.6"
   resolved "https://registry.yarnpkg.com/@vitest/coverage-v8/-/coverage-v8-0.34.6.tgz#931d9223fa738474e00c08f52b84e0f39cedb6d1"
@@ -5346,7 +5351,7 @@ semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.3:
+semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==


### PR DESCRIPTION
Otherwise, using older versions than `0.1.44` won't work.

Additionally, add a mechanism to require a minimum version of the launcher for particular tooling versions.  