### PR TITLE
Restore beta warning for Jak 2. Use different text/links for Jak 3 beta warning

### DIFF
--- a/src/assets/translations/af-ZA.json
+++ b/src/assets/translations/af-ZA.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Tooling Version Does Not Support Game!",
   "gameControls_toolingTooOld_subheader": "Head over to the following settings page to download the latest release",
   "gameControls_beta_headerA": "Jak 2 is in Beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "You will encounter minor bugs and instability.",
   "gameControls_beta_issueTracker_linkPreText": "For a list of all known issues, see",
   "gameControls_beta_issueTracker_linkText": "here",

--- a/src/assets/translations/ar-SA.json
+++ b/src/assets/translations/ar-SA.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Tooling Version Does Not Support Game!",
   "gameControls_toolingTooOld_subheader": "Head over to the following settings page to download the latest release",
   "gameControls_beta_headerA": "Jak 2 is in Beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "You will encounter minor bugs and instability.",
   "gameControls_beta_issueTracker_linkPreText": "For a list of all known issues, see",
   "gameControls_beta_issueTracker_linkText": "here",

--- a/src/assets/translations/ca-ES.json
+++ b/src/assets/translations/ca-ES.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "La versió de la ferramenta no és compatible amb el joc!",
   "gameControls_toolingTooOld_subheader": "Dirigeix-te a la següent pàgina de configuració per a descarregar l'última versió",
   "gameControls_beta_headerA": "Jak II està en Beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "Pots trobar inestabilitat i petits errors.",
   "gameControls_beta_issueTracker_linkPreText": "Per a una llista amb els problemes coneguts veure",
   "gameControls_beta_issueTracker_linkText": "ací",

--- a/src/assets/translations/cs-CZ.json
+++ b/src/assets/translations/cs-CZ.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Verze nástrojů nepodporuje hru!",
   "gameControls_toolingTooOld_subheader": "Přejděte na následující stránku nastavení a stáhněte si nejnovější verzi",
   "gameControls_beta_headerA": "Jak II je v betaverzi!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "Setkáte se s drobnými chybami a nestabilitou.",
   "gameControls_beta_issueTracker_linkPreText": "Seznam všech známých problémů najdete",
   "gameControls_beta_issueTracker_linkText": "zde",

--- a/src/assets/translations/da-DK.json
+++ b/src/assets/translations/da-DK.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Tooling Version Does Not Support Game!",
   "gameControls_toolingTooOld_subheader": "Head over to the following settings page to download the latest release",
   "gameControls_beta_headerA": "Jak 2 is in Beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "You will encounter minor bugs and instability.",
   "gameControls_beta_issueTracker_linkPreText": "For a list of all known issues, see",
   "gameControls_beta_issueTracker_linkText": "here",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Diese Tooling-Version unterstützt dieses Spiel nicht!",
   "gameControls_toolingTooOld_subheader": "Gehen Sie in die Einstellungen und laden Sie die neuste Version herunter",
   "gameControls_beta_headerA": "Jak 2 ist in der Beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "Sie werden auf kleinere Fehler und Instabilität treffen.",
   "gameControls_beta_issueTracker_linkPreText": "Eine Liste aller bekannten Probleme findest du ",
   "gameControls_beta_issueTracker_linkText": "hier",

--- a/src/assets/translations/el-GR.json
+++ b/src/assets/translations/el-GR.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Η Έκδοση Εργαλείων Δεν Υποστηρίζει Το Παιχνίδι!",
   "gameControls_toolingTooOld_subheader": "Μεταβείτε στην παρακάτω σελίδα ρυθμίσεων για να κατεβάσετε την πιο πρόσφατη έκδοση",
   "gameControls_beta_headerA": "Το Jak II είναι σε beta (τεχνική προεπισκόπιση)!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "Θα αντιμετωπίσετε αστάθεια και μικρά σφάλματα.",
   "gameControls_beta_issueTracker_linkPreText": "Για κατάλογο γνωστών ζητημάτων και σφαλμάτων, βλέπετε",
   "gameControls_beta_issueTracker_linkText": "εδώ",

