### PR TITLE
Refactor util/tar functions

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -15,6 +15,8 @@ pub mod window;
 #[derive(Debug, thiserror::Error)]
 pub enum CommandError {
   #[error(transparent)]
+  Anyhow(#[from] anyhow::Error),
+  #[error(transparent)]
   IO(#[from] std::io::Error),
   #[error(transparent)]
   NetworkRequest(#[from] reqwest::Error),

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -77,10 +77,7 @@ pub async fn extract_new_mod(
       CommandError::GameFeatures(format!("Unable to extract mod: {}", err))
     })?;
   } else if cfg!(unix) {
-    extract_tar_ball(&bundle_path_buf, destination_dir).map_err(|err| {
-      log::error!("Unable to extract mod: {}", err);
-      CommandError::GameFeatures(format!("Unable to extract mod: {}", err))
-    })?;
+    extract_tar_ball(&bundle_path_buf, destination_dir)?;
   } else {
     Err(CommandError::VersionManagement(
       "Unknown operating system, unable to download and extract mod".to_owned(),
@@ -145,10 +142,7 @@ pub async fn download_and_extract_new_mod(
       CommandError::GameFeatures(format!("Unable to extract mod: {}", err))
     })?;
   } else if cfg!(unix) {
-    extract_and_delete_tar_ball(download_path, parent_path).map_err(|err| {
-      log::error!("Unable to extract mod: {}", err);
-      CommandError::GameFeatures(format!("Unable to extract mod: {}", err))
-    })?;
+    extract_and_delete_tar_ball(download_path, parent_path)?;
   } else {
     Err(CommandError::VersionManagement(
       "Unknown operating system, unable to download and extract mod".to_owned(),

--- a/src-tauri/src/commands/versions.rs
+++ b/src-tauri/src/commands/versions.rs
@@ -147,13 +147,8 @@ pub async fn download_version(
       CommandError::VersionManagement("Unable to successfully download version".to_owned())
     })?;
 
-    // Extract the zip file
-    extract_and_delete_tar_ball(&download_path, &dest_dir).map_err(|err| {
-      log::error!("unable to extract and delete version tar.gz file {}", err);
-      CommandError::VersionManagement(
-        "Unable to successfully extract downloaded version".to_owned(),
-      )
-    })?;
+    // Extract the tar file
+    extract_and_delete_tar_ball(download_path, &dest_dir)?;
 
     // Verify that the extracted files seem correct (look for extractor.exe)
     let expected_extractor_path = dest_dir.join("extractor");

--- a/src-tauri/src/util/tar.rs
+++ b/src-tauri/src/util/tar.rs
@@ -1,20 +1,31 @@
-use std::path::PathBuf;
+use anyhow::{Context, Result};
+use std::path::Path;
 
-pub fn extract_tar_ball(tar_path: &PathBuf, extract_dir: &PathBuf) -> Result<(), std::io::Error> {
-  log::info!("extracting {}", tar_path.display());
-  let tar_gz = std::fs::File::open(tar_path)?;
+pub fn extract_tar_ball(tar_path: impl AsRef<Path>, extract_dir: impl AsRef<Path>) -> Result<()> {
+  let tar_path = tar_path.as_ref();
+  let extract_dir = extract_dir.as_ref();
+  let tar_gz = std::fs::File::open(tar_path)
+    .with_context(|| format!("failed to open: {}", tar_path.display()))?;
   let tar = flate2::read::GzDecoder::new(tar_gz);
   let mut archive = tar::Archive::new(tar);
-  archive.unpack(extract_dir)?;
+  archive.unpack(extract_dir).with_context(|| {
+    format!(
+      "failed to unpack: {} into {}",
+      tar_path.display(),
+      extract_dir.display()
+    )
+  })?;
   Ok(())
 }
 
 pub fn extract_and_delete_tar_ball(
-  tar_path: &PathBuf,
-  extract_dir: &PathBuf,
-) -> Result<(), std::io::Error> {
+  tar_path: impl AsRef<Path>,
+  extract_dir: impl AsRef<Path>,
+) -> Result<()> {
+  let tar_path = tar_path.as_ref();
+  let extract_dir = extract_dir.as_ref();
   extract_tar_ball(tar_path, extract_dir)?;
-  log::info!("deleting {}", tar_path.display());
-  std::fs::remove_file(tar_path)?;
+  std::fs::remove_file(tar_path)
+    .with_context(|| format!("failed to delete: {}", tar_path.display()))?;
   Ok(())
 }


### PR DESCRIPTION
The following changes have been made in this pull request:
1. Refactored tar extraction helpers to use `impl AsRef<Path>` and `anyhow context` for more ergonomic call sites and improved error diagnostics respectively.
2. Added an Anyhow variant to `CommandError`, enabling seamless propagation of rich error chains from internal logic to the command boundary.
3. Simplified error handling across call sites by relying on `?` and `From<anyhow::Error>` conversions, removing redundant map_err, logging, and manual error wrapping.