### PR TITLE
Allow mod preview before install

### DIFF
--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -33,6 +33,7 @@
   "gameControls_button_openGameFolder": "Open Game Data Folder",
   "gameControls_button_openSavesFolder": "Open Saves Folder",
   "gameControls_button_openSettingsFolder": "Open Settings Folder",
+  "gameControls_button_install": "Install",
   "gameControls_button_play": "Play",
   "gameControls_button_playInDebug": "Play in Debug Mode",
   "gameControls_button_resetSettings": "Reset Settings",

--- a/src/components/games/features/mods/ModSelection.svelte
+++ b/src/components/games/features/mods/ModSelection.svelte
@@ -339,24 +339,9 @@
                         modInfo,
                       )}'); background-size: cover;"
                       on:click={async () => {
-                        // Install the mod
-                        const assetUrl = getModAssetUrlFromLatestVersion(
-                          userPlatform,
-                          modInfo,
+                        navigate(
+                          `/${getInternalName(activeGame)}/features/mods/${encodeURI(sourceInfo.sourceName)}/${encodeURI(modName)}`,
                         );
-                        if (assetUrl !== undefined) {
-                          await addModFromUrl(
-                            assetUrl,
-                            modName,
-                            sourceInfo.sourceName,
-                            modInfo.versions[0].version,
-                          );
-                        } else {
-                          toastStore.makeToast(
-                            $_("toasts_unableToRetrieveModDownloadURL"),
-                            "error",
-                          );
-                        }
                       }}
                     >
                       <h3 class="pointer-events-none select-none text-outline">


### PR DESCRIPTION
When not yet installed, clicking a mod now brings you to the mod page and requires Install / Version selection before you can launch the game. Advanced/settings options are disabled.
![image](https://github.com/user-attachments/assets/477f7db0-366e-4bb4-82ed-f427c6edbd66)

If you somehow get here and we don't have a list of versions (e.g. you're offline), the Install button is also disabled
![image](https://github.com/user-attachments/assets/56dd85b5-af37-4104-9398-5954923e512b)
