### PR TITLE
DRY: Collect repeated requirements checking code into a single store.

### DIFF
--- a/src/components/job/GameSetup.svelte
+++ b/src/components/job/GameSetup.svelte
@@ -3,60 +3,25 @@
   import { onMount } from "svelte";
   import { Button } from "flowbite-svelte";
   import { folderPrompt, isoPrompt } from "$lib/utils/file-dialogs";
+  import { getProceedAfterSuccessfulOperation } from "$lib/rpc/config";
   import {
-    isAVXRequirementMet,
-    isDiskSpaceRequirementMet,
-    isOpenGLRequirementMet,
-    getProceedAfterSuccessfulOperation,
-  } from "$lib/rpc/config";
+    requirementsStore,
+    currentRequirements,
+  } from "/src/state/requirements-store";
   import { _ } from "svelte-i18n";
-  import { arch, type } from "@tauri-apps/plugin-os";
   import type { SupportedGame } from "$lib/rpc/bindings/SupportedGame";
   import { navigate } from "/src/router";
   import { asJobType } from "$lib/job/jobs";
-  import { systemInfoState } from "/src/state/SystemInfoState.svelte";
 
   let { activeGame }: { activeGame: SupportedGame } = $props();
 
-  let requirementsMet: boolean | undefined = $state(undefined);
   let proceedAfterSuccessfulOperation = $state(true);
 
   onMount(async () => {
-    // Check requirements
-    await checkRequirements();
+    await requirementsStore.refresh(activeGame);
     proceedAfterSuccessfulOperation =
       await getProceedAfterSuccessfulOperation();
   });
-
-  async function checkRequirements() {
-    const architecture = arch();
-    const osType = type();
-    const isOpenGLMet = await isOpenGLRequirementMet(false);
-    const isDiskSpaceMet = await isDiskSpaceRequirementMet(activeGame);
-    if (architecture === "aarch64") {
-      // arm, we don't bother checking for simd
-      // - if macOS (the only supported ARM platform), we check they are on atleast macOS 15
-      // there is no easy way to check to see if they have rosetta 2, if you know of one, contribute it
-      if (osType !== "macos") {
-        requirementsMet = false;
-        return;
-      }
-      requirementsMet =
-        systemInfoState.isMinMacOSVersion && isOpenGLMet && isDiskSpaceMet;
-    } else {
-      const isAvxMet = await isAVXRequirementMet();
-      if (osType == "windows") {
-        requirementsMet = Boolean(
-          isAvxMet &&
-          isOpenGLMet &&
-          isDiskSpaceMet &&
-          systemInfoState.isMinVCCRuntimeInstalled,
-        );
-      } else {
-        requirementsMet = isAvxMet && isOpenGLMet && isDiskSpaceMet;
-      }
-    }
-  }
 
   async function install(viaFolder: boolean) {
     let sourcePath = undefined;
@@ -82,9 +47,9 @@
   }
 </script>
 
