### PR TITLE
installing games from folder

### DIFF
--- a/src-tauri/src/commands/binaries.rs
+++ b/src-tauri/src/commands/binaries.rs
@@ -234,6 +234,7 @@ pub async fn extract_and_validate_iso(
   app_handle: tauri::AppHandle,
   path_to_iso: String,
   game_name: String,
+  via_folder: bool,
 ) -> Result<InstallStepOutput, CommandError> {
   let config_lock = config.lock().await;
   let config_info = common_prelude(&config_lock)?;
@@ -261,7 +262,7 @@ pub async fn extract_and_validate_iso(
     "--proj-path".to_string(),
     data_folder.to_string_lossy().into_owned(),
   ];
-  if Path::new(&path_to_iso.clone()).is_dir() {
+  if via_folder {
     args.push("--folder".to_string());
   }
   // Add new --game argument
@@ -335,6 +336,7 @@ pub async fn run_decompiler(
   game_name: String,
   truncate_logs: bool,
   use_decomp_settings: bool,
+  via_folder: bool,
 ) -> Result<InstallStepOutput, CommandError> {
   let config_lock = config.lock().await;
   let config_info = common_prelude(&config_lock)?;
@@ -406,6 +408,10 @@ pub async fn run_decompiler(
   if config_info.tooling_version.minor > 1 || config_info.tooling_version.patch >= 44 {
     args.push("--game".to_string());
     args.push(game_name.clone());
+  }
+
+  if via_folder {
+    args.push("--folder".to_string());
   }
 
   // TODO NOW - minimum
@@ -483,6 +489,7 @@ pub async fn run_compiler(
   path_to_iso: String,
   game_name: String,
   truncate_logs: bool,
+  via_folder: bool,
 ) -> Result<InstallStepOutput, CommandError> {
   let config_lock = config.lock().await;
   let config_info = common_prelude(&config_lock)?;
@@ -521,6 +528,10 @@ pub async fn run_compiler(
   if config_info.tooling_version.minor > 1 || config_info.tooling_version.patch >= 44 {
     args.push("--game".to_string());
     args.push(game_name.clone());
+  }
+
+  if via_folder {
+    args.push("--folder".to_string());
   }
 
   log::info!("Running compiler with args: {:?}", args);

--- a/src/components/games/setup/GameSetup.svelte
+++ b/src/components/games/setup/GameSetup.svelte
@@ -108,6 +108,7 @@
       let resp = await extractAndValidateISO(
         sourcePath,
         getInternalName(activeGame),
+        viaFolder,
       );
       if (!resp.success) {
         progressTracker.halt();
@@ -120,6 +121,7 @@
         getInternalName(activeGame),
         false,
         false,
+        viaFolder,
       );
       if (!resp.success) {
         progressTracker.halt();
@@ -127,7 +129,12 @@
         return;
       }
       progressTracker.proceed();
-      resp = await runCompiler(sourcePath, getInternalName(activeGame));
+      resp = await runCompiler(
+        sourcePath,
+        getInternalName(activeGame),
+        false,
+        viaFolder,
+      );
       if (!resp.success) {
         progressTracker.halt();
         installationError = resp.msg;
@@ -201,11 +208,10 @@
         >{$_("setup_button_installViaISO")}</Button
       >
       <!-- TODO - disabled for now, needs fixes in the extractor -->
-      <!-- <Button
+      <Button
         class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
-        on:click={async () => await install(true)}
-        >Install via Folder</Button
-      > -->
+        on:click={async () => await install(true)}>Install via Folder</Button
+      >
     </div>
   </div>
 {/if}

--- a/src/lib/rpc/binaries.ts
+++ b/src/lib/rpc/binaries.ts
@@ -21,10 +21,11 @@ export async function updateDataDirectory(
 export async function extractAndValidateISO(
   pathToIso: string,
   gameName: string,
+  viaFolder: boolean = false,
 ): Promise<InstallationOutput> {
   return await invoke_rpc(
     "extract_and_validate_iso",
-    { pathToIso, gameName },
+    { pathToIso, gameName, viaFolder },
     () => failed("Failed to extract and validate ISO"),
   );
 }
@@ -34,10 +35,11 @@ export async function runDecompiler(
   gameName: string,
   truncateLogs: boolean = false,
   useDecompSettings: boolean = false,
+  viaFolder: boolean = false,
 ): Promise<InstallationOutput> {
   return await invoke_rpc(
     "run_decompiler",
-    { pathToIso, gameName, truncateLogs, useDecompSettings },
+    { pathToIso, gameName, truncateLogs, useDecompSettings, viaFolder },
     () => failed("Failed to run decompiler"),
   );
 }
@@ -46,10 +48,11 @@ export async function runCompiler(
   pathToIso: string,
   gameName: string,
   truncateLogs: boolean = false,
+  viaFolder: boolean = false,
 ): Promise<InstallationOutput> {
   return await invoke_rpc(
     "run_compiler",
-    { pathToIso, gameName, truncateLogs },
+    { pathToIso, gameName, truncateLogs, viaFolder },
     () => failed("Failed to run compiler"),
   );
 }

--- a/src/lib/utils/file-dialogs.ts
+++ b/src/lib/utils/file-dialogs.ts
@@ -60,7 +60,7 @@ export async function isoPrompt(
   fileExplanation: string,
   title: string,
 ): Promise<string | undefined> {
-  const path = await filePrompt(["ISO, zip", "iso"], fileExplanation, title);
+  const path = await filePrompt(["ISO", "iso"], fileExplanation, title);
   if (path === null) {
     return undefined;
   }

--- a/src/lib/utils/file-dialogs.ts
+++ b/src/lib/utils/file-dialogs.ts
@@ -60,7 +60,7 @@ export async function isoPrompt(
   fileExplanation: string,
   title: string,
 ): Promise<string | undefined> {
-  const path = await filePrompt(["ISO", "iso"], fileExplanation, title);
+  const path = await filePrompt(["ISO, zip", "iso"], fileExplanation, title);
   if (path === null) {
     return undefined;
   }


### PR DESCRIPTION
Made some minor tweaks to the install process and it seems to work fine for jak 1.
jak 2 currently failing due to incorrect iso hash.

while not exactly the same thing as "reading/copying the data directly from the disc" reading from a folder is more than enough. its reasonable that we can expect users to mount, highlight all the files, and copy them to a directory given that this is already required to make their own iso files to install traditionally.

closes #3 