--- a/src/assets/translations/en-GB.json
+++ b/src/assets/translations/en-GB.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Tooling Version Does Not Support Game!",
   "gameControls_toolingTooOld_subheader": "Head over to the following settings page to download the latest release",
   "gameControls_beta_headerA": "Jak II: Renegade is in Beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "You will encounter minor bugs and instability.",
   "gameControls_beta_issueTracker_linkPreText": "For a list of all known issues, see",
   "gameControls_beta_issueTracker_linkText": "here",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Tooling Version Does Not Support Game!",
   "gameControls_toolingTooOld_subheader": "Head over to the following settings page to download the latest release",
   "gameControls_beta_headerA": "Jak 2 is in Beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "You will encounter minor bugs and instability.",
   "gameControls_beta_issueTracker_linkPreText": "For a list of all known issues, see",
   "gameControls_beta_issueTracker_linkText": "here",

--- a/src/assets/translations/es-ES.json
+++ b/src/assets/translations/es-ES.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "¡La versión de la herramienta no es compatible con el juego!",
   "gameControls_toolingTooOld_subheader": "Dirígete a la siguiente página de configuración para descargar la última versión",
   "gameControls_beta_headerA": "¡Jak 2 está en Beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "Encontrará errores menores e inestabilidades.",
   "gameControls_beta_issueTracker_linkPreText": "Para ver una lista de todos los problemas conocidos, consulte",
   "gameControls_beta_issueTracker_linkText": "aquí",

--- a/src/assets/translations/fi-FI.json
+++ b/src/assets/translations/fi-FI.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Työkalun versio ei tue peliä!",
   "gameControls_toolingTooOld_subheader": "Mene oheiselle asetussivulle ja lataa uusin versio",
   "gameControls_beta_headerA": "Jak II on beta-versiossa!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "Tulet kohtaamaan pieniä bugeja ja epävakautta.",
   "gameControls_beta_issueTracker_linkPreText": "Luettelo kaikista tunnetuista vioista löytyy",
   "gameControls_beta_issueTracker_linkText": "täältä",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "La version d'outil ne prend pas en charge le jeu !",
   "gameControls_toolingTooOld_subheader": "Accédez à la page suivante pour télécharger la dernière version",
   "gameControls_beta_headerA": "Jak 2 est en Bêta !",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "Vous rencontrerez des bugs mineurs et instabilités.",
   "gameControls_beta_issueTracker_linkPreText": "Pour une liste de tous les problèmes connus, voir",
   "gameControls_beta_issueTracker_linkText": "ici",

--- a/src/assets/translations/gl-ES.json
+++ b/src/assets/translations/gl-ES.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Tooling Version Does Not Support Game!",
   "gameControls_toolingTooOld_subheader": "Head over to the following settings page to download the latest release",
   "gameControls_beta_headerA": "Jak 2 is in Beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "You will encounter minor bugs and instability.",
   "gameControls_beta_issueTracker_linkPreText": "For a list of all known issues, see",
   "gameControls_beta_issueTracker_linkText": "here",

--- a/src/assets/translations/he-IL.json
+++ b/src/assets/translations/he-IL.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Tooling Version Does Not Support Game!",
   "gameControls_toolingTooOld_subheader": "Head over to the following settings page to download the latest release",
   "gameControls_beta_headerA": "Jak 2 is in Beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "You will encounter minor bugs and instability.",
   "gameControls_beta_issueTracker_linkPreText": "For a list of all known issues, see",
   "gameControls_beta_issueTracker_linkText": "כאן",

--- a/src/assets/translations/hr-HR.json
+++ b/src/assets/translations/hr-HR.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Tooling Version Does Not Support Game!",
   "gameControls_toolingTooOld_subheader": "Head over to the following settings page to download the latest release",
   "gameControls_beta_headerA": "Jak 2 is in Beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "You will encounter minor bugs and instability.",
   "gameControls_beta_issueTracker_linkPreText": "For a list of all known issues, see",
   "gameControls_beta_issueTracker_linkText": "here",