-{#if requirementsMet !== undefined}
-  {#if !requirementsMet}
-    <Requirements {activeGame} on:recheckRequirements={checkRequirements} />
+{#if $currentRequirements?.requirementsMet !== undefined}
+  {#if !$currentRequirements.requirementsMet}
+    <Requirements {activeGame} />
   {:else}
     <div class="flex flex-col justify-end items-end mt-auto">
       <h1

--- a/src/components/job/Requirements.svelte
+++ b/src/components/job/Requirements.svelte
@@ -1,37 +1,16 @@
 <script lang="ts">
-  import { createEventDispatcher, onMount } from "svelte";
   import { Alert, Button } from "flowbite-svelte";
+  import { setBypassRequirements } from "$lib/rpc/config";
   import {
-    isAVXRequirementMet,
-    isDiskSpaceRequirementMet,
-    isOpenGLRequirementMet,
-    setBypassRequirements,
-  } from "$lib/rpc/config";
+    requirementsStore,
+    currentRequirements,
+  } from "/src/state/requirements-store";
   import { _ } from "svelte-i18n";
   import { confirm } from "@tauri-apps/plugin-dialog";
-  import { arch, type } from "@tauri-apps/plugin-os";
   import type { SupportedGame } from "$lib/rpc/bindings/SupportedGame";
   import { systemInfoState } from "/src/state/SystemInfoState.svelte";
 
   let { activeGame }: { activeGame: SupportedGame } = $props();
-
-  let isAVXRelevant = type() !== "macos";
-  let isTryingToUseARMOutsideOfMacOS: boolean | undefined =
-    arch() == "aarch64" && type() !== "macos";
-  let isAVXMet: boolean | undefined = $state(false);
-  let isOpenGLMet: boolean | undefined = $state(false);
-  let isDiskSpaceMet: boolean | undefined = $state(false);
-  const isVCCRelevant: boolean | undefined = type() == "windows";
-
-  const dispatch = createEventDispatcher();
-
-  onMount(async () => {
-    isOpenGLMet = await isOpenGLRequirementMet(false);
-    isDiskSpaceMet = await isDiskSpaceRequirementMet(activeGame);
-    if (isAVXRelevant) {
-      isAVXMet = await isAVXRequirementMet();
-    }
-  });
 
   function alertColor(val: boolean | undefined) {
     if (val === undefined) {
@@ -41,22 +20,20 @@
   }
 </script>
 
-<!-- TODO - good spot for a new component -->
-
 <div
   class="flex flex-col h-full justify-center items-center p-5 text-center gap-3"
 >
   <h1 class="text-xl font-black mb-5 text-outline">
     {$_("requirements_notMet_header")}
   </h1>
-  {#if isAVXRelevant}
-    {#if !isAVXMet}
+  {#if $currentRequirements?.isAVXRelevant}
+    {#if !$currentRequirements?.isAVXMet}
       <Alert
         class="w-full text-start"
         rounded={false}
-        color={alertColor(isAVXMet)}
+        color={alertColor($currentRequirements?.isAVXMet)}
       >
-        {#if isAVXMet === undefined}
+        {#if $currentRequirements?.isAVXMet === undefined}
           <span class="font-bold"
             >{$_("requirements_cpu_unableToCheckAVX")}</span
           >
@@ -80,11 +57,11 @@
         {/if}
       </Alert>
     {/if}
-  {:else if isTryingToUseARMOutsideOfMacOS}
+  {:else if $currentRequirements?.isTryingToUseARMOutsideOfMacOS}
     <Alert
       class="w-full text-start"
       rounded={false}
-      color={alertColor(!isTryingToUseARMOutsideOfMacOS)}
+      color={alertColor(!$currentRequirements?.isTryingToUseARMOutsideOfMacOS)}
     >
       <span class="font-bold"
         >{$_("requirements_armNotSupportedOutsideMacOS")}</span
@@ -108,13 +85,13 @@
     </Alert>
   {/if}
 
-  {#if !isOpenGLMet}
+  {#if !$currentRequirements?.isOpenGLMet}
     <Alert
       class="w-full text-start"
       rounded={false}
-      color={alertColor(isOpenGLMet)}
+      color={alertColor($currentRequirements?.isOpenGLMet)}
     >
-      {#if isOpenGLMet === undefined}
+      {#if $currentRequirements?.isOpenGLMet === undefined}
         <span class="font-bold"
           >{$_("requirements_gpu_unableToCheckOpenGL")}</span
         >
@@ -143,13 +120,13 @@
     </Alert>
   {/if}
 
-  {#if !isDiskSpaceMet}
+  {#if !$currentRequirements?.isDiskSpaceMet}
     <Alert
       class="w-full text-start"
       rounded={false}
-      color={alertColor(isDiskSpaceMet)}
+      color={alertColor($currentRequirements?.isDiskSpaceMet)}
     >
-      {#if isDiskSpaceMet === undefined}
+      {#if $currentRequirements?.isDiskSpaceMet === undefined}
         <span class="font-bold"
           >{$_(`requirements_disk_unableToCheckSpace`)}</span
         >
@@ -161,7 +138,7 @@
     </Alert>
   {/if}
 
-  {#if isVCCRelevant}
+  {#if $currentRequirements?.isVCCRelevant}
     {#if !systemInfoState.isMinVCCRuntimeInstalled}
       <Alert
         class="w-full text-start"
@@ -198,13 +175,12 @@
     <Button
       class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
       onclick={async () => {
-        isAVXMet = await isAVXRequirementMet();
-        isOpenGLMet = await isOpenGLRequirementMet(true);
-        dispatch("recheckRequirements");
+        await requirementsStore.refresh(activeGame, true);
       }}>{$_("requirements_button_recheck")}</Button
     >
     <Button
-      hidden={isVCCRelevant && !systemInfoState.isMinVCCRuntimeInstalled}
+      hidden={$currentRequirements?.isVCCRelevant &&
+        !systemInfoState.isMinVCCRuntimeInstalled}
       class="border-solid border-2 border-slate-900 rounded bg-orange-800 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
       onclick={async () => {
         const confirmed = await confirm(
@@ -215,7 +191,7 @@
         );
         if (confirmed) {
           await setBypassRequirements(true);
-          dispatch("recheckRequirements");
+          await requirementsStore.refresh(activeGame, false);
         }
       }}>{$_("requirements_button_bypass")}</Button
     >

--- a/src/state/requirements-store.ts
+++ b/src/state/requirements-store.ts
@@ -1,0 +1,102 @@
+import { writable, derived } from "svelte/store";
+import { arch, type } from "@tauri-apps/plugin-os";
+import {
+  isAVXRequirementMet,
+  isDiskSpaceRequirementMet,
+  isOpenGLRequirementMet,
+} from "$lib/rpc/config";
+import type { SupportedGame } from "$lib/rpc/bindings/SupportedGame";
+import { systemInfoState } from "/src/state/SystemInfoState.svelte";
+
+export interface RequirementResult {
+  architecture: string;
+  osType: string;
+
+  isAVXRelevant: boolean;
+  isTryingToUseARMOutsideOfMacOS: boolean;
+  isVCCRelevant: boolean;
+
+  isAVXMet?: boolean;
+  isOpenGLMet?: boolean;
+  isDiskSpaceMet?: boolean;
+
+  requirementsMet: boolean;
+}
+
+async function evaluateRequirements(
+  game: SupportedGame,
+  forceOpenGL = false,
+): Promise<RequirementResult> {
+  const architecture = arch();
+  const osType = type();
+
+  const isAVXRelevant = osType !== "macos";
+  const isTryingToUseARMOutsideOfMacOS =
+    architecture === "aarch64" && osType !== "macos";
+  const isVCCRelevant = osType === "windows";
+
+  const isOpenGLMet = await isOpenGLRequirementMet(forceOpenGL);
+  const isDiskSpaceMet = await isDiskSpaceRequirementMet(game);
+
+  let isAVXMet: boolean | undefined;
+  if (isAVXRelevant) {
+    isAVXMet = await isAVXRequirementMet();
+  }
+
+  let requirementsMet: boolean;
+
+  if (architecture === "aarch64") {
+    if (osType !== "macos") {
+      requirementsMet = false;
+    } else {
+      requirementsMet =
+        Boolean(systemInfoState.isMinMacOSVersion) &&
+        Boolean(isOpenGLMet) &&
+        Boolean(isDiskSpaceMet);
+    }
+  } else {
+    if (osType === "windows") {
+      requirementsMet = Boolean(
+        isAVXMet &&
+        isOpenGLMet &&
+        isDiskSpaceMet &&
+        systemInfoState.isMinVCCRuntimeInstalled,
+      );
+    } else {
+      requirementsMet = Boolean(isAVXMet && isOpenGLMet && isDiskSpaceMet);
+    }
+  }
+
+  return {
+    architecture,
+    osType,
+    isAVXRelevant,
+    isTryingToUseARMOutsideOfMacOS,
+    isVCCRelevant,
+    isAVXMet,
+    isOpenGLMet,
+    isDiskSpaceMet,
+    requirementsMet,
+  };
+}
+
+interface ReqState {
+  game?: SupportedGame;
+  result?: RequirementResult;
+}
+
+const state = writable<ReqState>({});
+
+async function refresh(game: SupportedGame, forceOpenGL = false) {
+  const res = await evaluateRequirements(game, forceOpenGL);
+  state.set({ game, result: res });
+  return res;
+}
+
+export const requirementsStore = {
+  subscribe: state.subscribe,
+  refresh,
+};
+
+export const currentRequirements = derived(state, (s) => s.result);
+export const currentGame = derived(state, (s) => s.game);


### PR DESCRIPTION
This PR does two things:
1. Refactors common requirements checking code out of two svelte components into a single svelte store.
2. Avoids calling the requirements checking code multiple times in a row.

Prior to this PR our application would check the requirements `onMount` for both `<GameSetup>` and `<Requirements>`. `<Requirements>` is rendered as a child of `<GameSetup>` so executing the requirements check here is redundant.