### PR TITLE
ux: if the game crashes unexpectedly, show a toast

### DIFF
--- a/src-tauri/src/commands/binaries.rs
+++ b/src-tauri/src/commands/binaries.rs
@@ -756,6 +756,12 @@ pub async fn get_launch_game_string(
   ))
 }
 
+#[derive(Clone, serde::Serialize)]
+struct ToastPayload {
+  toast: String,
+  level: String,
+}
+
 #[tauri::command]
 pub async fn launch_game(
   config: tauri::State<'_, tokio::sync::Mutex<LauncherConfig>>,
@@ -795,9 +801,22 @@ pub async fn launch_game(
   tokio::spawn(async move {
     let start_time = Instant::now(); // get the start time of the game
                                      // start waiting for the game to exit
-    if let Err(err) = child.wait() {
-      log::error!("Error occured when waiting for game to exit: {}", err);
-      return;
+    match child.wait() {
+      Ok(status_code) => {
+        if !status_code.code().is_some() || status_code.code().unwrap() != 0 {
+          let _ = app_handle.emit_all(
+            "toast_msg",
+            ToastPayload {
+              toast: "Game crashed unexpectedly!".to_string(),
+              level: "error".to_string(),
+            },
+          );
+        }
+      }
+      Err(err) => {
+        log::error!("Error occured when waiting for game to exit: {}", err);
+        return;
+      }
     }
     // once the game exits pass the time the game started to the track_playtine function
     if let Err(err) = track_playtime(start_time, game_name).await {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,6 +1,6 @@
-<script>
+<script lang="ts">
   // Other Imports
-  import { onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import { Router, Route } from "svelte-navigator";
   import Game from "./routes/Game.svelte";
   import Settings from "./routes/Settings.svelte";
@@ -15,8 +15,11 @@
   import { isLoading } from "svelte-i18n";
   import { getLocale, setLocale } from "$lib/rpc/config";
   import GameFeature from "./routes/GameFeature.svelte";
+  import { listen } from "@tauri-apps/api/event";
+  import { toastStore } from "$lib/stores/ToastStore";
 
   let revokeSpecificActions = false;
+  let toastListener: any = undefined;
 
   // Events
   onMount(async () => {
@@ -31,6 +34,16 @@
     const locale = await getLocale();
     if (locale !== null) {
       setLocale(locale);
+    }
+
+    toastListener = await listen("toast_msg", (event) => {
+      toastStore.makeToast(event.payload.toast, event.payload.level);
+    });
+  });
+
+  onDestroy(() => {
+    if (toastListener !== undefined) {
+      toastListener();
     }
   });
 


### PR DESCRIPTION
Fixes #290

Displays a toast with an error message if the game just crashes on startup.  This does not cover launching a mod since that code-path does not monitor the process' execution.