--- a/src/assets/translations/hu-HU.json
+++ b/src/assets/translations/hu-HU.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Az eszközkészlet verziója nem támogatja a játékot!",
   "gameControls_toolingTooOld_subheader": "Head over to the following settings page to download the latest release",
   "gameControls_beta_headerA": "Jak II jelenleg Béta fázisban van!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "Apróbb hibák és stabilitási problémák előfordulnak.",
   "gameControls_beta_issueTracker_linkPreText": "Minden ismert hibáért kattints",
   "gameControls_beta_issueTracker_linkText": "ide",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "La versione di gioco selezionata non è supportata per questo gioco!",
   "gameControls_toolingTooOld_subheader": "Clicca il pulsante qui sotto per aprire le impostazioni e scaricare l'ultima versione.",
   "gameControls_beta_headerA": "Jak II: Renegade è in beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "Riscontrerai instabilità e diversi bug.",
   "gameControls_beta_issueTracker_linkPreText": "Per la lista di tutti i problemi conosciuti, consulta",
   "gameControls_beta_issueTracker_linkText": "qui",

--- a/src/assets/translations/ja-JP.json
+++ b/src/assets/translations/ja-JP.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "現在のツールバージョンはゲームをサポートしていません！",
   "gameControls_toolingTooOld_subheader": "最新のリリースをダウンロードするには、以下のページにアクセスしてください。",
   "gameControls_beta_headerA": "ジャックｘダクスター２は現在にベータ版です！",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "プレイ中に軽いバグや欠陥、または不安定な実行など遭遇する可能性があります。",
   "gameControls_beta_issueTracker_linkPreText": "すべての既知の問題のリストについてには、",
   "gameControls_beta_issueTracker_linkText": "こちら",

--- a/src/assets/translations/ko-KR.json
+++ b/src/assets/translations/ko-KR.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Tooling Version Does Not Support Game!",
   "gameControls_toolingTooOld_subheader": "Head over to the following settings page to download the latest release",
   "gameControls_beta_headerA": "Jak 2 is in Beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "You will encounter minor bugs and instability.",
   "gameControls_beta_issueTracker_linkPreText": "For a list of all known issues, see",
   "gameControls_beta_issueTracker_linkText": "here",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Įrankių versija nepalaiko žaidimo!",
   "gameControls_toolingTooOld_subheader": "Eikite į toliau nurodytą nustatymų puslapį ir atsisiųskite naujausią versiją",
   "gameControls_beta_headerA": "Jak 2 yra beta versijoje!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "Susidursite su nedidelėmis klaidomis ir nestabilumu.",
   "gameControls_beta_issueTracker_linkPreText": "Visų žinomų problemų sąrašą rasite",
   "gameControls_beta_issueTracker_linkText": "čia",

--- a/src/assets/translations/nl-NL.json
+++ b/src/assets/translations/nl-NL.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Deze Tooling Versie Ondersteunt Dit Spel Niet!",
   "gameControls_toolingTooOld_subheader": "Ga naar de volgende instellingen-pagina om de nieuwste versie te downloaden",
   "gameControls_beta_headerA": "Jak II is in Beta-fase!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "Je zult kleine bugs en instabiliteit kunnen ervaren.",
   "gameControls_beta_issueTracker_linkPreText": "Voor een lijst van alle bekende problemen, zie",
   "gameControls_beta_issueTracker_linkText": "hier",

--- a/src/assets/translations/no-NO.json
+++ b/src/assets/translations/no-NO.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Tooling Version Does Not Support Game!",
   "gameControls_toolingTooOld_subheader": "Head over to the following settings page to download the latest release",
   "gameControls_beta_headerA": "Jak 2 is in Beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "You will encounter minor bugs and instability.",
   "gameControls_beta_issueTracker_linkPreText": "For a list of all known issues, see",
   "gameControls_beta_issueTracker_linkText": "here",

--- a/src/assets/translations/pl-PL.json
+++ b/src/assets/translations/pl-PL.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Wersja narzędzia nie obsługuje gry!",
   "gameControls_toolingTooOld_subheader": "Przejdź do następującej strony w ustawieniach, aby pobrać najnowszą wersję",
   "gameControls_beta_headerA": "Jak 2 jest w wersji Beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "Napotkasz drobne błędy i niestabilność.",
   "gameControls_beta_issueTracker_linkPreText": "Aby zobaczyć listę wszystkich znanych problemów, sprawdź",
   "gameControls_beta_issueTracker_linkText": "tutaj",

