### PR TITLE
ci: remove the `macos-13` runner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-22.04, windows-latest, macos-13, macos-15]
+        platform: [ubuntu-22.04, windows-latest, macos-15]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-22.04, windows-latest, macos-15]
+        platform: [ubuntu-22.04, windows-latest, macos-15-intel, macos-15]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-22.04, windows-latest, macos-15]
+        platform: [ubuntu-22.04, windows-latest, macos-15-intel, macos-15]
     runs-on: ${{ matrix.platform }}
     steps:
       # NOTE - there is technically a race condition here if multiple releases go out

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-22.04, windows-latest, macos-13, macos-15]
+        platform: [ubuntu-22.04, windows-latest, macos-15]
     runs-on: ${{ matrix.platform }}
     steps:
       # NOTE - there is technically a race condition here if multiple releases go out


### PR DESCRIPTION
MacOS 13 has been end of life for a month, and the image is being removed from github by the beginning of december, get rid of it before CI starts failing.