### PR TITLE
automate successful install progression and handle file not found errors

### DIFF
--- a/src-tauri/src/commands/game.rs
+++ b/src-tauri/src/commands/game.rs
@@ -44,7 +44,7 @@ pub async fn uninstall_game(
         log::error!("Failed to delete directory: {:?}", e);
         Err(e)
       }
-    }
+    },
   }?;
 
   match std::fs::remove_dir_all(data_folder.join("iso_data")) {
@@ -55,7 +55,7 @@ pub async fn uninstall_game(
         log::error!("Failed to delete directory: {:?}", e);
         Err(e)
       }
-    }
+    },
   }?;
 
   match std::fs::remove_dir_all(data_folder.join("out")) {
@@ -66,7 +66,7 @@ pub async fn uninstall_game(
         log::error!("Failed to delete directory: {:?}", e);
         Err(e)
       }
-    }
+    },
   }?;
 
   config_lock

--- a/src-tauri/src/commands/game.rs
+++ b/src-tauri/src/commands/game.rs
@@ -36,9 +36,21 @@ pub async fn uninstall_game(
     .join(&game_name)
     .join("data");
 
-  std::fs::remove_dir_all(data_folder.join("decompiler_out"))?;
-  std::fs::remove_dir_all(data_folder.join("iso_data"))?;
-  std::fs::remove_dir_all(data_folder.join("out"))?;
+  std::fs::remove_dir_all(data_folder.join("decompiler_out")).unwrap_or_else(|e| {
+    if e.kind() != std::io::ErrorKind::NotFound {
+        return Err(CommandError::GameManagement("Failed to remove decompiler_out directory: {}", e));
+    }
+  });
+  std::fs::remove_dir_all(data_folder.join("iso_data")).unwrap_or_else(|e| {
+    if e.kind() != std::io::ErrorKind::NotFound {
+        return Err(CommandError::GameManagement("Failed to remove iso_data directory: {}", e));
+    }
+  });
+  std::fs::remove_dir_all(data_folder.join("out")).unwrap_or_else(|e| {
+    if e.kind() != std::io::ErrorKind::NotFound {
+        return Err(CommandError::GameManagement("Failed to remove out directory: {}", e));
+    }
+  });
 
   config_lock
     .update_installed_game_version(&game_name, false)

--- a/src-tauri/src/commands/game.rs
+++ b/src-tauri/src/commands/game.rs
@@ -36,21 +36,38 @@ pub async fn uninstall_game(
     .join(&game_name)
     .join("data");
 
-  std::fs::remove_dir_all(data_folder.join("decompiler_out")).unwrap_or_else(|e| {
-    if e.kind() != std::io::ErrorKind::NotFound {
-        return Err(CommandError::GameManagement("Failed to remove decompiler_out directory: {}", e));
+  match std::fs::remove_dir_all(data_folder.join("decompiler_out")) {
+    Ok(_) => Ok(()),
+    Err(e) => match e.kind() {
+      std::io::ErrorKind::NotFound => Ok(()),
+      _ => {
+        log::error!("Failed to delete directory: {:?}", e);
+        Err(e)
+      }
     }
-  });
-  std::fs::remove_dir_all(data_folder.join("iso_data")).unwrap_or_else(|e| {
-    if e.kind() != std::io::ErrorKind::NotFound {
-        return Err(CommandError::GameManagement("Failed to remove iso_data directory: {}", e));
+  }?;
+
+  match std::fs::remove_dir_all(data_folder.join("iso_data")) {
+    Ok(_) => Ok(()),
+    Err(e) => match e.kind() {
+      std::io::ErrorKind::NotFound => Ok(()),
+      _ => {
+        log::error!("Failed to delete directory: {:?}", e);
+        Err(e)
+      }
     }
-  });
-  std::fs::remove_dir_all(data_folder.join("out")).unwrap_or_else(|e| {
-    if e.kind() != std::io::ErrorKind::NotFound {
-        return Err(CommandError::GameManagement("Failed to remove out directory: {}", e));
+  }?;
+
+  match std::fs::remove_dir_all(data_folder.join("out")) {
+    Ok(_) => Ok(()),
+    Err(e) => match e.kind() {
+      std::io::ErrorKind::NotFound => Ok(()),
+      _ => {
+        log::error!("Failed to delete directory: {:?}", e);
+        Err(e)
+      }
     }
-  });
+  }?;
 
   config_lock
     .update_installed_game_version(&game_name, false)

--- a/src/components/games/job/GameJob.svelte
+++ b/src/components/games/job/GameJob.svelte
@@ -45,6 +45,10 @@
   const dispatch = createEventDispatcher();
   let installationError: string | undefined | null = undefined;
 
+   $: if ($progressTracker.overallStatus === "success") {
+      dispatch("jobFinished");
+    }
+
   async function setupDecompileJob() {
     installationError = undefined;
     progressTracker.init([
@@ -470,27 +474,13 @@
       await setupCompileModJob();
     }
   });
-
-  function dispatchCompleteJob() {
-    dispatch("jobFinished");
-  }
 </script>
 
 <div class="flex flex-col justify-content">
   <Progress />
   <LogViewer />
 </div>
-{#if $progressTracker.overallStatus === "success"}
-  <div class="flex flex-col justify-end items-end mt-auto">
-    <div class="flex flex-row gap-2">
-      <Button
-        class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
-        on:click={async () => dispatchCompleteJob()}
-        >{$_("setup_button_continue")}</Button
-      >
-    </div>
-  </div>
-{:else if $progressTracker.overallStatus === "failed"}
+{#if $progressTracker.overallStatus === "failed"}
   <div class="flex flex-col mt-auto">
     <div class="flex flex-row gap-2">
       <Alert color="red" class="dark:bg-slate-900 flex-grow">

--- a/src/components/games/job/GameJob.svelte
+++ b/src/components/games/job/GameJob.svelte
@@ -45,9 +45,9 @@
   const dispatch = createEventDispatcher();
   let installationError: string | undefined | null = undefined;
 
-   $: if ($progressTracker.overallStatus === "success") {
-      dispatch("jobFinished");
-    }
+  $: if ($progressTracker.overallStatus === "success") {
+    dispatch("jobFinished");
+  }
 
   async function setupDecompileJob() {
     installationError = undefined;

--- a/src/components/games/setup/GameSetup.svelte
+++ b/src/components/games/setup/GameSetup.svelte
@@ -118,7 +118,7 @@
   }
 
   $: if ($progressTracker.overallStatus === "success") {
-    dispatch("change")
+    dispatch("change");
   }
 </script>
 

--- a/src/components/games/setup/GameSetup.svelte
+++ b/src/components/games/setup/GameSetup.svelte
@@ -117,8 +117,8 @@
     }
   }
 
-  async function dispatchSetupEvent() {
-    dispatch("change");
+  $: if ($progressTracker.overallStatus === "success") {
+    dispatch("change")
   }
 </script>
 
@@ -129,17 +129,7 @@
     <Progress />
     <LogViewer />
   </div>
-  {#if $progressTracker.overallStatus === "success"}
-    <div class="flex flex-col justify-end items-end mt-auto">
-      <div class="flex flex-row gap-2">
-        <Button
-          class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
-          on:click={async () => await dispatchSetupEvent()}
-          >{$_("setup_button_continue")}</Button
-        >
-      </div>
-    </div>
-  {:else if $progressTracker.overallStatus === "failed"}
+  {#if $progressTracker.overallStatus === "failed"}
     <div class="flex flex-col mt-auto">
       <div class="flex flex-row gap-2">
         <Alert


### PR DESCRIPTION
- automatically progress app after successful install. reduces friction leading to a better UX.
- ignore file not found error when uninstalling. after deleted my `iso_data` directory I was unable to successfully uninstall the game because the `?` unwrap would propagate the file not found error. Since our intention is to delete these files, if they are not found we should ignore the error and continue deleting the rest.