--- a/src/assets/translations/pt-BR.json
+++ b/src/assets/translations/pt-BR.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Tooling Version Does Not Support Game!",
   "gameControls_toolingTooOld_subheader": "Head over to the following settings page to download the latest release",
   "gameControls_beta_headerA": "Jak 2 está em Beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "You will encounter minor bugs and instability.",
   "gameControls_beta_issueTracker_linkPreText": "Para uma lista de todos os problemas conhecidos, veja",
   "gameControls_beta_issueTracker_linkText": "aqui",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "A versão das ferramentas não é compatível com o jogo!",
   "gameControls_toolingTooOld_subheader": "Vá para a seguinte página de configurações para descarregar a última versão",
   "gameControls_beta_headerA": "O Jak 2 está em versão beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "Encontrará pequenos erros e instabilidade.",
   "gameControls_beta_issueTracker_linkPreText": "Para uma lista de todos os problemas conhecidos, veja",
   "gameControls_beta_issueTracker_linkText": "aqui",

--- a/src/assets/translations/ro-RO.json
+++ b/src/assets/translations/ro-RO.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Tooling Version Does Not Support Game!",
   "gameControls_toolingTooOld_subheader": "Head over to the following settings page to download the latest release",
   "gameControls_beta_headerA": "Jak 2 is in Beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "You will encounter minor bugs and instability.",
   "gameControls_beta_issueTracker_linkPreText": "For a list of all known issues, see",
   "gameControls_beta_issueTracker_linkText": "here",

--- a/src/assets/translations/ru-RU.json
+++ b/src/assets/translations/ru-RU.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Пакет инструментария не поддерживает данную игру!",
   "gameControls_toolingTooOld_subheader": "Перейдите на следующую страницу настроек, чтобы скачать последнюю версию",
   "gameControls_beta_headerA": "Jak 2 в бета-версии!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "Вы столкнетесь с мелкими ошибками и нестабильностью.",
   "gameControls_beta_issueTracker_linkPreText": "Список всех известных проблем см.",
   "gameControls_beta_issueTracker_linkText": "здесь",

--- a/src/assets/translations/sr-SP.json
+++ b/src/assets/translations/sr-SP.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Tooling Version Does Not Support Game!",
   "gameControls_toolingTooOld_subheader": "Head over to the following settings page to download the latest release",
   "gameControls_beta_headerA": "Jak 2 is in Beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "You will encounter minor bugs and instability.",
   "gameControls_beta_issueTracker_linkPreText": "For a list of all known issues, see",
   "gameControls_beta_issueTracker_linkText": "here",

--- a/src/assets/translations/sv-SE.json
+++ b/src/assets/translations/sv-SE.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Verktygsversionen stödjer inte spelet!",
   "gameControls_toolingTooOld_subheader": "Gå till följande inställningssida för att ladda ner den senaste versionen",
   "gameControls_beta_headerA": "Jak 2 är i beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "Du kommer att stöta på mindre buggar och instabilitet.",
   "gameControls_beta_issueTracker_linkPreText": "För en lista över alla kända problem, se",
   "gameControls_beta_issueTracker_linkText": "här",

--- a/src/assets/translations/tr-TR.json
+++ b/src/assets/translations/tr-TR.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Bu Tooling Versiyonu Oyunu Desteklemiyor!",
   "gameControls_toolingTooOld_subheader": "Son sürümü indirmek için ayarlar sayfasına gidin",
   "gameControls_beta_headerA": "Jak 2, Beta sürümüne girdi!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "Bazı küçük hatalar ve dengesizliklerle karşılabilirsiniz.",
   "gameControls_beta_issueTracker_linkPreText": "Bilinen tüm sıkıntıları görmek istiyorsanız,",
   "gameControls_beta_issueTracker_linkText": "buraya tıklayın",

--- a/src/assets/translations/uk-UA.json
+++ b/src/assets/translations/uk-UA.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Версія інструментарію не підтримує гру!",
   "gameControls_toolingTooOld_subheader": "Перейдіть на наступну сторінку налаштувань, щоб завантажити останню версію",
   "gameControls_beta_headerA": "Jak 2 в бета-версії!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "Ви можете зіткнутися з незначними помилками та нестабільністю.",
   "gameControls_beta_issueTracker_linkPreText": "Список усіх відомих проблем перейдіть",
   "gameControls_beta_issueTracker_linkText": "сюди",

