### PR TITLE
frontend: add warning about out of date VCC runtime

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -167,7 +167,7 @@ fn main() {
       commands::config::is_diskspace_requirement_met,
       commands::config::is_game_installed,
       commands::config::is_opengl_requirement_met,
-      commands::config::is_vcc_runtime_installed,
+      commands::config::is_minimum_vcc_runtime_installed,
       commands::config::reset_to_defaults,
       commands::config::save_active_version_change,
       commands::config::set_bypass_requirements,

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -42,6 +42,8 @@
   "gameControls_timePlayed_hours": "hours",
   "gameControls_timePlayed_minute": "minute",
   "gameControls_timePlayed_minutes": "minutes",
+  "gameControls_warning_vccVersion_headerA": "Your Microsoft Visual C++ Runtime is out of date",
+  "gameControls_warning_vccVersion_headerB": "Due to recent changes, the tools may fail to launch if this is not updated, please update using the link below.",
   "gameJob_applyTexturePacks": "Applying Packs",
   "gameJob_deleteTexturePacks": "Deleting Packs",
   "gameJob_enablingTexturePacks": "Enabling Packs",

--- a/src/components/games/setup/GameSetup.svelte
+++ b/src/components/games/setup/GameSetup.svelte
@@ -17,7 +17,7 @@
     isAVXRequirementMet,
     isDiskSpaceRequirementMet,
     isOpenGLRequirementMet,
-    isVCCRuntimeInstalled,
+    isMinimumVCCRuntimeInstalled,
   } from "$lib/rpc/config";
   import { progressTracker } from "$lib/stores/ProgressStore";
   import { generateSupportPackage } from "$lib/rpc/support";
@@ -46,7 +46,7 @@
     );
     const osType = await type();
     if (osType == "Windows_NT") {
-      const isVCCInstalled = await isVCCRuntimeInstalled();
+      const isVCCInstalled = await isMinimumVCCRuntimeInstalled();
       requirementsMet =
         isAvxMet && isOpenGLMet && isDiskSpaceMet && isVCCInstalled;
     } else {

--- a/src/components/games/setup/Requirements.svelte
+++ b/src/components/games/setup/Requirements.svelte
@@ -5,7 +5,7 @@
     isAVXRequirementMet,
     isDiskSpaceRequirementMet,
     isOpenGLRequirementMet,
-    isVCCRuntimeInstalled,
+    isMinimumVCCRuntimeInstalled,
     setBypassRequirements,
   } from "$lib/rpc/config";
   import { _ } from "svelte-i18n";
@@ -32,7 +32,7 @@
     const osType = await type();
     isVCCRelevant = osType == "Windows_NT";
     if (isVCCRelevant) {
-      isVCCInstalled = await isVCCRuntimeInstalled();
+      isVCCInstalled = await isMinimumVCCRuntimeInstalled();
     }
   });
 

--- a/src/lib/rpc/config.ts
+++ b/src/lib/rpc/config.ts
@@ -84,8 +84,14 @@ export async function isDiskSpaceRequirementMet(
   );
 }
 
-export async function isVCCRuntimeInstalled(): Promise<boolean | undefined> {
-  return await invoke_rpc("is_vcc_runtime_installed", {}, () => undefined);
+export async function isMinimumVCCRuntimeInstalled(): Promise<
+  boolean | undefined
+> {
+  return await invoke_rpc(
+    "is_minimum_vcc_runtime_installed",
+    {},
+    () => undefined,
+  );
 }
 
 export async function finalizeInstallation(gameName: string): Promise<void> {

--- a/src/routes/Game.svelte
+++ b/src/routes/Game.svelte
@@ -11,6 +11,7 @@
     getInstalledVersion,
     getInstalledVersionFolder,
     isGameInstalled,
+    isMinimumVCCRuntimeInstalled,
   } from "$lib/rpc/config";
   import GameJob from "../components/games/job/GameJob.svelte";
   import GameUpdate from "../components/games/setup/GameUpdate.svelte";
@@ -23,6 +24,7 @@
   import GameNotSupportedByTooling from "../components/games/GameNotSupportedByTooling.svelte";
   import { VersionStore } from "$lib/stores/VersionStore";
   import type { Job } from "$lib/utils/jobs";
+  import { type } from "@tauri-apps/api/os";
 
   const params = useParams();
   $: $params, loadGameInfo();
@@ -44,9 +46,14 @@
 
   let gameInBeta = false;
   let gameSupportedByTooling = false;
+  let showVccWarning = false;
 
   onMount(async () => {
     loadGameInfo();
+    const osType = await type();
+    if (osType == "Windows_NT") {
+      showVccWarning = !(await isMinimumVCCRuntimeInstalled());
+    }
   });
 
   async function loadGameInfo() {
@@ -148,6 +155,28 @@
       on:job={runGameJob}
     />
   {:else}
+    {#if showVccWarning}
+      <Alert color="red" rounded={false} class="border-t-4">
+        <span class="font-bold"
+          >{$_("gameControls_warning_vccVersion_headerA")}</span
+        >
+        <em>{$_("gameControls_warning_vccVersion_headerB")}</em>
+        <br />
+        <ul>
+          <li>
+            <a
+              class="font-bold text-blue-500"
+              target="_blank"
+              rel="noreferrer"
+              href="https://aka.ms/vs/17/release/vc_redist.x64.exe"
+              >{$_(
+                "requirements_windows_vccRuntimeExplanation_downloadLink",
+              )}</a
+            >
+          </li>
+        </ul>
+      </Alert>
+    {/if}
     {#if gameInBeta}
       <Alert color="red" rounded={false} class="border-t-4">
         <span class="font-bold">{$_("gameControls_beta_headerA")}</span>


### PR DESCRIPTION
Due to recent changes in the CI builders, we use a newer Clang which requires a newer VCC runtime (atleast, as far as I understand it).  Instead of doing something hacky like overriding the default choice of the compiler, which may cause issues in the future, just get users to update.

![Screenshot 2024-06-28 184008](https://github.com/open-goal/launcher/assets/13153231/469deb22-238b-4818-8f96-060bf844ada0)

![Screenshot 2024-06-28 184345](https://github.com/open-goal/launcher/assets/13153231/712d5baf-44af-4548-97fa-3aca7b5c4b1f)