### PR TITLE
schemas: move mod-related schemas to this repository

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,7 @@
+Generated via typescript definitions:
+
+```bash
+npx ts-json-schema-generator --path './*.ts' --type 'ModMetadata' > mod-schema.v1.json
+```
+
+And then some value validations added on mostly for valid semver checking

--- a/schemas/mod-source/v1/mod-source-schema.v1.json
+++ b/schemas/mod-source/v1/mod-source-schema.v1.json
@@ -1,0 +1,266 @@
+{
+  "$ref": "#/definitions/ModSourceData",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "ModSourceData": {
+      "additionalProperties": false,
+      "properties": {
+        "lastUpdated": {
+          "type": "string"
+        },
+        "mods": {
+          "additionalProperties": {
+            "additionalProperties": false,
+            "properties": {
+              "authors": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "coverArtUrl": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "displayName": {
+                "type": "string"
+              },
+              "externalLink": {
+                "type": "string"
+              },
+              "perGameConfig": {
+                "additionalProperties": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "coverArtUrl": {
+                      "type": "string"
+                    },
+                    "releaseDate": {
+                      "type": "string"
+                    },
+                    "thumbnailArtUrl": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "object"
+              },
+              "supportedGames": {
+                "items": {
+                  "enum": [
+                    "jak1",
+                    "jak2",
+                    "jak3",
+                    "jakx"
+                  ],
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "tags": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "thumbnailArtUrl": {
+                "type": "string"
+              },
+              "versions": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "assets": {
+                      "additionalProperties": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    "publishedDate": {
+                      "type": "string"
+                    },
+                    "supportedGames": {
+                      "items": {
+                        "enum": [
+                          "jak1",
+                          "jak2",
+                          "jak3",
+                          "jakx"
+                        ],
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "version": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "version",
+                    "publishedDate",
+                    "assets"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "websiteUrl": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "displayName",
+              "description",
+              "authors",
+              "tags",
+              "supportedGames",
+              "versions"
+            ],
+            "type": "object"
+          },
+          "type": "object"
+        },
+        "schemaVersion": {
+          "description": "Semantic Version",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "texturePacks": {
+          "additionalProperties": {
+            "additionalProperties": false,
+            "properties": {
+              "authors": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "coverArtUrl": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "displayName": {
+                "type": "string"
+              },
+              "externalLink": {
+                "type": "string"
+              },
+              "perGameConfig": {
+                "additionalProperties": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "coverArtUrl": {
+                      "type": "string"
+                    },
+                    "releaseDate": {
+                      "type": "string"
+                    },
+                    "thumbnailArtUrl": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "object"
+              },
+              "supportedGames": {
+                "items": {
+                  "enum": [
+                    "jak1",
+                    "jak2",
+                    "jak3",
+                    "jakx"
+                  ],
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "tags": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "thumbnailArtUrl": {
+                "type": "string"
+              },
+              "versions": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "assets": {
+                      "additionalProperties": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    "publishedDate": {
+                      "type": "string"
+                    },
+                    "supportedGames": {
+                      "items": {
+                        "enum": [
+                          "jak1",
+                          "jak2",
+                          "jak3",
+                          "jakx"
+                        ],
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "version": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "version",
+                    "publishedDate",
+                    "assets"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "websiteUrl": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "displayName",
+              "description",
+              "authors",
+              "tags",
+              "supportedGames",
+              "versions"
+            ],
+            "type": "object"
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "sourceName",
+        "lastUpdated",
+        "mods",
+        "texturePacks"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/schemas/mod-source/v1/types.ts
+++ b/schemas/mod-source/v1/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Semantic Version
+ * @pattern ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+ */
+type Semver = string;
+
+type SupportedGame = "jak1" | "jak2" | "jak3" | "jakx";
+
+interface ModVersion {
+  version: string;
+  publishedDate: string;
+  assets: Record<string, string | null>;
+  supportedGames?: SupportedGame[];
+}
+
+interface ModPerGameConfig {
+  coverArtUrl?: string;
+  thumbnailArtUrl?: string;
+  releaseDate?: string;
+}
+
+interface ModInfo {
+  displayName: string;
+  description: string;
+  authors: string[];
+  tags: string[];
+  supportedGames: SupportedGame[];
+  websiteUrl?: string;
+  versions: ModVersion[];
+  perGameConfig?: Record<string, ModPerGameConfig>;
+  coverArtUrl?: string;
+  thumbnailArtUrl?: string;
+  externalLink?: string;
+}
+
+export interface ModSourceData {
+  schemaVersion: Semver;
+  sourceName: string;
+  lastUpdated: string;
+  mods: Record<string, ModInfo>
+  texturePacks: Record<string, ModInfo>
+}

--- a/schemas/texture-packs/v1/texture-pack-schema.v1.json
+++ b/schemas/texture-packs/v1/texture-pack-schema.v1.json
@@ -1,0 +1,62 @@
+{
+  "$ref": "#/definitions/TexturePackMetadata",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "TexturePackMetadata": {
+      "additionalProperties": false,
+      "properties": {
+        "authors": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "publishedDate": {
+          "type": "string"
+        },
+        "schemaVersion": {
+          "description": "Semantic Version",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+          "type": "string"
+        },
+        "supportedGames": {
+          "items": {
+            "enum": [
+              "jak1",
+              "jak2",
+              "jak3",
+              "jakx"
+            ],
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "version": {
+          "description": "Semantic Version",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "version",
+        "name",
+        "description",
+        "authors",
+        "publishedDate",
+        "tags",
+        "supportedGames"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/schemas/texture-packs/v1/types.ts
+++ b/schemas/texture-packs/v1/types.ts
@@ -1,0 +1,18 @@
+/**
+ * Semantic Version
+ * @pattern ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+ */
+type Semver = string;
+
+type SupportedGame = "jak1" | "jak2" | "jak3" | "jakx";
+
+export interface TexturePackMetadata {
+  schemaVersion: Semver;
+  version: Semver;
+  name: string;
+  description: string;
+  authors: string;
+  publishedDate: string;
+  tags: string[];
+  supportedGames: SupportedGame[];
+}


### PR DESCRIPTION
Moving the schemas from https://github.com/open-goal/mod-bundling-tools to here as this is the spot where they are relevant now (the code here reads them)