### PR TITLE
Allow the main window to be resized and allow linux users to change their installation dir again

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: yarn
 
       - name: Install Rust Stable

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: yarn
 
       - name: Install Dependencies and Check Formatting
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: yarn
 
       - name: Install Linux Dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: yarn
 
       - name: Install Rust Stable
@@ -90,7 +90,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: yarn
 
       - name: Install NPM Dependencies
@@ -127,7 +127,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: yarn
 
       - name: Install Rust Stable
@@ -178,7 +178,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: yarn
 
       - name: update release metadata and publish the release

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: yarn
 
       - name: Install NPM Dependencies

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -12,19 +12,10 @@ pub async fn open_main_window(handle: tauri::AppHandle) -> Result<(), CommandErr
   // and when a panic hook was added that exited the process, the app would crash.
   //
   // So instead we make the main window at runtime, and close the splashscreen
-
-  // Create main window
-  // {
-  //   "title": "OpenGOAL Launcher",
-  //   "label": "main",
-  //   "width": 800,
-  //   "height": 600,
-  //   "resizable": false,
-  //   "fullscreen": false,
-  //   "visible": false,
-  //   "center": true,
-  //   "decorations": false
-  // },
+  //
+  // TODO LATER - consider removing the multi-window setup and just integrate the splash
+  // into the main app.  This would probably make for a better experience on things like
+  // the steamdeck
   log::info!("Creating main window");
   tauri::WebviewWindowBuilder::new(
     &handle,
@@ -32,7 +23,7 @@ pub async fn open_main_window(handle: tauri::AppHandle) -> Result<(), CommandErr
     tauri::WebviewUrl::App("index.html".parse().unwrap()),
   )
   .title("OpenGOAL Launcher")
-  .resizable(false)
+  .resizable(true)
   .fullscreen(false)
   .visible(true)
   .center()

--- a/src/components/games/setup/Progress.svelte
+++ b/src/components/games/setup/Progress.svelte
@@ -20,7 +20,7 @@
   }
 </script>
 
