### PR TITLE
versions: don't leave behind an empty folder if the download fails

### DIFF
--- a/src-tauri/src/commands/versions.rs
+++ b/src-tauri/src/commands/versions.rs
@@ -195,13 +195,12 @@ pub async fn remove_version(
     Some(path) => Path::new(path),
   };
 
-  info!("Deleting Version: {}", version);
-
   let version_dir = install_path
     .join("versions")
     .join("official")
     .join(&version);
 
+  info!("Deleting Version: {} at {:?}", version, version_dir);
   delete_dir(&version_dir)?;
 
   // If it's the active version, we should clean that up in the settings file

--- a/src-tauri/src/util/file.rs
+++ b/src-tauri/src/util/file.rs
@@ -11,6 +11,13 @@ use std::{
 pub fn delete_dir<T: AsRef<Path>>(path: T) -> Result<(), std::io::Error> {
   if path.as_ref().exists() && path.as_ref().is_dir() {
     std::fs::remove_dir_all(path)?;
+  } else {
+    log::warn!(
+      "Not deleting dir: {:?} as it does not exist ({}) or is not a directory ({})",
+      path.as_ref(),
+      path.as_ref().exists(),
+      path.as_ref().is_dir()
+    )
   }
   Ok(())
 }

--- a/src/routes/settings/versions/OfficialVersions.svelte
+++ b/src/routes/settings/versions/OfficialVersions.svelte
@@ -137,6 +137,8 @@
       });
       await saveActiveVersionChange(version);
     } else {
+      // ensure the version folder is removed if it failed
+      await onRemoveVersion(version);
       releases = releases.map((release) =>
         release.version === version
           ? { ...release, pendingAction: false }


### PR DESCRIPTION
If the download of a version failed, it would leave behind an empty folder -- enough to convince the launcher that the version existed but of course it doesn't function.

A secondary improvement here could be that we do a more comprehensive check on each folder to consider it a valid version (does it atleast have the binaries we expect and do they run).  However this fix should be done _as well_, as a failure should be cleaned up appropriately.