### PR TITLE
Refactor vcc check

### DIFF
--- a/src-tauri/src/commands/support.rs
+++ b/src-tauri/src/commands/support.rs
@@ -284,12 +284,7 @@ pub async fn generate_support_package(
   // System Information
   let mut system_info = System::new_all();
   system_info.refresh_all();
-  let installed_vcc_runtime_version = get_installed_vcc_runtime();
-  if installed_vcc_runtime_version.is_none() {
-    package.installed_vcc_runtime = None;
-  } else {
-    package.installed_vcc_runtime = Some(installed_vcc_runtime_version.unwrap().to_string());
-  }
+  package.installed_vcc_runtime = get_installed_vcc_runtime().map(|v| v.to_string());
   package.total_memory_megabytes = system_info.total_memory() / 1024 / 1024;
   package.cpu_name = system_info.cpus()[0].name().to_string();
   package.cpu_vendor = system_info.cpus()[0].vendor_id().to_string();

--- a/src-tauri/src/commands/util.rs
+++ b/src-tauri/src/commands/util.rs
@@ -107,16 +107,10 @@ pub async fn is_minimum_vcc_runtime_installed() -> Result<bool, CommandError> {
   }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(not(target_os = "windows"))]
 #[tauri::command]
 pub async fn is_minimum_vcc_runtime_installed() -> Result<bool, CommandError> {
   return Ok(false);
-}
-
-#[cfg(target_os = "macos")]
-#[tauri::command]
-pub async fn is_minimum_vcc_runtime_installed() -> Result<bool, CommandError> {
-  Ok(false)
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]

--- a/src/components/games/setup/GameSetup.svelte
+++ b/src/components/games/setup/GameSetup.svelte
@@ -16,7 +16,6 @@
     isAVXRequirementMet,
     isDiskSpaceRequirementMet,
     isOpenGLRequirementMet,
-    isMinimumVCCRuntimeInstalled,
     getProceedAfterSuccessfulOperation,
   } from "$lib/rpc/config";
   import { progressTracker } from "$lib/stores/ProgressStore";
@@ -25,6 +24,7 @@
   import { emit } from "@tauri-apps/api/event";
   import { arch, type } from "@tauri-apps/plugin-os";
   import { isMacOSVersion15OrAbove } from "$lib/rpc/util";
+  import { isMinVCCRuntime } from "$lib/stores/VersionStore";
 
   export let activeGame: SupportedGame;
 
