### PR TITLE
Persist mod info metadata to disk to create a better fallback path

### DIFF
--- a/src-tauri/src/cache.rs
+++ b/src-tauri/src/cache.rs
@@ -34,8 +34,7 @@ pub struct ModPerGameConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export)]
-pub struct ModInfo {
+pub struct ModInfoSchema {
   pub display_name: String,
   pub description: String,
   pub authors: Vec<String>,
@@ -47,6 +46,66 @@ pub struct ModInfo {
   pub cover_art_url: Option<String>,
   pub thumbnail_art_url: Option<String>,
   pub external_link: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct ModSourceDataSchema {
+  pub schema_version: String,
+  pub source_name: String,
+  pub last_updated: String,
+  pub mods: HashMap<String, ModInfoSchema>,
+  pub texture_packs: HashMap<String, ModInfoSchema>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export)]
+pub struct ModInfo {
+  pub name: String,
+  pub source: String,
+  pub display_name: String,
+  pub description: String,
+  pub authors: Vec<String>,
+  pub tags: Vec<String>,
+  pub supported_games: Vec<SupportedGame>,
+  pub website_url: Option<String>,
+  pub versions: Vec<ModVersion>,
+  pub per_game_config: Option<HashMap<String, ModPerGameConfig>>,
+  pub cover_art_url: Option<String>,
+  pub thumbnail_art_url: Option<String>,
+  pub external_link: Option<String>,
+}
+
+impl From<ModInfoSchema> for ModInfo {
+  fn from(schema: ModInfoSchema) -> Self {
+    Self {
+      display_name: schema.display_name,
+      description: schema.description,
+      authors: schema.authors,
+      tags: schema.tags,
+      supported_games: schema.supported_games,
+      website_url: schema.website_url,
+      versions: schema.versions,
+      per_game_config: schema.per_game_config,
+      cover_art_url: schema.cover_art_url,
+      thumbnail_art_url: schema.thumbnail_art_url,
+      external_link: schema.external_link,
+      // name + source filled later
+      name: String::new(),
+      source: String::new(),
+    }
+  }
+}
+
+impl From<(String, ModInfoSchema, String)> for ModInfo {
+  fn from((name, schema, source): (String, ModInfoSchema, String)) -> Self {
+    Self {
+      name,
+      source,
+      ..schema.into()
+    }
+  }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, TS)]
@@ -78,7 +137,35 @@ impl LauncherCache {
       match source_json {
         Ok(json) => match serde_json::from_str(&json) {
           Ok(json_value) => {
-            let source_data: ModSourceData = json_value;
+            let source_schema_data: ModSourceDataSchema = json_value;
+            let source_name = source_schema_data.source_name.clone();
+            let source_mods_data = source_schema_data
+              .mods
+              .into_iter()
+              .map(|(mod_name, mod_info)| {
+                let mut info: ModInfo = mod_info.into();
+                info.name = mod_name;
+                info.source = source_name.clone();
+                (info.name.clone(), info)
+              })
+              .collect();
+            let source_textures_data = source_schema_data
+              .texture_packs
+              .into_iter()
+              .map(|(mod_name, mod_info)| {
+                let mut info: ModInfo = mod_info.into();
+                info.name = mod_name;
+                info.source = source_name.clone();
+                (info.name.clone(), info)
+              })
+              .collect();
+            let source_data = ModSourceData {
+              schema_version: source_schema_data.schema_version,
+              source_name: source_schema_data.source_name,
+              last_updated: source_schema_data.last_updated,
+              mods: source_mods_data,
+              texture_packs: source_textures_data,
+            };
             self.mod_sources.insert(source, source_data);
           }
           Err(err) => error!("Unable to convert {json} to typed value: {err:?}"),

--- a/src-tauri/src/commands/util.rs
+++ b/src-tauri/src/commands/util.rs
@@ -120,10 +120,3 @@ pub async fn is_macos_version_15_or_above() -> bool {
     .map(|major| major >= 15)
     .unwrap_or(false)
 }
-
-// TODO - macOS check if rosetta 2 is installed
-// #[cfg(target_os = "macos")]
-// #[tauri::command]
-// pub async fn is_rosetta2_installed() -> bool {
-//   todo!()
-// }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -193,6 +193,7 @@ fn main() {
       commands::features::mods::compile_for_mod_install,
       commands::features::mods::decompile_for_mod_install,
       commands::features::mods::download_and_extract_new_mod,
+      commands::features::mods::get_locally_persisted_mod_info,
       commands::features::mods::extract_iso_for_mod_install,
       commands::features::mods::extract_new_mod,
       commands::features::mods::get_launch_mod_string,

--- a/src/components/background/Background.svelte
+++ b/src/components/background/Background.svelte
@@ -67,15 +67,17 @@
     if (activeGameFromRoute) {
       activeGame = activeGameFromRoute;
       if (route.params.mod_name && route.params.source_name) {
-        getModInfo(route.params.mod_name, route.params.source_name).then(
-          (modInfo) => {
-            if (activeGame) {
-              updateModBackground(activeGame, modInfo).then(() => {
-                loading = false;
-              });
-            }
-          },
-        );
+        getModInfo(
+          activeGame,
+          route.params.mod_name,
+          route.params.source_name,
+        ).then((modInfo) => {
+          if (activeGame) {
+            updateModBackground(activeGame, modInfo).then(() => {
+              loading = false;
+            });
+          }
+        });
       } else {
         updateBackground(activeGame).then(() => {
           loading = false;
@@ -112,7 +114,7 @@
     if (modInfo.source === "_local") {
       const coverResult = await getLocalModThumbnailBase64(
         activeGame,
-        modInfo.name ?? "",
+        modInfo.name,
       );
       modBackground = coverResult || coverArtPlaceholder;
       return;

--- a/src/components/games/GameControlsMod.svelte
+++ b/src/components/games/GameControlsMod.svelte
@@ -81,7 +81,7 @@
 
   onMount(async () => {
     checkForLatestModVersionChecked = await getCheckForLatestModVersion();
-    modInfo = await getModInfo(modName, modSource);
+    modInfo = await getModInfo(activeGame, modName, modSource);
     await initDirectories(modInfo);
     await sortModVersions(modInfo);
   });
@@ -93,8 +93,6 @@
   });
 
   async function initDirectories(modInfo: ModInfo) {
-    // TODO - why are name/source Options from rust, makes this code very cumbersome
-    // these two values should be the bare minimum that can be guaranteed about the mod
     let installationDir = await getInstallationDirectory();
     if (installationDir !== null) {
       gameDataDir = await join(
@@ -102,8 +100,8 @@
         "features",
         activeGame,
         "mods",
-        modInfo.source ?? "",
-        modInfo.name ?? "",
+        modInfo.source,
+        modInfo.name,
         "data",
       );
       extractedAssetsDir = await join(
@@ -116,9 +114,9 @@
         "features",
         activeGame,
         "mods",
-        modInfo.source ?? "",
+        modInfo.source,
         "_settings",
-        modInfo.name ?? "",
+        modInfo.name,
         "OpenGOAL",
         activeGame,
         "settings",
@@ -131,9 +129,9 @@
         "features",
         activeGame,
         "mods",
-        modInfo.source ?? "",
+        modInfo.source,
         "_settings",
-        modInfo.name ?? "",
+        modInfo.name,
         "OpenGOAL",
         activeGame,
         "saves",
@@ -159,9 +157,9 @@
 
     if (
       relevantSourceData !== undefined &&
-      Object.keys(relevantSourceData.mods).includes(modInfo.name ?? "")
+      Object.keys(relevantSourceData.mods).includes(modInfo.name)
     ) {
-      const mod = relevantSourceData.mods[modInfo.name ?? ""];
+      const mod = relevantSourceData.mods[modInfo.name];
       if (mod !== undefined) {
         // ensure versions are sorted by date desc (newest first)
         let versions = mod.versions;
@@ -187,13 +185,10 @@
     // get current installed version
     let installedMods = await getInstalledMods(activeGame);
     if (
-      Object.keys(installedMods).includes(modInfo.source ?? "") &&
-      Object.keys(installedMods[modInfo.source ?? ""]).includes(
-        modInfo.name ?? "",
-      )
+      Object.keys(installedMods).includes(modInfo.source) &&
+      Object.keys(installedMods[modInfo.source]).includes(modInfo.name)
     ) {
-      currentlyInstalledVersion =
-        installedMods[modInfo.source ?? ""][modInfo.name ?? ""];
+      currentlyInstalledVersion = installedMods[modInfo.source][modInfo.name];
       versionState.displayModVersion = true;
       versionState.activeModVersionInfo.installedVersion =
         currentlyInstalledVersion;

--- a/src/lib/rpc/bindings/ModInfo.ts
+++ b/src/lib/rpc/bindings/ModInfo.ts
@@ -4,6 +4,8 @@ import type { ModVersion } from "./ModVersion";
 import type { SupportedGame } from "./SupportedGame";
 
 export type ModInfo = {
+  name: string;
+  source: string;
   displayName: string;
   description: string;
   authors: Array<string>;
@@ -15,6 +17,5 @@ export type ModInfo = {
   coverArtUrl: string | null;
   thumbnailArtUrl: string | null;
   externalLink: string | null;
-  name?: string;
-  source?: string;
+  metadataOffline?: boolean;
 };

--- a/src/lib/rpc/bindings/utils/ModInfo.ts
+++ b/src/lib/rpc/bindings/utils/ModInfo.ts
@@ -1,7 +1,10 @@
 import { getModSourcesData } from "$lib/rpc/cache";
+import { getLocallyPersistedModInfo } from "$lib/rpc/features";
 import type { ModInfo } from "../ModInfo";
+import type { SupportedGame } from "../SupportedGame";
 
 export async function getModInfo(
+  activeGame: SupportedGame,
   modName: string,
   modSource: string,
 ): Promise<ModInfo> {
@@ -15,9 +18,18 @@ export async function getModInfo(
   if (foundMod) {
     return { ...foundMod, name: modName, source: modSource };
   } else {
-    // TODO: this should be a temporary fix until we land on a permanent solution (e.g. caching mod metadata)
-    // couldn't find mod in modlists (user might be offline, or mod/list abandoned)
-    // just create a dummy entry so they can at least launch game
+    // If we could not get the information from the live mod source, then we have two fallbacks paths
+    // - grab the local metadata file that is colocated along with the mod
+    //   - this is also nice because it allows locally installed mods to test the same metadata as well
+    const persistedMetadata = await getLocallyPersistedModInfo(
+      activeGame,
+      modName,
+      modSource,
+    );
+    if (persistedMetadata) {
+      return { ...persistedMetadata, metadataOffline: true };
+    }
+    // - if not, return sensible defaults
     return {
       name: modName,
       source: modSource,
@@ -32,6 +44,7 @@ export async function getModInfo(
       coverArtUrl: null,
       thumbnailArtUrl: null,
       externalLink: null,
+      metadataOffline: true,
     };
   }
 }

--- a/src/lib/rpc/features.ts
+++ b/src/lib/rpc/features.ts
@@ -1,4 +1,5 @@
 import { toastStore } from "$lib/stores/ToastStore";
+import type { ModInfo } from "./bindings/ModInfo";
 import type { ModSourceData } from "./bindings/ModSourceData";
 import { errorLog } from "./logging";
 import { invoke_rpc } from "./rpc";
@@ -170,6 +171,18 @@ export async function downloadAndExtractNewMod(
     "download_and_extract_new_mod",
     { gameName, downloadUrl, modName, sourceName },
     () => failed("Failed to download and extract mod"),
+  );
+}
+
+export async function getLocallyPersistedModInfo(
+  gameName: string,
+  modName: string,
+  sourceName: string,
+): Promise<ModInfo | undefined> {
+  return await invoke_rpc(
+    "get_locally_persisted_mod_info",
+    { gameName, modName, sourceName },
+    () => undefined,
   );
 }
 


### PR DESCRIPTION
If the mod source is unavailable, it would be nice to persist the information as a fallback before resorting to very basic / stripped down info (which is also a very suitable last resort fallback).

This does that, it also adds a new `metadataOffline` boolean to the mod info incase someone wants to use that to cleanup the mod controls component (ie. inform the user that info like the version list may be out of date).  Another benefit of this is it should allow mods to be tested locally with the full final intended metadata (just include a `_metadata.json` file in your zip)

Fixes #847 

<img width="782" height="596" alt="Screenshot 2025-12-20 at 3 56 54 PM" src="https://github.com/user-attachments/assets/04a0de5c-3c7a-4c52-8689-80486c240868" />

- persisted metadata, page basically works as expected

<img width="767" height="582" alt="Screenshot 2025-12-20 at 3 56 59 PM" src="https://github.com/user-attachments/assets/1b1bc43a-1209-4f77-a5c0-3c3acee0aa03" />

- no locally persisted metadata, fallsback completely to only having the name/source set