### PR TITLE
frontend: warn about the dangers of massive texture packs

### DIFF
--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -14,6 +14,7 @@
   "features_textures_moveDown_buttonAlt": "move texture pack down in order",
   "features_textures_moveUp_buttonAlt": "move texture pack up in order",
   "features_textures_replacedCount": "Textures replaced",
+  "features_textures_largePackWarning": "Very large texture packs (hundreds of megabytes) may fail to install or impact game performance.",
   "gameControls_update_mod": "Update",
   "gameControls_active": "(Active)",
   "gameControls_always_use_newest": "Always Use Newest",

--- a/src/components/games/features/texture-packs/TexturePacks.svelte
+++ b/src/components/games/features/texture-packs/TexturePacks.svelte
@@ -261,6 +261,12 @@
             {packAddingError}
           </Alert>
         </div>
+      {:else}
+        <div class="flex flex-row font-bold mt-3">
+          <Alert color="red" class="flex-grow">
+            {$_("features_textures_largePackWarning")}
+          </Alert>
+        </div>
       {/if}
       <div class="flex flex-row font-bold mt-3">
         <h2>{$_("features_textures_listHeading")}</h2>


### PR DESCRIPTION
Fixes #310 

I don't really want to do too much in regards to this because it's a problem caused by third-party stuff.  So I'm just adding a warning to hopefully reduce the little frequency of this that we get.

Support wise:
- the launcher settings shows if they are using texture packs or not
- the installation logs from the tooling show if it's massive or not (it's usually obvious if they have thousands of texture replacement logs)