### PR TITLE
macos: self-sign the macOS application

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,6 +35,9 @@
         "certificateThumbprint": null,
         "digestAlgorithm": "sha256",
         "timestampUrl": ""
+      },
+      "macOS": {
+        "signingIdentity": "-"
       }
     },
     "allowlist": {


### PR DESCRIPTION
This will allegedly workaround this issue.

If it does not, then there isn't much else we can do in a practical sense, it is what is recommended from Tauri's support / other tauri devs.

![image](https://github.com/user-attachments/assets/10495320-de72-4d50-be1d-604a689da138)
