### PR TITLE
backend: Fix issue causing the `Continue` button to be unresponsive on new installs

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -406,6 +406,7 @@ impl LauncherConfig {
     let active_version = self.active_version.clone();
     let active_version_folder = self.active_version_folder.clone();
     let game_config = self.get_supported_game_config_mut(game_name)?;
+    game_config.is_installed = installed;
     if installed {
       game_config.version = active_version;
       game_config.version_folder = active_version_folder;


### PR DESCRIPTION
It helps to actually save to the config if the game was installed, I accidentally deleted this line in the previous fix PR (but wasn't caught because when you are updating a game, it's already `installed: true`!)