### PR TITLE
ui: avoid brief rendering flashes when switching between persisted components (like `Game`)

### DIFF
--- a/src/components/games/GameBetaAlert.svelte
+++ b/src/components/games/GameBetaAlert.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { Alert } from "flowbite-svelte";
+  import { _ } from "svelte-i18n";
+</script>
+
+<Alert rounded={false} class="border-t-4 text-red-400">
+  <span class="font-bold">{$_("gameControls_beta_headerA")}</span>
+  <em>{$_("gameControls_beta_headerB")}</em>
+  <br />
+  <ul>
+    <li>
+      {$_("gameControls_beta_issueTracker_linkPreText")}
+      <a
+        class="text-blue-400"
+        href="https://github.com/open-goal/jak-project/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Ajak2"
+        target="_blank"
+        rel="noopener noreferrer"
+        >{$_("gameControls_beta_issueTracker_linkText")}</a
+      >
+    </li>
+    <li>
+      {$_("gameControls_beta_bugReport_linkPreText")}
+      <a
+        class="text-blue-400"
+        href="https://github.com/open-goal/jak-project/issues/new?template=jak2-bug-report.yml"
+        target="_blank"
+        rel="noopener noreferrer"
+        >{$_("gameControls_beta_bugReport_linkText")}</a
+      >
+    </li>
+  </ul>
+</Alert>

--- a/src/components/games/VCCWarning.svelte
+++ b/src/components/games/VCCWarning.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { Alert } from "flowbite-svelte";
+  import { _ } from "svelte-i18n";
+</script>
+
+<Alert rounded={false} class="border-t-4 text-red-400">
+  <span class="font-bold">{$_("gameControls_warning_vccVersion_headerA")}</span>
+  <em>{$_("gameControls_warning_vccVersion_headerB")}</em>
+  <br />
+  <ul>
+    <li>
+      <a
+        class="font-bold text-blue-500"
+        target="_blank"
+        rel="noreferrer"
+        href="https://aka.ms/vs/17/release/vc_redist.x64.exe"
+        >{$_("requirements_windows_vccRuntimeExplanation_downloadLink")}</a
+      >
+    </li>
+  </ul>
+</Alert>

--- a/src/routes/Job.svelte
+++ b/src/routes/Job.svelte
@@ -27,7 +27,6 @@
   import { infoLog } from "$lib/rpc/logging";
 
   let proceedAfterSuccessfulOperation = $state(true);
-  // TODO NOW - wire this up
   let invalidJobDefinition = $state(false);
 
   onMount(async () => {
@@ -186,7 +185,7 @@
 
 <div class="flex flex-col h-full p-5">
   {#if invalidJobDefinition}
-    Bad
+    App got into a bad state, report this to the devs!
   {:else}
     <div class="flex flex-col justify-content">
       <Progress />

--- a/src/routes/layouts/Layout.svelte
+++ b/src/routes/layouts/Layout.svelte
@@ -5,6 +5,7 @@
   import Header from "../../components/header/Header.svelte";
   import Sidebar from "../../components/sidebar/Sidebar.svelte";
   import Toast from "../../components/toast/Toast.svelte";
+  import { route } from "/src/router";
 
   let { children }: { children: Snippet } = $props();
 </script>
@@ -15,9 +16,11 @@
     <Header />
     <div class="flex flex-row grow shrink h-[90%] z-10">
       <Sidebar />
-      <main id="content" class="overflow-y-auto grow shrink">
-        {@render children()}
-      </main>
+      {#key route.params.game_name}
+        <main id="content" class="overflow-y-auto grow shrink">
+          {@render children()}
+        </main>
+      {/key}
     </div>
     <Toast />
   {/if}


### PR DESCRIPTION
When components are persisted across layout changes, they are not remounted, which means their state is persisted, which means you briefly see the impact of that old state.

When we switch between games, force a re-render so that the state can be properly initialized before the initial paint.