### PR TITLE
ci: enable verbose logs for tauri build to resolve macOS intermittent failures

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,3 +56,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+        with:
+          args: "--verbose"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -158,7 +158,7 @@ jobs:
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
         with:
-          args: "--config ./.tauri/release-config.json"
+          args: "--verbose --config ./.tauri/release-config.json"
           releaseId: ${{needs.create-release.outputs.release_id}}
 
   verify-release:


### PR DESCRIPTION
macOS builds are failing intermittently and the logs have no indication as to why, enabling verbose logs is the recommendation from tauri's support channels.

Hopefully the next time it happens there's a clue as to why.