### PR TITLE
Refactor util/process.rs

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -27,8 +27,6 @@ pub enum CommandError {
   #[error(transparent)]
   TauriEvent(#[from] tauri::Error),
   #[error("{0}")]
-  Installation(String),
-  #[error("{0}")]
   VersionManagement(String),
   #[error("{0}")]
   GameManagement(String),

--- a/src-tauri/src/commands/binaries.rs
+++ b/src-tauri/src/commands/binaries.rs
@@ -666,12 +666,13 @@ pub async fn launch_game(
   );
 
   let log_file = create_std_log_file(&app_handle, format!("game-{game_name}.log"), false)?;
+  let log_file_err = log_file.try_clone()?;
 
   let mut command = std::process::Command::new(exec_info.executable_path);
   command
     .args(args)
-    .stdout(log_file.try_clone().unwrap())
-    .stderr(log_file)
+    .stdout(log_file)
+    .stderr(log_file_err)
     .current_dir(exec_info.executable_dir);
   #[cfg(windows)]
   {

--- a/src-tauri/src/commands/binaries.rs
+++ b/src-tauri/src/commands/binaries.rs
@@ -8,7 +8,7 @@ use std::{
   str::FromStr,
   time::Instant,
 };
-use tokio::{io::AsyncWriteExt, process::Command};
+use tokio::process::Command;
 
 use log::{info, warn};
 use semver::Version;
@@ -217,36 +217,33 @@ pub async fn extract_and_validate_iso(
   let mut log_file =
     create_log_file(&app_handle, format!("extractor-{game_name}.log"), true).await?;
 
-  let process_status = watch_process(&mut log_file, &mut child, &app_handle).await?;
-  log_file.flush().await?;
-  match process_status.code() {
-    Some(code) => {
-      if code == 0 {
-        log::info!("extraction and validation was successful");
-        return Ok(InstallStepOutput {
-          success: true,
-          msg: None,
-        });
-      }
-      let error_code_map = get_error_codes(&config_info, game_name);
-      let default_error = LauncherErrorCode {
-        msg: format!("Unexpected error occured with code {code}"),
-      };
-      let message = error_code_map.get(&code).unwrap_or(&default_error);
-      log::error!("extraction and validation was not successful. Code {code}");
-      Ok(InstallStepOutput {
-        success: false,
-        msg: Some(message.msg.clone()),
-      })
-    }
-    None => {
-      log::error!("extraction and validation was not successful. No status code");
-      Ok(InstallStepOutput {
-        success: false,
-        msg: Some("Unexpected error occurred".to_owned()),
-      })
-    }
+  let status = watch_process(&mut log_file, &mut child, &app_handle).await?;
+  if status.success() {
+    log::info!("extraction and validation was successful");
+    return Ok(InstallStepOutput {
+      success: true,
+      msg: None,
+    });
   }
+
+  if let Some(code) = status.code() {
+    let error_code_map = get_error_codes(&config_info, game_name);
+    let default_error = LauncherErrorCode {
+      msg: format!("Unexpected error occured with code {code}"),
+    };
+    let message = error_code_map.get(&code).unwrap_or(&default_error);
+    log::error!("extraction and validation was not successful. Code {code}");
+    return Ok(InstallStepOutput {
+      success: false,
+      msg: Some(message.msg.clone()),
+    });
+  }
+
+  log::error!("extraction and validation was not successful. No status code");
+  Ok(InstallStepOutput {
+    success: false,
+    msg: Some("Unexpected error occurred".to_owned()),
+  })
 }
 
 #[tauri::command]
@@ -356,38 +353,33 @@ pub async fn run_decompiler(
   )
   .await?;
 
-  let process_status = watch_process(&mut log_file, &mut child, &app_handle).await?;
-
-  // Ensure all remaining data is flushed to the file
-  log_file.flush().await?;
-  match process_status.code() {
-    Some(code) => {
-      if code == 0 {
-        log::info!("decompilation was successful");
-        return Ok(InstallStepOutput {
-          success: true,
-          msg: None,
-        });
-      }
-      let error_code_map = get_error_codes(&config_info, game_name);
-      let default_error = LauncherErrorCode {
-        msg: format!("Unexpected error occured with code {code}"),
-      };
-      let message = error_code_map.get(&code).unwrap_or(&default_error);
-      log::error!("decompilation was not successful. Code {code}");
-      Ok(InstallStepOutput {
-        success: false,
-        msg: Some(message.msg.clone()),
-      })
-    }
-    None => {
-      log::error!("decompilation was not successful. No status code");
-      Ok(InstallStepOutput {
-        success: false,
-        msg: Some("Unexpected error occurred".to_owned()),
-      })
-    }
+  let status = watch_process(&mut log_file, &mut child, &app_handle).await?;
+  if status.success() {
+    log::info!("decompilation was successful");
+    return Ok(InstallStepOutput {
+      success: true,
+      msg: None,
+    });
   }
+
+  if let Some(code) = status.code() {
+    let error_code_map = get_error_codes(&config_info, game_name);
+    let default_error = LauncherErrorCode {
+      msg: format!("Unexpected error occured with code {code}"),
+    };
+    let message = error_code_map.get(&code).unwrap_or(&default_error);
+    log::error!("decompilation was not successful. Code {code}");
+    return Ok(InstallStepOutput {
+      success: false,
+      msg: Some(message.msg.clone()),
+    });
+  }
+
+  log::error!("decompilation was not successful. No status code");
+  Ok(InstallStepOutput {
+    success: false,
+    msg: Some("Unexpected error occurred".to_owned()),
+  })
 }
 
 #[tauri::command]
@@ -458,36 +450,33 @@ pub async fn run_compiler(
   )
   .await?;
 
-  let process_status = watch_process(&mut log_file, &mut child, &app_handle).await?;
-  log_file.flush().await?;
-  match process_status.code() {
-    Some(code) => {
-      if code == 0 {
-        log::info!("compilation was successful");
-        return Ok(InstallStepOutput {
-          success: true,
-          msg: None,
-        });
-      }
-      let error_code_map = get_error_codes(&config_info, game_name);
-      let default_error = LauncherErrorCode {
-        msg: format!("Unexpected error occured with code {code}"),
-      };
-      let message = error_code_map.get(&code).unwrap_or(&default_error);
-      log::error!("compilation was not successful. Code {code}");
-      Ok(InstallStepOutput {
-        success: false,
-        msg: Some(message.msg.clone()),
-      })
-    }
-    None => {
-      log::error!("compilation was not successful. No status code");
-      Ok(InstallStepOutput {
-        success: false,
-        msg: Some("Unexpected error occurred".to_owned()),
-      })
-    }
+  let status = watch_process(&mut log_file, &mut child, &app_handle).await?;
+  if status.success() {
+    log::info!("compilation was successful");
+    return Ok(InstallStepOutput {
+      success: true,
+      msg: None,
+    });
   }
+
+  if let Some(code) = status.code() {
+    let error_code_map = get_error_codes(&config_info, game_name);
+    let default_error = LauncherErrorCode {
+      msg: format!("Unexpected error occured with code {code}"),
+    };
+    let message = error_code_map.get(&code).unwrap_or(&default_error);
+    log::error!("compilation was not successful. Code {code}");
+    return Ok(InstallStepOutput {
+      success: false,
+      msg: Some(message.msg.clone()),
+    });
+  }
+
+  log::error!("compilation was not successful. No status code");
+  Ok(InstallStepOutput {
+    success: false,
+    msg: Some("Unexpected error occurred".to_owned()),
+  })
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -667,13 +667,14 @@ pub async fn launch_mod(
     format!("game-{game_name}-{mod_name}.log"),
     false,
   )?;
+  let log_file_err = log_file.try_clone()?;
 
   // TODO - log rotation here would be nice too
   let mut command = Command::new(exec_info.executable_path);
   command
     .args(args)
-    .stdout(log_file.try_clone().unwrap())
-    .stderr(log_file)
+    .stdout(log_file)
+    .stderr(log_file_err)
     .current_dir(exec_info.executable_dir);
   #[cfg(windows)]
   {

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -9,7 +9,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 use tauri::Emitter;
-use tokio::{io::AsyncWriteExt, process::Command};
+use tokio::process::Command;
 
 use crate::{
   cache::{LauncherCache, ModInfo},
@@ -337,33 +337,30 @@ pub async fn extract_iso_for_mod_install(
   )
   .await?;
 
-  let process_status = watch_process(&mut log_file, &mut child, &app_handle).await?;
-  match process_status.code() {
-    Some(code) => {
-      if code == 0 {
-        log::info!("extraction and validation was successful");
-        return Ok(InstallStepOutput {
-          success: true,
-          msg: None,
-        });
-      }
-      let default_error = LauncherErrorCode {
-        msg: format!("Unexpected error occured with code {code}"),
-      };
-      log::error!("extraction and validation was not successful. Code {code}");
-      Ok(InstallStepOutput {
-        success: false,
-        msg: Some(default_error.msg.clone()),
-      })
-    }
-    None => {
-      log::error!("extraction and validation was not successful. No status code");
-      Ok(InstallStepOutput {
-        success: false,
-        msg: Some("Unexpected error occurred".to_owned()),
-      })
-    }
+  let status = watch_process(&mut log_file, &mut child, &app_handle).await?;
+  if status.success() {
+    log::info!("extraction and validation was successful");
+    return Ok(InstallStepOutput {
+      success: true,
+      msg: None,
+    });
   }
+  if let Some(code) = status.code() {
+    let default_error = LauncherErrorCode {
+      msg: format!("Unexpected error occured with code {code}"),
+    };
+    log::error!("extraction and validation was not successful. Code {code}");
+    return Ok(InstallStepOutput {
+      success: false,
+      msg: Some(default_error.msg.clone()),
+    });
+  }
+
+  log::error!("extraction and validation was not successful. No status code");
+  Ok(InstallStepOutput {
+    success: false,
+    msg: Some("Unexpected error occurred".to_owned()),
+  })
 }
 
 #[tauri::command]
@@ -433,36 +430,31 @@ pub async fn decompile_for_mod_install(
   let mut log_file =
     create_log_file(&app_handle, format!("extractor-{game_name}.log"), false).await?;
 
-  let process_status = watch_process(&mut log_file, &mut child, &app_handle).await?;
-
-  // Ensure all remaining data is flushed to the file
-  log_file.flush().await?;
-  match process_status.code() {
-    Some(code) => {
-      if code == 0 {
-        log::info!("decompilation was successful");
-        return Ok(InstallStepOutput {
-          success: true,
-          msg: None,
-        });
-      }
-      let default_error = LauncherErrorCode {
-        msg: format!("Unexpected error occured with code {code}"),
-      };
-      log::error!("decompilation was not successful. Code {code}");
-      Ok(InstallStepOutput {
-        success: false,
-        msg: Some(default_error.msg.clone()),
-      })
-    }
-    None => {
-      log::error!("decompilation was not successful. No status code");
-      Ok(InstallStepOutput {
-        success: false,
-        msg: Some("Unexpected error occurred".to_owned()),
-      })
-    }
+  let status = watch_process(&mut log_file, &mut child, &app_handle).await?;
+  if status.success() {
+    log::info!("decompilation was successful");
+    return Ok(InstallStepOutput {
+      success: true,
+      msg: None,
+    });
   }
+
+  if let Some(code) = status.code() {
+    let default_error = LauncherErrorCode {
+      msg: format!("Unexpected error occured with code {code}"),
+    };
+    log::error!("decompilation was not successful. Code {code}");
+    return Ok(InstallStepOutput {
+      success: false,
+      msg: Some(default_error.msg.clone()),
+    });
+  }
+
+  log::error!("decompilation was not successful. No status code");
+  Ok(InstallStepOutput {
+    success: false,
+    msg: Some("Unexpected error occurred".to_owned()),
+  })
 }
 
 #[tauri::command]
@@ -532,34 +524,31 @@ pub async fn compile_for_mod_install(
   let mut log_file =
     create_log_file(&app_handle, format!("extractor-{game_name}.log"), false).await?;
 
-  let process_status = watch_process(&mut log_file, &mut child, &app_handle).await?;
-  log_file.flush().await?;
-  match process_status.code() {
-    Some(code) => {
-      if code == 0 {
-        log::info!("compilation was successful");
-        return Ok(InstallStepOutput {
-          success: true,
-          msg: None,
-        });
-      }
-      let default_error = LauncherErrorCode {
-        msg: format!("Unexpected error occured with code {code}"),
-      };
-      log::error!("compilation was not successful. Code {code}");
-      Ok(InstallStepOutput {
-        success: false,
-        msg: Some(default_error.msg.clone()),
-      })
-    }
-    None => {
-      log::error!("compilation was not successful. No status code");
-      Ok(InstallStepOutput {
-        success: false,
-        msg: Some("Unexpected error occurred".to_owned()),
-      })
-    }
+  let status = watch_process(&mut log_file, &mut child, &app_handle).await?;
+  if status.success() {
+    log::info!("compilation was successful");
+    return Ok(InstallStepOutput {
+      success: true,
+      msg: None,
+    });
   }
+
+  if let Some(code) = status.code() {
+    let default_error = LauncherErrorCode {
+      msg: format!("Unexpected error occured with code {code}"),
+    };
+    log::error!("compilation was not successful. Code {code}");
+    return Ok(InstallStepOutput {
+      success: false,
+      msg: Some(default_error.msg.clone()),
+    });
+  }
+
+  log::error!("compilation was not successful. No status code");
+  Ok(InstallStepOutput {
+    success: false,
+    msg: Some("Unexpected error occurred".to_owned()),
+  })
 }
 
 #[tauri::command]

--- a/src-tauri/src/util/process.rs
+++ b/src-tauri/src/util/process.rs
@@ -1,12 +1,10 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::process::ExitStatus;
 
 use tokio::{
-  io::{AsyncBufReadExt, AsyncWriteExt},
+  io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
   sync::mpsc,
 };
-
-use crate::commands::CommandError;
 
 use super::file::create_dir;
 use tauri::{Emitter, Manager};
@@ -40,49 +38,54 @@ pub async fn watch_process(
   log_file: &mut tokio::fs::File,
   child: &mut tokio::process::Child,
   app_handle: &tauri::AppHandle,
-) -> Result<ExitStatus, CommandError> {
-  let stdout = child.stdout.take().unwrap();
-  let stderr = child.stderr.take().unwrap();
+) -> Result<ExitStatus> {
+  let stdout = child.stdout.take().context("Child stdout was not piped")?;
+  let stderr = child.stderr.take().context("Child stderr was not piped")?;
+  let mut stdout_lines = BufReader::new(stdout).lines();
+  let mut stderr_lines = BufReader::new(stderr).lines();
 
-  let mut stdout_reader = tokio::io::BufReader::new(stdout).lines();
-  let mut stderr_reader = tokio::io::BufReader::new(stderr).lines();
-  let (log_sender, mut log_receiver) = mpsc::channel::<String>(200);
-  let app_handle_clone = app_handle.clone();
+  let (tx, mut rx) = mpsc::channel::<String>(200);
+  let app = app_handle.clone();
 
   tokio::spawn(async move {
-    while let Some(log) = log_receiver.recv().await {
-      let _ = app_handle_clone.emit("log_update", LogPayload { logs: log });
+    while let Some(log) = rx.recv().await {
+      let _ = app.emit("log_update", LogPayload { logs: log });
     }
   });
 
-  let process_status: ExitStatus;
-
   loop {
     tokio::select! {
-        Ok(Some(line)) = stdout_reader.next_line() => {
-          let formatted_line = format!("{line}\n").trim().to_string();
-          if formatted_line != "\n" {
-            log_sender.try_send(formatted_line.clone()).ok();
-            log_file.write_all(formatted_line.as_bytes()).await?;
-            log_file.flush().await?;
-          }
-        },
-        Ok(Some(line)) = stderr_reader.next_line() => {
-          let formatted_line = format!("{line}\n").trim().to_string();
-          if formatted_line != "\n" {
-            log_sender.try_send(formatted_line.clone()).ok();
-            log_file.write_all(formatted_line.as_bytes()).await?;
-            log_file.flush().await?;
-          }
-        },
-        status = child.wait() => {
-          process_status = status?;
-          drop(log_sender);
-          break;
+      line = stdout_lines.next_line() => {
+        if let Some(line) = line.context("Failed reading stdout")? {
+          handle_line(log_file, &tx, line).await?;
         }
+      }
+      line = stderr_lines.next_line() => {
+        if let Some(line) = line.context("Failed reading stderr")? {
+          handle_line(log_file, &tx, line).await?;
+        }
+      }
+      status = child.wait() => {
+        drop(tx);
+        log_file.flush().await.context("Failed flushing log file")?;
+        return Ok(status.context("Failed waiting for child process")?);
+      }
     }
   }
-  Ok(process_status)
+}
+
+async fn handle_line(
+  log_file: &mut tokio::fs::File,
+  tx: &mpsc::Sender<String>,
+  line: String,
+) -> Result<()> {
+  if line.trim().is_empty() {
+    return Ok(());
+  }
+  let _ = tx.try_send(line.clone());
+  log_file.write_all(line.as_bytes()).await?;
+  log_file.write_all(b"\n").await?;
+  Ok(())
 }
 
 pub fn create_std_log_file(

--- a/src-tauri/src/util/process.rs
+++ b/src-tauri/src/util/process.rs
@@ -1,6 +1,8 @@
+use anyhow::Result;
 use std::process::ExitStatus;
 
 use tokio::{
+  fs::OpenOptions,
   io::{AsyncBufReadExt, AsyncWriteExt},
   sync::mpsc,
 };
@@ -12,28 +14,22 @@ use tauri::{Emitter, Manager};
 
 pub async fn create_log_file(
   app_handle: &tauri::AppHandle,
-  name: String,
+  file_name: String,
   append: bool,
-) -> Result<tokio::fs::File, CommandError> {
-  let log_path = &match app_handle.path().app_log_dir() {
-    Ok(path) => path,
-    Err(_) => {
-      return Err(CommandError::Installation(
-        "Could not determine path to save installation logs".to_owned(),
-      ));
-    }
-  };
-  create_dir(log_path)?;
-  let mut file_options = tokio::fs::OpenOptions::new();
-  file_options.read(true);
-  file_options.create(true);
-  if append {
-    file_options.append(true);
-  } else {
-    file_options.write(true).truncate(true);
-  }
-  let file = file_options.open(log_path.join(name)).await?;
-  Ok(file)
+) -> Result<tokio::fs::File> {
+  let log_path = app_handle.path().app_log_dir()?;
+  let file_path = log_path.join(file_name);
+  create_dir(&log_path)?;
+
+  OpenOptions::new()
+    .read(true)
+    .create(true)
+    .append(append)
+    .write(!append)
+    .truncate(!append)
+    .open(file_path)
+    .await
+    .map_err(Into::into)
 }
 
 #[derive(Clone, serde::Serialize)]

--- a/src-tauri/src/util/process.rs
+++ b/src-tauri/src/util/process.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use std::process::ExitStatus;
 
 use tokio::{
-  fs::OpenOptions,
   io::{AsyncBufReadExt, AsyncWriteExt},
   sync::mpsc,
 };
@@ -21,7 +20,7 @@ pub async fn create_log_file(
   let file_path = log_path.join(file_name);
   create_dir(&log_path)?;
 
-  OpenOptions::new()
+  tokio::fs::OpenOptions::new()
     .read(true)
     .create(true)
     .append(append)
@@ -88,25 +87,18 @@ pub async fn watch_process(
 
 pub fn create_std_log_file(
   app_handle: &tauri::AppHandle,
-  name: String,
+  file_name: String,
   append: bool,
-) -> Result<std::fs::File, CommandError> {
-  let log_path = &match app_handle.path().app_log_dir() {
-    Ok(path) => path,
-    Err(_) => {
-      return Err(CommandError::Installation(
-        "Could not determine path to save installation logs".to_owned(),
-      ));
-    }
-  };
-  create_dir(log_path)?;
-  let mut file_options = std::fs::OpenOptions::new();
-  file_options.create(true);
-  if append {
-    file_options.append(true);
-  } else {
-    file_options.write(true).truncate(true);
-  }
-  let file = file_options.open(log_path.join(name))?;
-  Ok(file)
+) -> Result<std::fs::File> {
+  let log_path = app_handle.path().app_log_dir()?;
+  let file_path = log_path.join(&file_name);
+  create_dir(&log_path)?;
+
+  std::fs::OpenOptions::new()
+    .create(true)
+    .append(append)
+    .write(!append)
+    .truncate(!append)
+    .open(file_path)
+    .map_err(Into::into)
 }


### PR DESCRIPTION
1. use the builder pattern for creating the log files
2. avoid `upwrap()`
3. streamlined the control flow and reduced nesting where `watch_process` is called