### PR TITLE
remove the info log when checking for active version

### DIFF
--- a/src-tauri/src/commands/versions.rs
+++ b/src-tauri/src/commands/versions.rs
@@ -265,11 +265,6 @@ pub async fn ensure_active_version_still_exists(
     Some(path) => Path::new(path),
   };
 
-  info!(
-    "Checking if active version still exists: {:?}",
-    config_lock.active_version
-  );
-
   match &config_lock.active_version {
     Some(config_version) => {
       let version_dir = install_path


### PR DESCRIPTION
This info is included in the support package so there is no need for it to be logged here.