### PR TITLE
Refactor util/game_tests.rs

### DIFF
--- a/src-tauri/src/commands/support.rs
+++ b/src-tauri/src/commands/support.rs
@@ -371,27 +371,23 @@ pub async fn generate_support_package(
     ))
   }
 
-  let test_result = crate::util::game_tests::run_game_gpu_test(&config_lock, &app_handle).await;
-  match test_result {
-    Ok(result) => {
-      let gpu_info = GPUInfo {
-        opengl_test_passed: result.success,
-        renderer_name: format!(
-          "{}:{}",
-          result
-            .gpu_renderer_string
-            .unwrap_or("unknown renderer".to_string()),
-          result
-            .gpu_vendor_string
-            .unwrap_or("unknown vendor".to_string())
-        ),
-      };
-      package.gpu_info = Some(gpu_info);
-    }
-    Err(_) => {
-      package.gpu_info = None;
-    }
-  };
+  package.gpu_info = crate::util::game_tests::run_game_gpu_test(&config_lock, &app_handle)
+    .await
+    .ok()
+    .map(|result| GPUInfo {
+      opengl_test_passed: result.success,
+      renderer_name: format!(
+        "{}:{}",
+        result
+          .gpu_renderer_string
+          .as_deref()
+          .unwrap_or("unknown renderer"),
+        result
+          .gpu_vendor_string
+          .as_deref()
+          .unwrap_or("unknown vendor")
+      ),
+    });
 
   // Create zip file
   let save_path = Path::new(&user_path);

--- a/src-tauri/src/util/game_tests.rs
+++ b/src-tauri/src/util/game_tests.rs
@@ -1,11 +1,10 @@
-#[cfg(target_os = "windows")]
-use std::os::windows::process::CommandExt;
 use std::process::Command;
 
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use tauri::Manager;
 
-use crate::{commands::CommandError, config::LauncherConfig, util::file::create_dir};
+use crate::{config::LauncherConfig, util::file::create_dir};
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -20,80 +19,53 @@ pub struct GPUTestOutput {
 pub async fn run_game_gpu_test(
   config_lock: &tokio::sync::MutexGuard<'_, LauncherConfig>,
   app_handle: &tauri::AppHandle,
-) -> Result<GPUTestOutput, CommandError> {
+) -> Result<GPUTestOutput> {
   let config_info = config_lock.common_prelude()?;
 
   let exec_info = config_info.get_exec_location("gk")?;
-  let gpu_test_result_path = &match app_handle.path().app_data_dir() {
-    Ok(path) => path,
-    Err(err) => {
-      log::error!(
-        "Error encountered when determined path for binary for GPU test: {:?}",
-        err
-      );
-      return Err(CommandError::BinaryExecution(
-        "Could not determine path to save GPU test results".to_owned(),
-      ));
-    }
-  };
-  create_dir(gpu_test_result_path)?;
-  let gpu_test_result_path = &gpu_test_result_path.join("gpu-test-result.json");
+  let result_path = app_handle.path().app_data_dir()?;
+  create_dir(&result_path)?;
+  let result_path = result_path.join("gpu-test-result.json");
 
   log::info!(
-    "Running GPU test on game version {:?} and storing in folder: {:?}",
+    "Running GPU test on game version {} and storing in {}",
     &config_info.active_version,
-    gpu_test_result_path
+    result_path.display()
   );
 
   let mut command = Command::new(exec_info.executable_path);
   command
-    .args([
-      "-v".to_string(),
-      "--gpu-test".to_string(),
-      "opengl".to_string(),
-      "--gpu-test-out-path".to_string(),
-      gpu_test_result_path.to_string_lossy().into_owned(),
-    ])
-    .current_dir(exec_info.executable_dir);
+    .current_dir(exec_info.executable_dir)
+    .arg("-v")
+    .arg("--gpu-test")
+    .arg("opengl")
+    .arg("--gpu-test-out-path")
+    .arg(&result_path);
+
   #[cfg(windows)]
   {
+    use std::os::windows::process::CommandExt;
     command.creation_flags(0x08000000);
   }
-  let output = command.output()?;
-  match output.status.code() {
-    Some(code) => {
-      if code == 0 {
-        // Parse the JSON file
-        // Read the file
-        let content = match std::fs::read_to_string(gpu_test_result_path) {
-          Ok(content) => content,
-          Err(err) => {
-            log::error!("Unable to read {}: {}", gpu_test_result_path.display(), err);
-            return Err(CommandError::BinaryExecution(
-              "Unable to read gpu test result".to_owned(),
-            ));
-          }
-        };
 
-        // Serialize from json
-        match serde_json::from_str::<GPUTestOutput>(&content) {
-          Ok(test_results) => Ok(test_results),
-          Err(err) => {
-            log::error!("Unable to parse {}: {}", &content, err);
-            Err(CommandError::BinaryExecution(
-              "Unable to parse GPU test result".to_owned(),
-            ))
-          }
-        }
-      } else {
-        Err(CommandError::BinaryExecution(format!(
-          "GPU Test failed with a non-zero exit code: {:?}",
-          code
-        )))
-      }
-    }
-    None => Err(CommandError::BinaryExecution(
-      "GPU test failed, no exit-code returned".to_owned(),
-    )),
+  let output = command.output()?;
+  if !output.status.success() {
+    anyhow::bail!("GPU test failed: exit status {}", output.status);
   }
+
+  let context = tokio::fs::read_to_string(&result_path)
+    .await
+    .with_context(|| {
+      format!(
+        "Failed to read GPU test result file: {}",
+        result_path.display()
+      )
+    })?;
+
+  return serde_json::from_str::<GPUTestOutput>(&context).with_context(|| {
+    format!(
+      "Failed to parse GPU test result file: {}",
+      result_path.display()
+    )
+  });
 }


### PR DESCRIPTION
1. Refactored `run_game_gpu_test` to use `anyhow` + early returns: replaced nested `match` blocks with `?`, `bail!`, and `with_context`, and simplified command construction for cleaner, more readable error handling.
2. Simplified call site and eliminated unnecessary `String` allocations, reducing lines of code while preserving behavior.