### PR TITLE
Refactor vcc runtime detection

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arbitrary"
@@ -3098,6 +3098,7 @@ dependencies = [
 name = "opengoal-launcher"
 version = "2.8.12"
 dependencies = [
+ "anyhow",
  "backtrace",
  "chrono",
  "cmake",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opengoal-launcher"
-version = "2.8.12" # APP_VERSION
+version = "2.8.12"                                   # APP_VERSION
 description = "A frontend for the OpenGOAL project"
 authors = ["OpenGOAL"]
 license = "ISC"
@@ -15,9 +15,10 @@ rust-version = "1.89"
 tauri-build = { version = "2.5.1", features = [] }
 
 [dependencies]
-plist = "1.7.4" # ensuring a bug fix for newer rustc versions
-notify-rust = "4.11.6" # ensuring a bug fix for newer rustc versions
-cmake = "0.1.57" # VS2026 causes issues
+anyhow = "1.0.102"
+plist = "1.7.4"                                                          # ensuring a bug fix for newer rustc versions
+notify-rust = "4.11.6"                                                   # ensuring a bug fix for newer rustc versions
+cmake = "0.1.57"                                                         # VS2026 causes issues
 backtrace = "0.3.74"
 chrono = "0.4.39"
 dir-diff = "0.3.3"
@@ -37,7 +38,7 @@ serde_json = "1.0.146"
 strum = { version = "0.27", features = ["derive"] }
 sysinfo = "0.37.0"
 tar = "0.4.43"
-tauri = { version = "2.9.5", features = [ "protocol-asset", "devtools"] }
+tauri = { version = "2.9.5", features = ["protocol-asset", "devtools"] }
 thiserror = "2.0.15"
 tokio = { version = "1", features = ["full"] }
 ts-rs = "11.0"
@@ -79,7 +80,7 @@ default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]
 
 [profile.release]
-strip = true  # Automatically strip symbols from the binary.
+strip = true # Automatically strip symbols from the binary.
 
 [profile.dev.package.zip] # build zip as release, else its slow when making a support package when dev'ing
 opt-level = 3

--- a/src-tauri/src/commands/support.rs
+++ b/src-tauri/src/commands/support.rs
@@ -308,7 +308,7 @@ pub async fn generate_support_package(
   // System Information
   let mut system_info = System::new_all();
   system_info.refresh_all();
-  package.installed_vcc_runtime = get_installed_vcc_runtime().map(|v| v.to_string());
+  package.installed_vcc_runtime = get_installed_vcc_runtime().ok().map(|v| v.to_string());
   package.total_memory_megabytes = system_info.total_memory() / 1024 / 1024;
   package.cpu_name = system_info.cpus()[0].name().to_string();
   package.cpu_vendor = system_info.cpus()[0].vendor_id().to_string();

--- a/src-tauri/src/commands/util.rs
+++ b/src-tauri/src/commands/util.rs
@@ -101,13 +101,12 @@ pub async fn is_minimum_vcc_runtime_installed() -> Result<bool, CommandError> {
   use crate::util::os::get_installed_vcc_runtime;
 
   let minimum_version = semver::Version::new(14, 40, 33810);
-  let installed_vcc_runtime_version = get_installed_vcc_runtime();
-  if installed_vcc_runtime_version.is_none() {
-    Err(CommandError::Configuration(
-      "Unable to check if VCC runtime is installed".to_owned(),
-    ))
-  } else {
-    Ok(installed_vcc_runtime_version.unwrap() >= minimum_version)
+  match get_installed_vcc_runtime() {
+    Ok(installed_version) => Ok(installed_version >= minimum_version),
+    Err(err) => Err(CommandError::Configuration(format!(
+      "Unable to check if VCC runtime is installed: {:?}",
+      err
+    ))),
   }
 }
 

--- a/src-tauri/src/util/os.rs
+++ b/src-tauri/src/util/os.rs
@@ -1,66 +1,35 @@
 #[cfg(not(target_os = "windows"))]
-pub fn get_installed_vcc_runtime() -> Option<semver::Version> {
-  None
+pub fn get_installed_vcc_runtime() -> anyhow::Result<semver::Version> {
+  anyhow::bail!("VCC runtime is only available on Windows");
 }
 
 #[cfg(target_os = "windows")]
-pub fn get_installed_vcc_runtime() -> Option<semver::Version> {
+pub fn get_installed_vcc_runtime() -> anyhow::Result<semver::Version> {
+  use anyhow::Context;
   use winreg::{
     RegKey,
     enums::{HKEY_LOCAL_MACHINE, KEY_READ},
   };
   let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
   let path = r"SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64";
+  let key = hklm
+    .open_subkey_with_flags(path, KEY_READ)
+    .context("opening VCC runtime registry key")?;
 
-  if let Ok(key) = hklm.open_subkey_with_flags(path, KEY_READ) {
-    match key.get_value::<u32, _>("Installed") {
-      Ok(val) => {
-        if val != 1 {
-          log::error!("VCC runtime exists in the registry but is not marked as installed");
-          return None;
-        }
-      }
-      Err(err) => {
-        log::error!("Couldn't determine if VCC runtime was installed: {}", err);
-        return None;
-      }
-    };
-    let patch_version: u32 = match key.get_value("Bld") {
-      Ok(val) => val,
-      Err(err) => {
-        log::error!(
-          "Couldn't determine installed VCC runtime patch version: {}",
-          err
-        );
-        return None;
-      }
-    };
-    let minor_version: u32 = match key.get_value("Minor") {
-      Ok(val) => val,
-      Err(err) => {
-        log::error!(
-          "Couldn't determine installed VCC runtime minor version: {}",
-          err
-        );
-        return None;
-      }
-    };
-    let major_version: u32 = match key.get_value("Major") {
-      Ok(val) => val,
-      Err(err) => {
-        log::error!(
-          "Couldn't determine installed VCC runtime major version: {}",
-          err
-        );
-        return None;
-      }
-    };
-    let installed_version = semver::Version::new(
-      major_version.into(),
-      minor_version.into(),
-      patch_version.into(),
-    );
-    return Some(installed_version);
+  let installed: u32 = key
+    .get_value("Installed")
+    .context("reading VCC Installed flag")?;
+  if installed != 1 {
+    anyhow::bail!("VCC runtime is not installed (Installed flag is not 1)");
   }
-  return None;
+
+  let major: u32 = key.get_value("Major").context("reading VCC Major")?;
+  let minor: u32 = key.get_value("Minor").context("reading VCC Minor")?;
+  let patch: u32 = key.get_value("Bld").context("reading VCC Bld")?;
+
+  Ok(semver::Version::new(
+    major as u64,
+    minor as u64,
+    patch as u64,
+  ))
 }

--- a/src/lib/rpc/config.ts
+++ b/src/lib/rpc/config.ts
@@ -88,7 +88,12 @@ export async function isDiskSpaceRequirementMet(
 }
 
 export async function isMinimumVCCRuntimeInstalled(): Promise<boolean> {
-  return await invoke_rpc("is_minimum_vcc_runtime_installed", {}, () => false);
+  return await invoke_rpc(
+    "is_minimum_vcc_runtime_installed",
+    {},
+    () => false,
+    "_mirror_",
+  );
 }
 
 export async function finalizeInstallation(


### PR DESCRIPTION
The intention of this pull request is to:
1. simplify the `get_installed_vcc_runtime` function without sacrificing readability or changing the behavior
2. improve error propagation by ensuring the toast mirrors relevant back-end errors properly
3. provide a clean, idiomatic example of using `anyhow` (with `?` and `.context()`) that I can use as a reference for future refactors