### PR TITLE
backend: ensure logs are pushed to the frontend when the process terminates

### DIFF
--- a/src-tauri/src/util/process.rs
+++ b/src-tauri/src/util/process.rs
@@ -85,6 +85,9 @@ pub async fn watch_process(
         },
         // Wait for the child process to finish
         status = child.wait() => {
+          let mut buf = buffer_clone.lock().await;
+          let _ = app_handle.emit_all("log_update", LogPayload { logs: buf.clone() });
+          buf.clear();
           process_status = Some(status?);
           break;
         }


### PR DESCRIPTION
This was leading to awkward situations where there are no logs in the frontend if the binaries immediately fail.

Fixed now:
![image](https://github.com/user-attachments/assets/441e6b7d-2f59-487c-b47d-a49d46eb8c12)
