### PR TITLE
backend: only use decompiler settings outside of installs/updates

### DIFF
--- a/src-tauri/src/commands/binaries.rs
+++ b/src-tauri/src/commands/binaries.rs
@@ -345,6 +345,7 @@ pub async fn run_decompiler(
   path_to_iso: String,
   game_name: String,
   truncate_logs: bool,
+  use_decomp_settings: bool,
 ) -> Result<InstallStepOutput, CommandError> {
   let config_lock = config.lock().await;
   let config_info = common_prelude(&config_lock)?;
@@ -377,25 +378,27 @@ pub async fn run_decompiler(
   let mut command = Command::new(exec_info.executable_path);
 
   let mut decomp_config_overrides = vec![];
-  if let Some(decomp_settings) = &config_lock.decompiler_settings {
-    if let Some(rip_levels) = decomp_settings.rip_levels_enabled {
-      if rip_levels {
-        decomp_config_overrides.push(format!("\"rip_levels\": {rip_levels}"));
+  if use_decomp_settings {
+    if let Some(decomp_settings) = &config_lock.decompiler_settings {
+      if let Some(rip_levels) = decomp_settings.rip_levels_enabled {
+        if rip_levels {
+          decomp_config_overrides.push(format!("\"rip_levels\": {rip_levels}"));
+        }
       }
-    }
-    if let Some(rip_collision) = decomp_settings.rip_collision_enabled {
-      if rip_collision {
-        decomp_config_overrides.push(format!("\"rip_collision\": {rip_collision}"));
+      if let Some(rip_collision) = decomp_settings.rip_collision_enabled {
+        if rip_collision {
+          decomp_config_overrides.push(format!("\"rip_collision\": {rip_collision}"));
+        }
       }
-    }
-    if let Some(rip_textures) = decomp_settings.rip_textures_enabled {
-      if rip_textures {
-        decomp_config_overrides.push(format!("\"save_texture_pngs\": {rip_textures}"));
+      if let Some(rip_textures) = decomp_settings.rip_textures_enabled {
+        if rip_textures {
+          decomp_config_overrides.push(format!("\"save_texture_pngs\": {rip_textures}"));
+        }
       }
-    }
-    if let Some(rip_streamed_audio) = decomp_settings.rip_streamed_audio_enabled {
-      if rip_streamed_audio {
-        decomp_config_overrides.push(format!("\"rip_streamed_audio\": {rip_streamed_audio}"));
+      if let Some(rip_streamed_audio) = decomp_settings.rip_streamed_audio_enabled {
+        if rip_streamed_audio {
+          decomp_config_overrides.push(format!("\"rip_streamed_audio\": {rip_streamed_audio}"));
+        }
       }
     }
   }

--- a/src/components/games/job/GameJob.svelte
+++ b/src/components/games/job/GameJob.svelte
@@ -62,7 +62,7 @@
       },
     ]);
     progressTracker.start();
-    let resp = await runDecompiler("", getInternalName(activeGame), true);
+    let resp = await runDecompiler("", getInternalName(activeGame), true, true);
     if (!resp.success) {
       progressTracker.halt();
       installationError = resp.msg;
@@ -123,7 +123,7 @@
       return;
     }
     progressTracker.proceed();
-    resp = await runDecompiler("", getInternalName(activeGame), true);
+    resp = await runDecompiler("", getInternalName(activeGame), true, false);
     if (!resp.success) {
       progressTracker.halt();
       installationError = resp.msg;
@@ -195,7 +195,7 @@
       return;
     }
     progressTracker.proceed();
-    resp = await runDecompiler("", getInternalName(activeGame), true);
+    resp = await runDecompiler("", getInternalName(activeGame), true, false);
     if (!resp.success) {
       progressTracker.halt();
       installationError = resp.msg;

--- a/src/components/games/setup/GameSetup.svelte
+++ b/src/components/games/setup/GameSetup.svelte
@@ -97,7 +97,12 @@
         return;
       }
       progressTracker.proceed();
-      resp = await runDecompiler(sourcePath, getInternalName(activeGame));
+      resp = await runDecompiler(
+        sourcePath,
+        getInternalName(activeGame),
+        false,
+        false,
+      );
       if (!resp.success) {
         progressTracker.halt();
         installationError = resp.msg;

--- a/src/lib/rpc/binaries.ts
+++ b/src/lib/rpc/binaries.ts
@@ -33,10 +33,11 @@ export async function runDecompiler(
   pathToIso: string,
   gameName: string,
   truncateLogs: boolean = false,
+  useDecompSettings: boolean = false,
 ): Promise<InstallationOutput> {
   return await invoke_rpc(
     "run_decompiler",
-    { pathToIso, gameName, truncateLogs },
+    { pathToIso, gameName, truncateLogs, useDecompSettings },
     () => failed("Failed to run decompiler"),
   );
 }


### PR DESCRIPTION
Typically just results in big slow-downs and such, as some users don't remember they enabled these settings and then leave them on.  Only use them when the users runs "Advanced > Decompiler"