### PR TITLE
Refactor util/file.rs

### DIFF
--- a/src-tauri/src/commands/binaries.rs
+++ b/src-tauri/src/commands/binaries.rs
@@ -109,9 +109,7 @@ fn copy_data_dir(
 
   info!("Copying {} into {}", src_dir.display(), dst_dir.display());
 
-  overwrite_dir(&src_dir, &dst_dir).map_err(|err| {
-    CommandError::Installation(format!("Unable to copy data directory: '{err}'",))
-  })?;
+  overwrite_dir(&src_dir, &dst_dir)?;
   Ok(())
 }
 

--- a/src-tauri/src/commands/download.rs
+++ b/src-tauri/src/commands/download.rs
@@ -4,24 +4,19 @@ use crate::util::{file::create_dir, network};
 
 use super::CommandError;
 
+// TODO: Finish refactoring this function to use anyhow result, after refactoring download_file
 #[tauri::command]
 pub async fn download_file(url: String, destination: PathBuf) -> Result<(), CommandError> {
-  let parent = destination.parent().ok_or_else(|| {
-    CommandError::OSOperation("Destination path has no parent directory".to_owned())
-  })?;
-
-  if !parent.exists() {
-    create_dir(parent).map_err(|_| {
-      CommandError::OSOperation(format!(
-        "Unable to prepare destination folder '{}'",
-        parent.display()
-      ))
-    })?;
+  if let Some(parent) = destination.parent() {
+    create_dir(parent)?;
+    network::download_file(&url, &destination)
+      .await
+      .map_err(|_| CommandError::OSOperation("Unable to successfully download file".to_owned()))?;
+    Ok(())
+  } else {
+    return Err(CommandError::OSOperation(
+      "Destination path has no parent directory".to_owned(),
+    ));
+    // TODO: anyhow::bail!("Destination path has no parent directory")
   }
-
-  network::download_file(&url, &destination)
-    .await
-    .map_err(|_| CommandError::OSOperation("Unable to successfully download file".to_owned()))?;
-
-  Ok(())
 }

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -722,31 +722,6 @@ pub async fn get_local_mod_thumbnail_base64(
 }
 
 #[tauri::command]
-pub async fn get_local_mod_cover_base64(
-  config: tauri::State<'_, tokio::sync::Mutex<LauncherConfig>>,
-  game_name: SupportedGame,
-  mod_name: String,
-) -> Result<String, CommandError> {
-  let config_lock = config.lock().await;
-  let install_path = match &config_lock.installation_dir {
-    None => return Ok("".to_string()),
-    Some(path) => Path::new(path),
-  };
-
-  let cover_path = install_path
-    .join("features")
-    .join(game_name.to_string())
-    .join("mods")
-    .join("_local")
-    .join(mod_name)
-    .join("cover.png");
-  if cover_path.exists() {
-    return Ok(to_image_base64(cover_path.to_string_lossy().as_ref()));
-  }
-  Ok("".to_string())
-}
-
-#[tauri::command]
 pub async fn uninstall_mod(
   config: tauri::State<'_, tokio::sync::Mutex<LauncherConfig>>,
   game_name: SupportedGame,

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -67,10 +67,7 @@ pub async fn extract_new_mod(
     .join(mod_source)
     .join(&mod_name);
   delete_dir(destination_dir)?;
-  create_dir(destination_dir).map_err(|err| {
-    log::error!("Unable to create directory for mod: {}", err);
-    CommandError::GameFeatures(format!("Unable to create directory for mod: {}", err))
-  })?;
+  create_dir(destination_dir)?;
   if cfg!(windows) {
     extract_zip_file(&bundle_path_buf, destination_dir, false).map_err(|err| {
       log::error!("Unable to extract mod: {}", err);
@@ -118,10 +115,7 @@ pub async fn download_and_extract_new_mod(
   let download_path = &parent_path.join(format!("{mod_name}.zip"));
 
   delete_dir(parent_path)?;
-  create_dir(parent_path).map_err(|err| {
-    log::error!("Unable to create directory for mod: {}", err);
-    CommandError::GameFeatures(format!("Unable to create directory for mod: {}", err))
-  })?;
+  create_dir(parent_path)?;
   download_file(&download_url, download_path)
     .await
     .map_err(|err| {

--- a/src-tauri/src/commands/features/texture_packs.rs
+++ b/src-tauri/src/commands/features/texture_packs.rs
@@ -206,13 +206,7 @@ pub async fn extract_new_texture_pack(
     .join("texture-packs")
     .join(&texture_pack_name);
   // TODO - delete it
-  create_dir(destination_dir).map_err(|err| {
-    log::error!("Unable to create directory for texture pack: {}", err);
-    CommandError::GameFeatures(format!(
-      "Unable to create directory for texture pack: {}",
-      err
-    ))
-  })?;
+  create_dir(destination_dir)?;
   extract_zip_file(&zip_path_buf, destination_dir, false).map_err(|err| {
     log::error!("Unable to extract replacement pack: {}", err);
     CommandError::GameFeatures(format!("Unable to extract texture pack: {}", err))

--- a/src-tauri/src/commands/features/texture_packs.rs
+++ b/src-tauri/src/commands/features/texture_packs.rs
@@ -3,7 +3,6 @@ use std::{
   path::{Path, PathBuf},
 };
 
-use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 

--- a/src-tauri/src/commands/features/texture_packs.rs
+++ b/src-tauri/src/commands/features/texture_packs.rs
@@ -3,6 +3,7 @@ use std::{
   path::{Path, PathBuf},
 };
 
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -264,11 +265,12 @@ pub async fn update_texture_pack_data(
 
       log::info!("Appending textures from: {}", texture_pack_dir.display());
 
+      // strange, but I can't worry about it right now.
       if let Err(err) = overwrite_dir(&texture_pack_dir, &game_texture_pack_dir) {
-        log::error!("Unable to update texture replacements: {}", err);
+        log::error!("{:#}", err);
         return Ok(GameJobStepOutput {
           success: false,
-          msg: Some(format!("Unable to update texture replacements: {}", err)),
+          msg: Some(err.to_string()),
         });
       }
     }

--- a/src-tauri/src/commands/versions.rs
+++ b/src-tauri/src/commands/versions.rs
@@ -86,12 +86,7 @@ pub async fn download_version(
     .join(&version);
 
   // Delete the directory if it exists, and create it from scratch
-  delete_dir(&dest_dir).map_err(|_| {
-    CommandError::VersionManagement(format!(
-      "Unable to prepare destination folder '{}' for download",
-      dest_dir.display()
-    ))
-  })?;
+  delete_dir(&dest_dir)?;
   create_dir(&dest_dir).map_err(|_| {
     CommandError::VersionManagement(format!(
       "Unable to prepare destination folder '{}' for download",
@@ -124,12 +119,7 @@ pub async fn download_version(
         "Version did not extract properly, {} is missing!",
         expected_extractor_path.display()
       );
-      delete_dir(&dest_dir).map_err(|_| {
-        CommandError::VersionManagement(format!(
-          "Unable to prepare destination folder '{}' for download",
-          dest_dir.display()
-        ))
-      })?;
+      delete_dir(&dest_dir)?;
       return Err(CommandError::VersionManagement(
         "Version did not extract properly, critical files are missing. An antivirus may have deleted the files!"
         .to_owned()
@@ -157,12 +147,7 @@ pub async fn download_version(
         "Version did not extract properly, {} is missing!",
         expected_extractor_path.display()
       );
-      delete_dir(&dest_dir).map_err(|_| {
-        CommandError::VersionManagement(format!(
-          "Unable to prepare destination folder '{}' for download",
-          dest_dir.display()
-        ))
-      })?;
+      delete_dir(&dest_dir)?;
       return Err(CommandError::VersionManagement(
         "Version did not extract properly, critical files are missing. An antivirus may have deleted the files!"
         .to_owned()

--- a/src-tauri/src/commands/versions.rs
+++ b/src-tauri/src/commands/versions.rs
@@ -87,12 +87,7 @@ pub async fn download_version(
 
   // Delete the directory if it exists, and create it from scratch
   delete_dir(&dest_dir)?;
-  create_dir(&dest_dir).map_err(|_| {
-    CommandError::VersionManagement(format!(
-      "Unable to prepare destination folder '{}' for download",
-      dest_dir.display()
-    ))
-  })?;
+  create_dir(&dest_dir)?;
 
   if cfg!(windows) {
     let download_path = install_path

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -25,6 +25,8 @@ use crate::util::file::touch_file;
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigError {
   #[error(transparent)]
+  Anyhow(#[from] anyhow::Error),
+  #[error(transparent)]
   IO(#[from] std::io::Error),
   #[error(transparent)]
   JSONError(#[from] serde_json::Error),

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -11,6 +11,7 @@
 
 use crate::commands::CommandError;
 use crate::util::file::create_dir;
+use anyhow::Context;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -396,15 +397,8 @@ impl LauncherConfig {
 
     // Check our permissions on the folder by touching a file (and deleting it)
     let test_file = path.join(".perm-test.tmp");
-    if let Err(e) = touch_file(&test_file) {
-      log::error!(
-        "Provided installation folder could not be written to: {}",
-        e
-      );
-      return Err(ConfigError::Configuration(
-        "Provided folder cannot be written to".to_owned(),
-      ));
-    }
+    touch_file(&test_file)
+      .with_context(|| format!("Provided installation folder could not be written to."))?;
 
     // If the directory changes (it's not a no-op), we need to:
     // - wipe any installed games (make them reinstall)

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -198,7 +198,6 @@ fn main() {
       commands::features::mods::extract_iso_for_mod_install,
       commands::features::mods::extract_new_mod,
       commands::features::mods::get_launch_mod_string,
-      commands::features::mods::get_local_mod_cover_base64,
       commands::features::mods::get_local_mod_thumbnail_base64,
       commands::features::mods::launch_mod,
       commands::features::mods::open_repl_for_mod,

--- a/src-tauri/src/util/file.rs
+++ b/src-tauri/src/util/file.rs
@@ -45,16 +45,15 @@ pub fn overwrite_dir(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<()>
   Ok(())
 }
 
-pub fn touch_file(path: &PathBuf) -> std::io::Result<()> {
-  match std::fs::OpenOptions::new()
+pub fn touch_file(path: impl AsRef<Path>) -> Result<()> {
+  let path = path.as_ref();
+  std::fs::OpenOptions::new()
     .create(true)
     .truncate(true)
     .write(true)
     .open(path)
-  {
-    Ok(_) => Ok(()),
-    Err(e) => Err(e),
-  }
+    .with_context(|| format!("Failed to touch file: {}", path.display()))?;
+  Ok(())
 }
 
 pub fn get_image_file_type(hex: &str) -> &str {

--- a/src-tauri/src/util/file.rs
+++ b/src-tauri/src/util/file.rs
@@ -26,13 +26,21 @@ pub fn create_dir(path: &Path) -> Result<()> {
   Ok(())
 }
 
-pub fn overwrite_dir(src: &PathBuf, dst: &PathBuf) -> Result<(), fs_extra::error::Error> {
+pub fn overwrite_dir(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<()> {
+  let src = src.as_ref();
+  let dst = dst.as_ref();
   if src.exists() {
-    let mut options = fs_extra::dir::CopyOptions::new();
-    options.copy_inside = true;
-    options.overwrite = true;
-    options.content_only = true;
-    fs_extra::dir::copy(src, dst, &options)?;
+    let options = fs_extra::dir::CopyOptions::new()
+      .copy_inside(true)
+      .overwrite(true)
+      .content_only(true);
+    fs_extra::dir::copy(src, dst, &options).with_context(|| {
+      format!(
+        "Unable to copy directory from {} to {}",
+        src.display(),
+        dst.display()
+      )
+    })?;
   }
   Ok(())
 }

--- a/src-tauri/src/util/file.rs
+++ b/src-tauri/src/util/file.rs
@@ -3,11 +3,7 @@ extern crate rustc_serialize;
 use anyhow::{Context, Result};
 use rustc_serialize::base64::{MIME, ToBase64};
 use rustc_serialize::hex::ToHex;
-use std::{
-  fs::File,
-  io::Read,
-  path::{Path, PathBuf},
-};
+use std::{fs::File, io::Read, path::Path};
 
 pub fn delete_dir(path: impl AsRef<Path>) -> Result<()> {
   let path = path.as_ref();
@@ -18,7 +14,8 @@ pub fn delete_dir(path: impl AsRef<Path>) -> Result<()> {
   Ok(())
 }
 
-pub fn create_dir(path: &Path) -> Result<()> {
+pub fn create_dir(path: impl AsRef<Path>) -> Result<()> {
+  let path = path.as_ref();
   if !path.exists() {
     std::fs::create_dir_all(path)
       .with_context(|| format!("Failed to create directory: {}", path.display()))?;
@@ -56,6 +53,7 @@ pub fn touch_file(path: impl AsRef<Path>) -> Result<()> {
   Ok(())
 }
 
+// TODO: come back to these last two functions later
 pub fn get_image_file_type(hex: &str) -> &str {
   if hex.starts_with("ffd8ffe0") {
     return "jpeg";

--- a/src-tauri/src/util/file.rs
+++ b/src-tauri/src/util/file.rs
@@ -1,5 +1,6 @@
 extern crate rustc_serialize;
 
+use anyhow::{Context, Result};
 use rustc_serialize::base64::{MIME, ToBase64};
 use rustc_serialize::hex::ToHex;
 use std::{
@@ -8,16 +9,11 @@ use std::{
   path::{Path, PathBuf},
 };
 
-pub fn delete_dir<T: AsRef<Path>>(path: T) -> Result<(), std::io::Error> {
-  if path.as_ref().exists() && path.as_ref().is_dir() {
-    std::fs::remove_dir_all(path)?;
-  } else {
-    log::warn!(
-      "Not deleting dir: {:?} as it does not exist ({}) or is not a directory ({})",
-      path.as_ref(),
-      path.as_ref().exists(),
-      path.as_ref().is_dir()
-    )
+pub fn delete_dir(path: impl AsRef<Path>) -> Result<()> {
+  let path = path.as_ref();
+  if path.is_dir() {
+    std::fs::remove_dir_all(path)
+      .with_context(|| format!("Failed to delete directory: {}", path.display()))?;
   }
   Ok(())
 }

--- a/src-tauri/src/util/file.rs
+++ b/src-tauri/src/util/file.rs
@@ -18,11 +18,11 @@ pub fn delete_dir(path: impl AsRef<Path>) -> Result<()> {
   Ok(())
 }
 
-pub fn create_dir(path: &Path) -> Result<(), std::io::Error> {
-  if path.exists() {
-    return Ok(());
+pub fn create_dir(path: &Path) -> Result<()> {
+  if !path.exists() {
+    std::fs::create_dir_all(path)
+      .with_context(|| format!("Failed to create directory: {}", path.display()))?;
   }
-  std::fs::create_dir_all(path)?;
   Ok(())
 }
 

--- a/src/lib/rpc/features.ts
+++ b/src/lib/rpc/features.ts
@@ -280,18 +280,6 @@ export async function getLocalModThumbnailBase64(
   );
 }
 
-export async function getLocalModCoverBase64(
-  gameName: string,
-  modName: string,
-): Promise<string> {
-  return await invoke_rpc(
-    "get_local_mod_cover_base64",
-    { gameName, modName },
-    () => "",
-    "_mirror_",
-  );
-}
-
 export async function uninstallMod(
   gameName: string,
   modName: string,


### PR DESCRIPTION
The following changes have been made in this pull request:
1. Refactored (4) helper functions in `util/file.rs` to use `impl AsRef<Path>` and
`anyhow context` for more ergonomic call sites and improved error
diagnostics respectively.
2. Added an Anyhow variant to `ConfigError`, enabling seamless
propagation of rich error chains from internal logic to the command
boundary.
3. Simplified error handling across call sites by relying on `?` and
`From<anyhow::Error>` conversions, removing redundant map_err, logging, and manual error wrapping.
4. Removed an unused function `get_local_mod_cover_base64`