@@ -62,9 +62,8 @@
     } else {
       const isAvxMet = await isAVXRequirementMet();
       if (osType == "windows") {
-        const isVCCInstalled = await isMinimumVCCRuntimeInstalled();
         requirementsMet =
-          isAvxMet && isOpenGLMet && isDiskSpaceMet && isVCCInstalled;
+          isAvxMet && isOpenGLMet && isDiskSpaceMet && $isMinVCCRuntime;
       } else {
         requirementsMet = isAvxMet && isOpenGLMet && isDiskSpaceMet;
       }

--- a/src/components/games/setup/GameUpdate.svelte
+++ b/src/components/games/setup/GameUpdate.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
   import type { SupportedGame } from "$lib/constants";
-  import {
-    getAutoUpdateGames,
-    isMinimumVCCRuntimeInstalled,
-  } from "$lib/rpc/config";
-  import { VersionStore } from "$lib/stores/VersionStore";
+  import { getAutoUpdateGames } from "$lib/rpc/config";
+  import { isMinVCCRuntime, VersionStore } from "$lib/stores/VersionStore";
   import { type } from "@tauri-apps/plugin-os";
   import { Button, Card } from "flowbite-svelte";
   import { createEventDispatcher, onMount } from "svelte";
@@ -16,14 +13,9 @@
 
   export let installedVersion: String | undefined;
 
-  let displayVCCWarning = false;
+  let displayVCCWarning = type() == "windows" && !$isMinVCCRuntime;
 
   onMount(async () => {
-    const osType = await type();
-    if (osType == "Windows_NT") {
-      const isVCCInstalled = await isMinimumVCCRuntimeInstalled();
-      displayVCCWarning = !isVCCInstalled;
-    }
     let shouldAutoUpdate = await getAutoUpdateGames();
     if (shouldAutoUpdate) {
       dispatch("job", {

--- a/src/lib/rpc/config.ts
+++ b/src/lib/rpc/config.ts
@@ -85,9 +85,7 @@ export async function isDiskSpaceRequirementMet(
   );
 }
 
-export async function isMinimumVCCRuntimeInstalled(): Promise<
-  boolean | undefined
-> {
+export async function isMinimumVCCRuntimeInstalled(): Promise<boolean> {
   return await invoke_rpc(
     "is_minimum_vcc_runtime_installed",
     {},

--- a/src/lib/stores/VersionStore.ts
+++ b/src/lib/stores/VersionStore.ts
@@ -7,3 +7,7 @@ export interface VersionStoreIFace {
 export const VersionStore = writable<VersionStoreIFace>({
   activeVersionName: null,
 });
+
+export const isMinVCCRuntime = writable(
+  JSON.parse(localStorage.getItem("isMinVCCRuntime")),
+);

--- a/src/routes/Game.svelte
+++ b/src/routes/Game.svelte
@@ -10,7 +10,6 @@
     doesActiveToolingVersionSupportGame,
     getInstalledVersion,
     isGameInstalled,
-    isMinimumVCCRuntimeInstalled,
   } from "$lib/rpc/config";
   import GameJob from "../components/games/job/GameJob.svelte";
   import GameUpdate from "../components/games/setup/GameUpdate.svelte";
@@ -20,7 +19,7 @@
   } from "$lib/rpc/versions";
   import GameToolsNotSet from "../components/games/GameToolsNotSet.svelte";
   import GameNotSupportedByTooling from "../components/games/GameNotSupportedByTooling.svelte";
-  import { VersionStore } from "$lib/stores/VersionStore";
+  import { isMinVCCRuntime, VersionStore } from "$lib/stores/VersionStore";
   import type { Job } from "$lib/utils/jobs";
   import { type } from "@tauri-apps/plugin-os";
   import { getModSourcesData, refreshModSources } from "$lib/rpc/cache";
@@ -51,14 +50,10 @@
 
   let gameInBeta = false;
   let gameSupportedByTooling = false;
-  let showVccWarning = false;
+  let showVccWarning = type() == "windows" && !$isMinVCCRuntime;
 
   onMount(async () => {
     loadGameInfo();
-    const osType = await type();
-    if (osType == "Windows_NT") {
-      showVccWarning = !(await isMinimumVCCRuntimeInstalled());
-    }
   });
 
   async function loadGameInfo() {

--- a/src/splash/Splash.svelte
+++ b/src/splash/Splash.svelte
@@ -4,6 +4,7 @@
   import {
     getInstallationDirectory,
     getLocale,
+    isMinimumVCCRuntimeInstalled,
     setLocale,
   } from "$lib/rpc/config";
   import { locale as svelteLocale, _ } from "svelte-i18n";
@@ -55,6 +56,10 @@
       },
       waitingForInteraction: false,
     });
+    localStorage.setItem(
+      "isMinVCCRuntime",
+      JSON.stringify(await isMinimumVCCRuntimeInstalled()),
+    );
     loaded = true;
     await proceedInSteps(false, false);
   });


### PR DESCRIPTION
These changes are directed towards reducing the number of times we check the required VCC version by shifting to only run the check to startup (on splash). This change uses a svelte writable store to contain the result of the VCC check and that store is accessed by all relevant components.

The motivation for this change is to prevent excessive logs of the VCC version. This change is part of a broader series of refactors I'm working on which will hopefully result in cleaner logs.

Additionally, there are a few misc. changes I've made along the way. In Tauri v2 `type()` and `arch()` are sync which means we can clean up the code a bit.