### PR TITLE
support: Compile mod info into support package and use a temp file when creating the package

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3113,6 +3113,7 @@ dependencies = [
  "tar",
  "tauri",
  "tauri-build",
+ "tempfile",
  "thiserror",
  "tokio",
  "ts-rs",
@@ -4909,14 +4910,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6072,6 +6074,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,6 +41,7 @@ walkdir = "2.5.0"
 wgpu = "22.1.0"
 zip = { version = "2.2.0", features = ["deflate-zlib-ng"] }
 zip-extract = "0.2.1"
+tempfile = "3.12.0"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52.0"

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -780,7 +780,9 @@ pub async fn uninstall_mod(
     .join("mods")
     .join(&source_name)
     .join(&mod_name);
-  std::fs::remove_dir_all(mod_dir)?;
+  if mod_dir.exists() {
+    std::fs::remove_dir_all(mod_dir)?;
+  }
   config_lock
     .uninstall_mod(game_name, mod_name, source_name)
     .map_err(|_| CommandError::GameFeatures("Unable to uninstall mod".to_owned()))?;

--- a/src-tauri/src/commands/support.rs
+++ b/src-tauri/src/commands/support.rs
@@ -1,9 +1,11 @@
+use log::info;
 use serde::{Deserialize, Serialize};
 use std::{
   io::{BufWriter, Write},
   path::Path,
 };
 use sysinfo::{Disks, System};
+use walkdir::WalkDir;
 use zip::write::SimpleFileOptions;
 
 use tauri::api::path::config_dir;
@@ -186,6 +188,76 @@ fn dump_per_game_info(
       dir_diff::is_different(data_dir.join("goal_src"), version_data_dir.join("goal_src"))
         .unwrap_or(true);
   }
+
+  // Append mod settings and logs
+  let mod_directory = install_path.join("features").join(&game_name).join("mods");
+  info!("Scanning mod directory {mod_directory:?}");
+  if mod_directory.exists() {
+    let mod_source_iter = WalkDir::new(mod_directory)
+      .into_iter()
+      .filter_map(|e| e.ok());
+    for source_entry in mod_source_iter {
+      let mod_source_path = source_entry.path();
+      let mod_source_name = mod_source_path.file_name().unwrap().to_string_lossy(); // TODO
+      if mod_source_path.is_dir() {
+        let mod_iter = WalkDir::new(mod_source_path)
+          .max_depth(0)
+          .into_iter()
+          .filter_map(|e| e.ok());
+        for mod_entry in mod_iter {
+          let mod_path = mod_entry.path();
+          if mod_path.is_dir() {
+            let folder_name = mod_path.file_name().unwrap().to_string_lossy();
+            // Check for settings
+            if folder_name.eq("_settings") {
+              if mod_path.exists() {
+                append_dir_contents_to_zip(
+                  zip_file,
+                  &mod_path,
+                  format!("Game Settings and Saves/{game_name}/mods/{mod_source_name}/settings")
+                    .as_str(),
+                  vec!["gc", "json"],
+                )
+                .map_err(|_| {
+                  CommandError::Support(
+                    "Unable to append mod settings to support package".to_owned(),
+                  )
+                })?;
+                append_dir_contents_to_zip(
+                  zip_file,
+                  &mod_path,
+                  format!("Game Settings and Saves/{game_name}/mods/{mod_source_name}/saves")
+                    .as_str(),
+                  vec!["bin"],
+                )
+                .map_err(|_| {
+                  CommandError::Support("Unable to append mod saves to support package".to_owned())
+                })?;
+              }
+            } else {
+              // Get logs for each individual mod
+              let mod_log_folder = mod_path.join("data").join("log");
+              if mod_log_folder.exists() {
+                append_dir_contents_to_zip(
+                  zip_file,
+                  &mod_log_folder,
+                  format!(
+                    "Game Logs and ISO Info/{game_name}/mods/{mod_source_name}/{folder_name}/logs"
+                  )
+                  .as_str(),
+                  vec!["log", "json", "txt"],
+                )
+                .map_err(|_| {
+                  CommandError::Support("Unable to append mod logs to support package".to_owned())
+                })?;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   Ok(())
 }
 

--- a/src-tauri/src/util/zip.rs
+++ b/src-tauri/src/util/zip.rs
@@ -10,7 +10,7 @@ use walkdir::WalkDir;
 use zip::write::SimpleFileOptions;
 
 pub fn append_dir_contents_to_zip(
-  zip_file: &mut zip::ZipWriter<File>,
+  zip_file: &mut zip::ZipWriter<&File>,
   dir: &Path,
   internal_folder: &str,
   allowed_extensions: Vec<&str>,
@@ -66,7 +66,7 @@ pub fn append_dir_contents_to_zip(
 }
 
 pub fn append_file_to_zip(
-  zip_file: &mut zip::ZipWriter<File>,
+  zip_file: &mut zip::ZipWriter<&File>,
   src: &Path,
   path_in_zip: &str,
 ) -> zip::result::ZipResult<()> {


### PR DESCRIPTION
My theory still remains that users are uploading the zip before it's done being constructed (or it fails for some reason).

So I switched to making it as a temp file, then copying that temp file over if everything succeeds.  This should hopefully help...