### PR TITLE
macos: isolate and check the macOS major version number

### DIFF
--- a/src-tauri/src/commands/util.rs
+++ b/src-tauri/src/commands/util.rs
@@ -1,5 +1,7 @@
 use crate::config::LauncherConfig;
 use crate::util::file::delete_dir;
+use log::error;
+use log::info;
 use serde_json::Value;
 use std::path::Path;
 #[cfg(target_os = "macos")]
@@ -137,7 +139,18 @@ pub async fn is_macos_version_15_or_above() -> Result<bool, CommandError> {
 pub async fn is_macos_version_15_or_above() -> Result<bool, CommandError> {
   if let Ok(ctl) = sysctl::Ctl::new("kern.osproductversion") {
     if let Ok(ctl_val) = ctl.value_string() {
-      let version = ctl_val.parse::<f32>();
+      info!("MacOS Version Number: {}", ctl_val);
+      let mut stripped_ctl_val = ctl_val.as_str();
+      if stripped_ctl_val.contains(".") {
+        let first_value = stripped_ctl_val.split(".").next();
+        if first_value.is_none() {
+          error!("Unable to parse MacOS major version number");
+          return Ok(false);
+        }
+        stripped_ctl_val = first_value.unwrap();
+      }
+      info!("Checking MacOS Version Number: {}", stripped_ctl_val);
+      let version = stripped_ctl_val.parse::<f32>();
       if version.is_ok() {
         return Ok(version.unwrap() >= 15.0);
       }


### PR DESCRIPTION
macOS version numbers may have a patch version, which makes naive parsing to a float insufficient.  They also might even contain words via the beta releases, though I've never installed one of those to know for sure.

<img width="159" alt="image" src="https://github.com/user-attachments/assets/8fb12f04-3f3d-4339-a4ba-ef0fb78ea290" />

This should solve the problem, the same improvement will need to be made in `jak-project`

Related to https://github.com/open-goal/launcher/issues/663