### PR TITLE
support: make the integrity check output less ambiguous

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -79,3 +79,6 @@ custom-protocol = ["tauri/custom-protocol"]
 
 [profile.release]
 strip = true  # Automatically strip symbols from the binary.
+
+[profile.dev.package.zip] # build zip as release, else its slow when making a support package when dev'ing
+opt-level = 3

--- a/src-tauri/src/commands/support.rs
+++ b/src-tauri/src/commands/support.rs
@@ -80,6 +80,7 @@ pub struct SupportPackage {
   pub install_dir: String,
   pub game_info: PerGameInfo,
   pub launcher_version: String,
+  pub active_tooling_version: String,
   pub extractor_binary_exists: bool,
   pub game_binary_exists: bool,
 }
@@ -316,6 +317,10 @@ pub async fn generate_support_package(
   package.os_name_long = System::long_os_version().unwrap_or("unknown".to_string());
   package.os_kernel_ver = System::kernel_version().unwrap_or("unknown".to_string());
   package.launcher_version = app_handle.package_info().version.to_string();
+  package.active_tooling_version = config_lock
+    .active_version
+    .clone()
+    .unwrap_or("unset".to_string());
   if config_lock.installation_dir.is_none() {
     package.install_dir = "Not Set".to_string();
   } else {


### PR DESCRIPTION
a true or false was not sufficient, it should be better now:

<img width="368" height="350" alt="image" src="https://github.com/user-attachments/assets/888f743f-1b1b-4913-9369-3eecdbb4b38e" />

before

<img width="431" height="467" alt="image" src="https://github.com/user-attachments/assets/6ad46339-6df8-4f88-8975-63e5a0c354ff" />

after

I also put the installation dir in the top level json file as well since it's something you often want to cross reference (see if they are installing into an empty drive)