### PR TITLE
Disable elements selection on dblclck

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -55,6 +55,8 @@
         event.preventDefault();
       }
     });
+    // Disable selecting elements
+    document.onselectstart = new Function ("return false");
     // Disable Refreshing (F5 / Ctrl+R)
     document.addEventListener("keydown", (e) => {
       if (e.code == "F5") {


### PR DESCRIPTION
Disables selection of HTML elements in app (by double clicking for example). Possible fix for issue #822
Selection was not happening only on sidebar but also on main window, as visible from attached image.

<img width="796" height="591" alt="image" src="https://github.com/user-attachments/assets/35b85f3f-3869-4b02-b779-e8f27c11a405" />