--- a/src/assets/translations/vi-VN.json
+++ b/src/assets/translations/vi-VN.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Tooling Version Does Not Support Game!",
   "gameControls_toolingTooOld_subheader": "Head over to the following settings page to download the latest release",
   "gameControls_beta_headerA": "Jak 2 is in Beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "You will encounter minor bugs and instability.",
   "gameControls_beta_issueTracker_linkPreText": "For a list of all known issues, see",
   "gameControls_beta_issueTracker_linkText": "here",

--- a/src/assets/translations/zh-CN.json
+++ b/src/assets/translations/zh-CN.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "工具版本不支持游戏！",
   "gameControls_toolingTooOld_subheader": "前往以下设置页面下载最新发行版",
   "gameControls_beta_headerA": "Jak 2 处于测试版！",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "你会遇到小错误与不稳定。",
   "gameControls_beta_issueTracker_linkPreText": "有关所有已知问题的列表，请参阅",
   "gameControls_beta_issueTracker_linkText": "此处",

--- a/src/assets/translations/zh-TW.json
+++ b/src/assets/translations/zh-TW.json
@@ -191,6 +191,7 @@
   "gameControls_toolingTooOld_header": "Tooling Version Does Not Support Game!",
   "gameControls_toolingTooOld_subheader": "Head over to the following settings page to download the latest release",
   "gameControls_beta_headerA": "Jak 2 is in Beta!",
+  "gameControls_beta_headerA_jak3": "Jak 3 is in Beta!",
   "gameControls_beta_headerB": "You will encounter minor bugs and instability.",
   "gameControls_beta_issueTracker_linkPreText": "For a list of all known issues, see",
   "gameControls_beta_issueTracker_linkText": "這裡",

--- a/src/routes/Game.svelte
+++ b/src/routes/Game.svelte
@@ -159,7 +159,7 @@
         </ul>
       </Alert>
     {/if}
-    
+
     <!-- Jak 2 BETA warning -->
     {#if $activeGame === SupportedGame.Jak2}
       <Alert rounded={false} class="border-t-4 text-red-400">

--- a/src/routes/Game.svelte
+++ b/src/routes/Game.svelte
@@ -48,7 +48,6 @@
   export let game_name;
   $: activeGame.set(game_name);
 
-  $: gameInBeta = $activeGame === SupportedGame.Jak3;
   let gameSupportedByTooling = false;
   let showVccWarning;
   $: showVccWarning = type() == "windows" && !$isMinVCCRuntime;
@@ -160,9 +159,42 @@
         </ul>
       </Alert>
     {/if}
-    {#if gameInBeta}
+    
+    <!-- Jak 2 BETA warning -->
+    {#if $activeGame === SupportedGame.Jak2}
       <Alert rounded={false} class="border-t-4 text-red-400">
         <span class="font-bold">{$_("gameControls_beta_headerA")}</span>
+        <em>{$_("gameControls_beta_headerB")}</em>
+        <br />
+        <ul>
+          <li>
+            {$_("gameControls_beta_issueTracker_linkPreText")}
+            <a
+              class="text-blue-400"
+              href="https://github.com/open-goal/jak-project/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Ajak2"
+              target="_blank"
+              rel="noopener noreferrer"
+              >{$_("gameControls_beta_issueTracker_linkText")}</a
+            >
+          </li>
+          <li>
+            {$_("gameControls_beta_bugReport_linkPreText")}
+            <a
+              class="text-blue-400"
+              href="https://github.com/open-goal/jak-project/issues/new?template=jak2-bug-report.yml"
+              target="_blank"
+              rel="noopener noreferrer"
+              >{$_("gameControls_beta_bugReport_linkText")}</a
+            >
+          </li>
+        </ul>
+      </Alert>
+    {/if}
+
+    <!-- Jak 3 BETA warning -->
+    {#if $activeGame === SupportedGame.Jak3}
+      <Alert rounded={false} class="border-t-4 text-red-400">
+        <span class="font-bold">{$_("gameControls_beta_headerA_jak3")}</span>
         <em>{$_("gameControls_beta_headerB")}</em>
         <br />
         <ul>


### PR DESCRIPTION
Think there are still some remaining items for Jak 2 before we want to consider it out of beta (see discord discussion)