### PR TITLE
i18n: remind the user to restart their machine after updating VCC

### DIFF
--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -49,7 +49,7 @@
   "gameControls_timePlayed_minute": "minute",
   "gameControls_timePlayed_minutes": "minutes",
   "gameControls_warning_vccVersion_headerA": "Your Microsoft Visual C++ Runtime is out of date",
-  "gameControls_warning_vccVersion_headerB": "Due to recent changes, the tools may fail to launch if this is not updated, please update using the link below.",
+  "gameControls_warning_vccVersion_headerB": "Due to recent changes, the tools may fail to launch if this is not updated, please update using the link below and restart your machine.",
   "gameJob_applyTexturePacks": "Applying Packs",
   "gameJob_deleteTexturePacks": "Deleting Packs",
   "gameJob_enablingTexturePacks": "Enabling Packs",


### PR DESCRIPTION
Some users have reported they had to restart for things to work properly after updating the VCC runtime.