### PR TITLE
bump tauri-plugin versions in cargo.toml

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,14 +47,14 @@ native-dialog = "0.9.0"
 tokio-util = "0.7.13"
 tauri-codegen = "2.1.0"
 tauri-plugin = "2.1.0"
-tauri-plugin-fs = "2.2.0"
-tauri-plugin-shell = "2.2.0"
-tauri-plugin-dialog = "2.2.0"
-tauri-plugin-http = "2.2.0"
-tauri-plugin-clipboard-manager = "2.2.0"
+tauri-plugin-fs = "2.3.0"
+tauri-plugin-shell = "2.2.1"
+tauri-plugin-dialog = "2.2.2"
+tauri-plugin-http = "2.4.4"
+tauri-plugin-clipboard-manager = "2.2.2"
 tauri-plugin-os = "2.2.1"
-tauri-plugin-notification = "2.2.0"
-tauri-plugin-process = "2.2.0"
+tauri-plugin-notification = "2.2.2"
+tauri-plugin-process = "2.2.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 sysctl = "0.6.0"
@@ -63,7 +63,7 @@ sysctl = "0.6.0"
 winreg = "0.55.0"
 
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
-tauri-plugin-global-shortcut = "2.2.0"
+tauri-plugin-global-shortcut = "2.2.1"
 tauri-plugin-updater = "2.7.1"
 
 [features]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -64,7 +64,7 @@ winreg = "0.55.0"
 
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
 tauri-plugin-global-shortcut = "2.2.0"
-tauri-plugin-updater = "2.2.0"
+tauri-plugin-updater = "2.7.1"
 
 [features]
 # by default Tauri runs in production mode


### PR DESCRIPTION
im hoping this fixes the updater issues we've been having, but im not confident it will.
after checking the logs of the release action it seems like the latest binaries were built using the latest versions of all these plugins so this is useless.