-<div class="w-full pt-2 pb-6 flex justify-evenly">
+<div class="w-full pt-2 pb-6 flex justify-evenly gap-2">
   {#each $progressTracker.steps as step, i}
     <!-- NOTE - this will break if you add too many steps! -->
     {#if i > 0}

--- a/src/routes/Game.svelte
+++ b/src/routes/Game.svelte
@@ -116,9 +116,8 @@
 <div class="flex flex-col h-full p-5">
   {#if $VersionStore.activeVersionName === null}
     <GameToolsNotSet />
-  {:else if $activeGame == "jak3"}
+  {:else if $activeGame == "jak3" || $activeGame == "jakx"}
     <!-- TODO: remove this else if arm for jak3 support -->
-    <!-- Delete GameInProgress.svelte component -->
     <GameInProgress />
   {:else if !gameSupportedByTooling}
     <GameNotSupportedByTooling />

--- a/src/routes/settings/General.svelte
+++ b/src/routes/settings/General.svelte
@@ -42,7 +42,6 @@
   let uninstallOldVersions = writable(false);
   let localeFontForDownload: Locale | undefined = undefined;
   let localeFontDownloading = false;
-  let isLinux = platform() === "linux";
   let initialized = false;
 
   onMount(async () => {
@@ -84,7 +83,7 @@
         class="mt-2"
         items={availableLocales}
         bind:value={$currentLocale}
-        onchange={async () => {
+        on:change={async () => {
           await setLocale($currentLocale);
           localeFontForDownload =
             await localeSpecificFontAvailableForDownload($currentLocale);
@@ -105,7 +104,7 @@
       <Button
         class="flex-shrink border-solid rounded bg-white hover:bg-orange-400 text-sm text-slate-900 font-semibold px-5 py-2 mt-2"
         disabled={localeFontDownloading}
-        onclick={async () => {
+        on:click={async () => {
           if (
             localeFontForDownload !== undefined &&
             localeFontForDownload.fontDownloadUrl !== undefined &&
@@ -132,43 +131,41 @@
       </Button>
     {/if}
   </div>
-  {#if !isLinux}
-    <div>
-      <Label for="default-input" class="block mb-2 text-gray-200"
-        >{$_("settings_folders_installationDir")}</Label
-      >
-      <Input
-        id="default-input"
-        placeholder={currentInstallationDirectory}
-        onclick={async () => {
-          const newInstallDir = await folderPrompt(
-            $_("settings_folders_installationDir_prompt"),
-          );
-          if (
-            newInstallDir !== undefined &&
-            newInstallDir !== currentInstallationDirectory
-          ) {
-            const errMsg = await setInstallationDirectory(newInstallDir);
-            if (errMsg === null) {
-              if (currentInstallationDirectory !== newInstallDir) {
-                $VersionStore.activeVersionType = null;
-                $VersionStore.activeVersionName = null;
-              }
-              currentInstallationDirectory = newInstallDir;
+  <div>
+    <Label for="default-input" class="block mb-2 text-gray-200"
+      >{$_("settings_folders_installationDir")}</Label
+    >
+    <Input
+      id="default-input"
+      placeholder={currentInstallationDirectory}
+      on:click={async () => {
+        const newInstallDir = await folderPrompt(
+          $_("settings_folders_installationDir_prompt"),
+        );
+        if (
+          newInstallDir !== undefined &&
+          newInstallDir !== currentInstallationDirectory
+        ) {
+          const errMsg = await setInstallationDirectory(newInstallDir);
+          if (errMsg === null) {
+            if (currentInstallationDirectory !== newInstallDir) {
+              $VersionStore.activeVersionType = null;
+              $VersionStore.activeVersionName = null;
             }
+            currentInstallationDirectory = newInstallDir;
           }
-        }}
-      />
-      <Helper class="text-xs mt-2 italic"
-        >{$_("settings_general_installationDir_helper")}</Helper
-      >
-    </div>
-  {/if}
+        }
+      }}
+    />
+    <Helper class="text-xs mt-2 italic"
+      >{$_("settings_general_installationDir_helper")}</Helper
+    >
+  </div>
   <div class="*:text-gray-200">
     <Toggle
       color="orange"
       bind:checked={$keepGamesUpdated}
-      onchange={async () => {
+      on:change={async () => {
         $uninstallOldVersions = false;
       }}
       class="mb-2">{$_("settings_general_keep_updated")}</Toggle
@@ -183,7 +180,7 @@
     <Toggle
       checked={currentBypassRequirementsVal}
       color="orange"
-      onchange={async (evt) => {
+      on:change={async (evt) => {
         if (evt.target.checked) {
           const confirmed = await confirm(
             `${$_("requirements_button_bypass_warning_1")}\n\n${$_(
@@ -207,7 +204,7 @@
   <div>
     <Button
       class="flex-shrink border-solid rounded bg-white hover:bg-orange-400 text-sm text-slate-900 font-semibold px-5 py-2"
-      onclick={async () => {
+      on:click={async () => {
         const confirmed = await confirm(
           $_("settings_general_button_resetSettings_confirmation"),
         );

--- a/src/routes/settings/General.svelte
+++ b/src/routes/settings/General.svelte
@@ -28,7 +28,6 @@
   import { onMount } from "svelte";
   import { _ } from "svelte-i18n";
   import { confirm } from "@tauri-apps/plugin-dialog";
-  import { platform } from "@tauri-apps/plugin-os";
   import { downloadFile } from "$lib/rpc/download";
   import { appDataDir, join } from "@tauri-apps/api/path";
   import { folderPrompt } from "$lib/utils/file-dialogs";
@@ -83,7 +82,7 @@
         class="mt-2"
         items={availableLocales}
         bind:value={$currentLocale}
-        on:change={async () => {
+        onchange={async () => {
           await setLocale($currentLocale);
           localeFontForDownload =
             await localeSpecificFontAvailableForDownload($currentLocale);
@@ -104,7 +103,7 @@
       <Button
         class="flex-shrink border-solid rounded bg-white hover:bg-orange-400 text-sm text-slate-900 font-semibold px-5 py-2 mt-2"
         disabled={localeFontDownloading}
-        on:click={async () => {
+        onclick={async () => {
           if (
             localeFontForDownload !== undefined &&
             localeFontForDownload.fontDownloadUrl !== undefined &&
@@ -138,7 +137,7 @@
     <Input
       id="default-input"
       placeholder={currentInstallationDirectory}
-      on:click={async () => {
+      onclick={async () => {
         const newInstallDir = await folderPrompt(
           $_("settings_folders_installationDir_prompt"),
         );
@@ -165,7 +164,7 @@
     <Toggle
       color="orange"
       bind:checked={$keepGamesUpdated}
-      on:change={async () => {
+      onchange={async () => {
         $uninstallOldVersions = false;
       }}
       class="mb-2">{$_("settings_general_keep_updated")}</Toggle
@@ -180,7 +179,7 @@
     <Toggle
       checked={currentBypassRequirementsVal}
       color="orange"
-      on:change={async (evt) => {
+      onchange={async (evt) => {
         if (evt.target.checked) {
           const confirmed = await confirm(
             `${$_("requirements_button_bypass_warning_1")}\n\n${$_(
@@ -204,7 +203,7 @@
   <div>
     <Button
       class="flex-shrink border-solid rounded bg-white hover:bg-orange-400 text-sm text-slate-900 font-semibold px-5 py-2"
-      on:click={async () => {
+      onclick={async () => {
         const confirmed = await confirm(
           $_("settings_general_button_resetSettings_confirmation"),
         );


### PR DESCRIPTION
The CSS on the app is properly responsive, the window no longer has to be a fixed size.  This should allow it to nicely expand to screens like the steamdeck where the application takes up the entire screen (in game mode) instead of having scaling compromises.

Also fixes the CSS around the last progress bar/icon where there would be no gap between the bar and the icon.