### PR TITLE
frontend: simplify the version pagination regex

### DIFF
--- a/src/lib/utils/github.ts
+++ b/src/lib/utils/github.ts
@@ -92,7 +92,7 @@ async function parseGithubRelease(githubRelease: any): Promise<ReleaseInfo> {
 }
 
 export async function listOfficialReleases(): Promise<ReleaseInfo[]> {
-  const nextUrlPattern = /(?<=<)([\S]*)(?=>; rel="Next")/i;
+  const nextUrlPattern = /<([\S]+)>; rel="Next"/i;
   let releases = [];
   let urlToHit =
     "https://api.github.com/repos/open-goal/jak-project/releases?per_page=100";
@@ -117,7 +117,7 @@ export async function listOfficialReleases(): Promise<ReleaseInfo[]> {
       resp.headers.get("link").includes(`rel=\"next\"`)
     ) {
       // we must paginate!
-      urlToHit = resp.headers.get("link").match(nextUrlPattern)[0];
+      urlToHit = resp.headers.get("link").match(nextUrlPattern)[1];
     } else {
       urlToHit = undefined;
     }


### PR DESCRIPTION
Fixes #586 

Depending on your javascript engine, you may or may not have support for lookaheads/lookbehinds.  I took this regex from github's examples without thinking -- probably fine in all versions of `node` but of course some platforms it's not going to work.

Simplify it to be a more typical regex.