### PR TITLE
Refactor features/mods

### DIFF
--- a/src-tauri/src/cache.rs
+++ b/src-tauri/src/cache.rs
@@ -121,11 +121,11 @@ pub struct ModSourceData {
   pub texture_packs: HashMap<String, ModInfo>,
 }
 
-pub struct LauncherCache {
+pub struct ModCache {
   pub mod_sources: HashMap<String, ModSourceData>,
 }
 
-impl LauncherCache {
+impl ModCache {
   pub fn default() -> Self {
     Self {
       mod_sources: HashMap::new(),

--- a/src-tauri/src/cache.rs
+++ b/src-tauri/src/cache.rs
@@ -1,19 +1,11 @@
 use std::collections::HashMap;
 
+use anyhow::{Context, Result};
 use log::error;
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
 use crate::{config::SupportedGame, util::network::download_json};
-
-#[derive(Debug, thiserror::Error)]
-pub enum CacheError {
-  #[error(transparent)]
-  Anyhow(#[from] anyhow::Error),
-  #[error("{0}")]
-  #[allow(dead_code)]
-  ModSource(String),
-}
 
 #[derive(Debug, Serialize, Deserialize, Clone, TS)]
 #[serde(rename_all = "camelCase")]
@@ -132,50 +124,48 @@ impl ModCache {
     }
   }
 
-  // TODO: this function is a beast and needs to be tackled later
-  pub async fn refresh_mod_sources(&mut self, sources: Vec<String>) -> Result<(), CacheError> {
-    self.mod_sources.clear();
-    for source in sources {
-      let source_json = download_json(&source).await?;
-      match serde_json::from_str(&source_json) {
-        Ok(json_value) => {
-          let source_schema_data: ModSourceDataSchema = json_value;
-          let source_name = source_schema_data.source_name.clone();
-          let source_mods_data = source_schema_data
-            .mods
-            .into_iter()
-            .map(|(mod_name, mod_info)| {
-              let mut info: ModInfo = mod_info.into();
-              info.name = mod_name;
-              info.source = source_name.clone();
-              (info.name.clone(), info)
-            })
-            .collect();
+  async fn refresh_mod_source(&mut self, url: String) -> Result<()> {
+    let source_json = download_json(&url).await?;
+    let schema: ModSourceDataSchema = serde_json::from_str(&source_json)
+      .with_context(|| format!("Failed to parse mod source JSON from {url}"))?;
 
-          let source_textures_data = source_schema_data
-            .texture_packs
-            .into_iter()
-            .map(|(mod_name, mod_info)| {
-              let mut info: ModInfo = mod_info.into();
-              info.name = mod_name;
-              info.source = source_name.clone();
-              (info.name.clone(), info)
-            })
-            .collect();
+    let source_name = schema.source_name.clone();
+    let mods = schema
+      .mods
+      .into_iter()
+      .map(|(name, schema)| (name, schema, source_name.clone()))
+      .map(ModInfo::from)
+      .map(|info| (info.name.clone(), info))
+      .collect();
 
-          let source_data = ModSourceData {
-            schema_version: source_schema_data.schema_version,
-            source_name: source_schema_data.source_name,
-            last_updated: source_schema_data.last_updated,
-            mods: source_mods_data,
-            texture_packs: source_textures_data,
-          };
+    let texture_packs = schema
+      .texture_packs
+      .into_iter()
+      .map(|(name, schema)| (name, schema, source_name.clone()))
+      .map(ModInfo::from)
+      .map(|info| (info.name.clone(), info))
+      .collect();
 
-          self.mod_sources.insert(source, source_data);
-        }
-        Err(err) => error!("Unable to convert {source_json} to typed value: {err:?}"),
-      }
-    }
+    self.mod_sources.insert(
+      url,
+      ModSourceData {
+        schema_version: schema.schema_version,
+        source_name: schema.source_name,
+        last_updated: schema.last_updated,
+        mods,
+        texture_packs,
+      },
+    );
     Ok(())
+  }
+
+  pub async fn refresh_mod_sources(&mut self, sources: Vec<String>) {
+    self.mod_sources.clear();
+    for url in sources {
+      self
+        .refresh_mod_source(url)
+        .await
+        .unwrap_or_else(|err| error!("{err:#}"));
+    }
   }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -22,8 +22,6 @@ pub enum CommandError {
   NetworkRequest(#[from] reqwest::Error),
   #[error("{0}")]
   Configuration(String),
-  #[error("{0}")]
-  Cache(String),
   #[error(transparent)]
   TauriEvent(#[from] tauri::Error),
   #[error("{0}")]

--- a/src-tauri/src/commands/cache.rs
+++ b/src-tauri/src/commands/cache.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::{
-  cache::{LauncherCache, ModSourceData},
+  cache::{ModCache, ModSourceData},
   config::LauncherConfig,
 };
 
@@ -9,7 +9,7 @@ use super::CommandError;
 
 #[tauri::command]
 pub async fn refresh_mod_sources(
-  cache: tauri::State<'_, tokio::sync::Mutex<LauncherCache>>,
+  cache: tauri::State<'_, tokio::sync::Mutex<ModCache>>,
   config: tauri::State<'_, tokio::sync::Mutex<LauncherConfig>>,
 ) -> Result<(), CommandError> {
   let mut cache_lock = cache.lock().await;
@@ -24,7 +24,7 @@ pub async fn refresh_mod_sources(
 
 #[tauri::command]
 pub async fn get_mod_sources_data(
-  cache: tauri::State<'_, tokio::sync::Mutex<LauncherCache>>,
+  cache: tauri::State<'_, tokio::sync::Mutex<ModCache>>,
 ) -> Result<HashMap<String, ModSourceData>, CommandError> {
   let cache_lock = cache.lock().await;
   Ok(cache_lock.mod_sources.clone())

--- a/src-tauri/src/commands/cache.rs
+++ b/src-tauri/src/commands/cache.rs
@@ -11,14 +11,11 @@ use super::CommandError;
 pub async fn refresh_mod_sources(
   cache: tauri::State<'_, tokio::sync::Mutex<ModCache>>,
   config: tauri::State<'_, tokio::sync::Mutex<LauncherConfig>>,
-) -> Result<(), CommandError> {
+) -> Result<(), ()> {
   let mut cache_lock = cache.lock().await;
   let config_lock = config.lock().await;
   let mod_sources = config_lock.mod_sources.clone();
-  cache_lock
-    .refresh_mod_sources(mod_sources)
-    .await
-    .map_err(|_| CommandError::Cache("Unable to refresh mod source cache".to_owned()))?;
+  cache_lock.refresh_mod_sources(mod_sources).await;
   Ok(())
 }
 

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -13,14 +13,13 @@ use tokio::process::Command;
 
 use crate::{
   cache::{LauncherCache, ModInfo},
-  commands::{CommandError, binaries::InstallStepOutput, cache::get_mod_sources_data},
+  commands::{CommandError, binaries::InstallStepOutput},
   config::{ExecutableLocation, LauncherConfig, SupportedGame},
   util::{
     file::{create_dir, delete_dir, to_image_base64},
     network::download_file,
     process::{create_log_file, create_std_log_file, watch_process},
-    tar::{extract_and_delete_tar_ball, extract_archive},
-    zip::extract_and_delete_zip_file,
+    tar::{extract_and_delete_archive, extract_archive},
   },
 };
 
@@ -68,68 +67,51 @@ pub async fn download_and_extract_new_mod(
   download_url: String,
   mod_name: String,
   source_name: String,
-) -> Result<InstallStepOutput, CommandError> {
-  let config_lock = config.lock().await;
-  let install_path = match &config_lock.installation_dir {
-    None => {
-      return Err(CommandError::GameFeatures(
-        "No installation directory set, can't download and extract mod".to_string(),
-      ));
-    }
-    Some(path) => Path::new(path),
+) -> Result<InstallStepOutput, String> {
+  let install_path = {
+    let config_lock = config.lock().await;
+    config_lock.install_dir()?
   };
 
   // Download the file
-  let parent_path = &install_path
+  let destination_dir = install_path
     .join("features")
     .join(game_name.to_string())
     .join("mods")
     .join(&source_name)
     .join(&mod_name);
-  let download_path = &parent_path.join(format!("{mod_name}.zip"));
+  let download_path = &destination_dir.join(format!("{mod_name}.zip"));
 
-  delete_dir(parent_path)?;
-  create_dir(parent_path)?;
-  download_file(&download_url, download_path).await?;
-
-  if cfg!(windows) {
-    extract_and_delete_zip_file(download_path, parent_path, false).map_err(|err| {
-      log::error!("Unable to extract mod: {}", err);
-      CommandError::GameFeatures(format!("Unable to extract mod: {}", err))
-    })?;
-  } else if cfg!(unix) {
-    extract_and_delete_tar_ball(download_path, parent_path)?;
-  } else {
-    Err(CommandError::VersionManagement(
-      "Unknown operating system, unable to download and extract mod".to_owned(),
-    ))?;
-  }
+  delete_dir(&destination_dir).map_err(|e| e.to_string())?;
+  create_dir(&destination_dir).map_err(|e| e.to_string())?;
+  download_file(&download_url, &download_path)
+    .await
+    .map_err(|e| e.to_string())?;
+  extract_and_delete_archive(&download_path, &destination_dir).map_err(|e| e.to_string())?;
 
   // Persist the info about the mod to the disk in the event that the mod source is removed / etc
-  let mod_source_data = get_mod_sources_data(cache).await;
-  match mod_source_data {
-    Ok(mod_source_data) => {
-      let relevant_mod_source = mod_source_data
-        .iter()
-        .find(|(_mod_source_url, mod_source_data)| mod_source_data.source_name == source_name);
-      if let Some(found_mode_source) = relevant_mod_source {
-        if let Some(mod_info) = found_mode_source.1.mods.get(&mod_name) {
-          let metadata_path = parent_path.join("_metadata.json");
-          log::info!("saving mod info to: {metadata_path:?}");
-          create_dir(&metadata_path.parent().unwrap())?;
-          let file = fs::File::create(metadata_path)?;
-          if let Err(err) = serde_json::to_writer_pretty(file, mod_info) {
-            log::error!("Unable to save _metadata.json file: {err:?}")
-          }
-        }
-      }
-    }
-    Err(err) => {
-      log::error!(
-        "Unable to fetch mod source data, so unable to persist metadata to disk: {err:?}"
-      );
-    }
-  }
+  let mod_info = {
+    let cache_lock = cache.lock().await;
+    cache_lock
+      .mod_sources
+      .iter()
+      .find(|(_, data)| data.source_name == source_name)
+      .and_then(|(_, source)| source.mods.get(&mod_name))
+      .cloned()
+      .ok_or_else(|| format!("Unable to find mod {} in source {}", mod_name, source_name))?
+  };
+
+  let metadata_path = destination_dir.join("_metadata.json");
+  let parent = metadata_path
+    .parent()
+    .ok_or_else(|| "Unable to get parent directory for mod metadata".to_owned())?;
+
+  create_dir(parent).map_err(|e| e.to_string())?;
+  let file = fs::File::create(&metadata_path).map_err(|e| e.to_string())?;
+
+  log::info!("saving mod info to: {}", &metadata_path.display());
+  serde_json::to_writer_pretty(file, &mod_info)
+    .map_err(|e| format!("Unable to save mod metadata: {}", e).to_string())?;
 
   Ok(InstallStepOutput {
     success: true,

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -30,7 +30,7 @@ pub async fn extract_new_mod(
   game_name: SupportedGame,
   bundle_path: PathBuf,
   mod_source: String,
-) -> Result<InstallStepOutput, String> {
+) -> Result<InstallStepOutput, CommandError> {
   let install_path = {
     let config_lock = config.lock().await;
     config_lock.install_dir()?
@@ -41,7 +41,7 @@ pub async fn extract_new_mod(
     .file_stem()
     .and_then(|stem| stem.to_str())
     .map(|s| s.strip_suffix(".tar").unwrap_or(s))
-    .ok_or_else(|| "Unable to get mod name from archive path".to_owned())?;
+    .ok_or_else(|| anyhow::anyhow!("Unable to get mod name from archive path"))?;
 
   let destination_dir = install_path
     .join("features")
@@ -50,9 +50,9 @@ pub async fn extract_new_mod(
     .join(mod_source)
     .join(&mod_name);
 
-  delete_dir(&destination_dir).map_err(|e| e.to_string())?;
-  create_dir(&destination_dir).map_err(|e| e.to_string())?;
-  extract_archive(&bundle_path, &destination_dir).map_err(|e| e.to_string())?;
+  delete_dir(&destination_dir)?;
+  create_dir(&destination_dir)?;
+  extract_archive(&bundle_path, &destination_dir)?;
 
   Ok(InstallStepOutput {
     success: true,
@@ -68,7 +68,7 @@ pub async fn download_and_extract_new_mod(
   download_url: String,
   mod_name: String,
   source_name: String,
-) -> Result<InstallStepOutput, String> {
+) -> Result<InstallStepOutput, CommandError> {
   let install_path = {
     let config_lock = config.lock().await;
     config_lock.install_dir()?
@@ -83,12 +83,10 @@ pub async fn download_and_extract_new_mod(
     .join(&mod_name);
   let download_path = &destination_dir.join(format!("{mod_name}.zip"));
 
-  delete_dir(&destination_dir).map_err(|e| e.to_string())?;
-  create_dir(&destination_dir).map_err(|e| e.to_string())?;
-  download_file(&download_url, &download_path)
-    .await
-    .map_err(|e| e.to_string())?;
-  extract_and_delete_archive(&download_path, &destination_dir).map_err(|e| e.to_string())?;
+  delete_dir(&destination_dir)?;
+  create_dir(&destination_dir)?;
+  download_file(&download_url, &download_path).await?;
+  extract_and_delete_archive(&download_path, &destination_dir)?;
 
   // Persist the info about the mod to the disk in the event that the mod source is removed / etc
   let mod_info = {
@@ -99,20 +97,20 @@ pub async fn download_and_extract_new_mod(
       .find(|(_, data)| data.source_name == source_name)
       .and_then(|(_, source)| source.mods.get(&mod_name))
       .cloned()
-      .ok_or_else(|| format!("Unable to find mod {} in source {}", mod_name, source_name))?
+      .ok_or_else(|| anyhow::anyhow!("Unable to find mod {} in source {}", mod_name, source_name))?
   };
 
   let metadata_path = destination_dir.join("_metadata.json");
   let parent = metadata_path
     .parent()
-    .ok_or_else(|| "Unable to get parent directory for mod metadata".to_owned())?;
+    .ok_or_else(|| anyhow::anyhow!("Unable to get parent directory for mod metadata"))?;
 
-  create_dir(parent).map_err(|e| e.to_string())?;
-  let file = fs::File::create(&metadata_path).map_err(|e| e.to_string())?;
+  create_dir(parent)?;
+  let file = fs::File::create(&metadata_path)?;
 
   log::info!("saving mod info to: {}", &metadata_path.display());
   serde_json::to_writer_pretty(file, &mod_info)
-    .map_err(|e| format!("Unable to save mod metadata: {}", e).to_string())?;
+    .map_err(|e| anyhow::anyhow!("Unable to save mod metadata: {}", e))?;
 
   Ok(InstallStepOutput {
     success: true,
@@ -126,7 +124,7 @@ pub async fn get_locally_persisted_mod_info(
   game_name: SupportedGame,
   mod_name: String,
   source_name: String,
-) -> Result<ModInfo, String> {
+) -> Result<ModInfo, CommandError> {
   let install_path = {
     let config_lock = config.lock().await;
     config_lock.install_dir()?
@@ -141,19 +139,21 @@ pub async fn get_locally_persisted_mod_info(
     .join("_metadata.json");
 
   if metadata_path.exists() {
-    let file = fs::File::open(metadata_path).map_err(|e| e.to_string())?;
+    let file = fs::File::open(metadata_path)?;
     let mod_info = serde_json::from_reader(file)
-      .map_err(|e| format!("Unable to deserialize local mod metadata: {}", e))?;
+      .map_err(|e| anyhow::anyhow!("Unable to deserialize local mod metadata: {}", e))?;
     return Ok(mod_info);
   }
-  Err("Locally persisted mod metadata does not exist".into())
+  Err(anyhow::anyhow!(
+    "Locally persisted mod metadata does not exist"
+  ))?
 }
 
 #[tauri::command]
 pub async fn base_game_iso_exists(
   config: tauri::State<'_, tokio::sync::Mutex<LauncherConfig>>,
   game_name: SupportedGame,
-) -> Result<bool, String> {
+) -> Result<bool, CommandError> {
   let install_path = {
     let config_lock = config.lock().await;
     config_lock.install_dir()?
@@ -215,15 +215,11 @@ pub async fn extract_iso_for_mod_install(
   source_name: String,
   path_to_iso: String,
 ) -> Result<InstallStepOutput, CommandError> {
-  let config_lock = config.lock().await;
-  let install_path = match &config_lock.installation_dir {
-    None => {
-      return Err(CommandError::GameFeatures(
-        "No installation directory set, can't extract mod".to_string(),
-      ));
-    }
-    Some(path) => Path::new(path),
+  let install_path = {
+    let config_lock = config.lock().await;
+    config_lock.install_dir()?
   };
+
   let exec_info = match get_mod_exec_location(
     &install_path,
     "extractor",
@@ -232,11 +228,13 @@ pub async fn extract_iso_for_mod_install(
     &source_name,
   ) {
     Ok(exec_info) => exec_info,
-    Err(_) => {
-      log::error!("extractor executable not found");
+    Err(e) => {
       return Ok(InstallStepOutput {
         success: false,
-        msg: Some("Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again.".to_string()),
+        msg: Some(format!(
+          "Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again. {}",
+          e
+        )),
       });
     }
   };
@@ -245,13 +243,12 @@ pub async fn extract_iso_for_mod_install(
     .join("active")
     .join(game_name.to_string())
     .join("data")
-    .join("iso_data")
-    .to_path_buf();
+    .join("iso_data");
 
   create_dir(&iso_extraction_dir)?;
 
   let args = vec![
-    path_to_iso.clone(),
+    path_to_iso,
     "--extract".to_string(),
     "--validate".to_string(),
     "--extract-path".to_string(),
@@ -290,21 +287,15 @@ pub async fn extract_iso_for_mod_install(
       msg: None,
     });
   }
-  if let Some(code) = status.code() {
-    let default_error = LauncherErrorCode {
-      msg: format!("Unexpected error occured with code {code}"),
-    };
-    log::error!("extraction and validation was not successful. Code {code}");
-    return Ok(InstallStepOutput {
-      success: false,
-      msg: Some(default_error.msg.clone()),
-    });
-  }
 
-  log::error!("extraction and validation was not successful. No status code");
+  let msg = status
+    .code()
+    .map(|code| format!("Unexpected error occurred with code {code}"))
+    .unwrap_or_else(|| "Unexpected error occurred".to_owned());
+
   Ok(InstallStepOutput {
     success: false,
-    msg: Some("Unexpected error occurred".to_owned()),
+    msg: Some(msg),
   })
 }
 
@@ -316,15 +307,11 @@ pub async fn decompile_for_mod_install(
   mod_name: String,
   source_name: String,
 ) -> Result<InstallStepOutput, CommandError> {
-  let config_lock = config.lock().await;
-  let install_path = match &config_lock.installation_dir {
-    None => {
-      return Err(CommandError::GameFeatures(
-        "No installation directory set, can't extract mod".to_string(),
-      ));
-    }
-    Some(path) => Path::new(path),
+  let install_path = {
+    let config_lock = config.lock().await;
+    config_lock.install_dir()?
   };
+
   let exec_info = match get_mod_exec_location(
     &install_path,
     "extractor",
@@ -333,11 +320,13 @@ pub async fn decompile_for_mod_install(
     &source_name,
   ) {
     Ok(exec_info) => exec_info,
-    Err(_) => {
-      log::error!("extractor executable not found");
+    Err(e) => {
       return Ok(InstallStepOutput {
         success: false,
-        msg: Some("Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again.".to_string()),
+        msg: Some(format!(
+          "Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again. {}",
+          e
+        )),
       });
     }
   };
@@ -347,8 +336,7 @@ pub async fn decompile_for_mod_install(
     .join(game_name.to_string())
     .join("data")
     .join("iso_data")
-    .join(game_name.to_string())
-    .to_path_buf();
+    .join(game_name.to_string());
 
   let args = vec![
     iso_dir.clone().to_string_lossy().into_owned(),
@@ -384,21 +372,14 @@ pub async fn decompile_for_mod_install(
     });
   }
 
-  if let Some(code) = status.code() {
-    let default_error = LauncherErrorCode {
-      msg: format!("Unexpected error occured with code {code}"),
-    };
-    log::error!("decompilation was not successful. Code {code}");
-    return Ok(InstallStepOutput {
-      success: false,
-      msg: Some(default_error.msg.clone()),
-    });
-  }
+  let msg = status
+    .code()
+    .map(|code| format!("Unexpected error occurred with code {code}"))
+    .unwrap_or_else(|| "Unexpected error occurred".to_owned());
 
-  log::error!("decompilation was not successful. No status code");
   Ok(InstallStepOutput {
     success: false,
-    msg: Some("Unexpected error occurred".to_owned()),
+    msg: Some(msg),
   })
 }
 
@@ -410,14 +391,9 @@ pub async fn compile_for_mod_install(
   mod_name: String,
   source_name: String,
 ) -> Result<InstallStepOutput, CommandError> {
-  let config_lock = config.lock().await;
-  let install_path = match &config_lock.installation_dir {
-    None => {
-      return Err(CommandError::GameFeatures(
-        "No installation directory set, can't extract mod".to_string(),
-      ));
-    }
-    Some(path) => Path::new(path),
+  let install_path = {
+    let config_lock = config.lock().await;
+    config_lock.install_dir()?
   };
   let exec_info = match get_mod_exec_location(
     &install_path,
@@ -427,11 +403,14 @@ pub async fn compile_for_mod_install(
     &source_name,
   ) {
     Ok(exec_info) => exec_info,
-    Err(_) => {
+    Err(e) => {
       log::error!("extractor executable not found");
       return Ok(InstallStepOutput {
         success: false,
-        msg: Some("Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again.".to_string()),
+        msg: Some(format!(
+          "Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again. {}",
+          e
+        )),
       });
     }
   };
@@ -441,8 +420,7 @@ pub async fn compile_for_mod_install(
     .join(game_name.to_string())
     .join("data")
     .join("iso_data")
-    .join(game_name.to_string())
-    .to_path_buf();
+    .join(game_name.to_string());
 
   let args = vec![
     iso_dir.clone().to_string_lossy().into_owned(),
@@ -478,21 +456,14 @@ pub async fn compile_for_mod_install(
     });
   }
 
-  if let Some(code) = status.code() {
-    let default_error = LauncherErrorCode {
-      msg: format!("Unexpected error occured with code {code}"),
-    };
-    log::error!("compilation was not successful. Code {code}");
-    return Ok(InstallStepOutput {
-      success: false,
-      msg: Some(default_error.msg.clone()),
-    });
-  }
+  let msg = status
+    .code()
+    .map(|code| format!("Unexpected error occurred with code {code}"))
+    .unwrap_or_else(|| "Unexpected error occurred".to_owned());
 
-  log::error!("compilation was not successful. No status code");
   Ok(InstallStepOutput {
     success: false,
-    msg: Some("Unexpected error occurred".to_owned()),
+    msg: Some(msg),
   })
 }
 
@@ -569,14 +540,9 @@ pub async fn launch_mod(
   mod_name: String,
   source_name: String,
 ) -> Result<(), CommandError> {
-  let config_lock = config.lock().await;
-  let install_path = match &config_lock.installation_dir {
-    None => {
-      return Err(CommandError::GameFeatures(
-        "No installation directory set, can't extract mod".to_string(),
-      ));
-    }
-    Some(path) => Path::new(path),
+  let install_path = {
+    let config_lock = config.lock().await;
+    config_lock.install_dir()?
   };
   let config_dir = install_path
     .join("features")
@@ -619,10 +585,9 @@ pub async fn get_local_mod_thumbnail_base64(
   game_name: SupportedGame,
   mod_name: String,
 ) -> Result<String, CommandError> {
-  let config_lock = config.lock().await;
-  let install_path = match &config_lock.installation_dir {
-    None => return Ok("".to_string()),
-    Some(path) => Path::new(path),
+  let install_path = {
+    let config_lock = config.lock().await;
+    config_lock.install_dir()?
   };
 
   let cover_path = install_path
@@ -646,14 +611,7 @@ pub async fn uninstall_mod(
   source_name: String,
 ) -> Result<(), CommandError> {
   let mut config_lock = config.lock().await;
-  let install_path = match &config_lock.installation_dir {
-    None => {
-      return Err(CommandError::GameFeatures(
-        "No installation directory set, can't extract mod".to_string(),
-      ));
-    }
-    Some(path) => Path::new(path),
-  };
+  let install_path = config_lock.install_dir()?;
   let mod_dir = install_path
     .join("features")
     .join(game_name.to_string())
@@ -683,14 +641,9 @@ pub async fn reset_mod_settings(
   mod_name: String,
   source_name: String,
 ) -> Result<(), CommandError> {
-  let config_lock = config.lock().await;
-  let install_path = match &config_lock.installation_dir {
-    None => {
-      return Err(CommandError::GameFeatures(
-        "No installation directory set, can't reset mod settings".to_string(),
-      ));
-    }
-    Some(path) => Path::new(path),
+  let install_path = {
+    let config_lock = config.lock().await;
+    config_lock.install_dir()?
   };
   let path_to_settings = install_path
     .join("features")
@@ -704,16 +657,16 @@ pub async fn reset_mod_settings(
     .join("settings")
     .join("pc-settings.gc");
 
-  if path_to_settings.exists() {
-    let mut backup_file = path_to_settings.clone();
-    backup_file.set_file_name("pc-settings.old.gc");
-    std::fs::rename(path_to_settings, backup_file)?;
-    Ok(())
-  } else {
-    Err(CommandError::GameFeatures(
+  if !path_to_settings.exists() {
+    return Err(CommandError::GameManagement(
       "Game config directory does not exist, cannot reset settings".to_owned(),
-    ))
+    ));
   }
+
+  let mut backup_file = path_to_settings.clone();
+  backup_file.set_file_name("pc-settings.old.gc");
+  std::fs::rename(path_to_settings, backup_file)?;
+  Ok(())
 }
 
 #[tauri::command]
@@ -723,14 +676,9 @@ pub async fn get_launch_mod_string(
   mod_name: String,
   source_name: String,
 ) -> Result<String, CommandError> {
-  let config_lock = config.lock().await;
-  let install_path = match &config_lock.installation_dir {
-    None => {
-      return Err(CommandError::GameFeatures(
-        "No installation directory set, can't extract mod".to_string(),
-      ));
-    }
-    Some(path) => Path::new(path),
+  let install_path = {
+    let config_lock = config.lock().await;
+    config_lock.install_dir()?
   };
   let exec_info = get_mod_exec_location(&install_path, "gk", game_name, &mod_name, &source_name)?;
   let config_dir = install_path
@@ -763,22 +711,17 @@ pub async fn open_repl_for_mod(
   mod_name: String,
   source_name: String,
 ) -> Result<(), CommandError> {
-  let config_lock = config.lock().await;
-  let install_path = match &config_lock.installation_dir {
-    None => {
-      return Err(CommandError::GameFeatures(
-        "No installation directory set, can't open REPL for mod".to_string(),
-      ));
-    }
-    Some(path) => Path::new(path),
+  let install_path = {
+    let config_lock = config.lock().await;
+    config_lock.install_dir()?
   };
   let iso_dir = install_path
     .join("active")
     .join(game_name.to_string())
     .join("data")
     .join("iso_data")
-    .join(game_name.to_string())
-    .to_path_buf();
+    .join(game_name.to_string());
+
   let exec_info =
     get_mod_exec_location(&install_path, "goalc", game_name, &mod_name, &source_name)?;
   let mut command;

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -33,11 +33,7 @@ pub async fn extract_new_mod(
 ) -> Result<InstallStepOutput, String> {
   let install_path = {
     let config_lock = config.lock().await;
-    config_lock
-      .installation_dir
-      .as_ref()
-      .cloned()
-      .ok_or_else(|| "No installation directory set, can't extract mod".to_owned())?
+    config_lock.install_dir()?
   };
 
   // The name of the zip becomes the folder, if one already exists it will be deleted!
@@ -150,11 +146,7 @@ pub async fn get_locally_persisted_mod_info(
 ) -> Result<ModInfo, String> {
   let install_path = {
     let config_lock = config.lock().await;
-    config_lock
-      .installation_dir
-      .as_ref()
-      .cloned()
-      .ok_or_else(|| "No installation directory set, can't get mod info".to_owned())?
+    config_lock.install_dir()?
   };
 
   let metadata_path = &install_path
@@ -181,13 +173,7 @@ pub async fn base_game_iso_exists(
 ) -> Result<bool, String> {
   let install_path = {
     let config_lock = config.lock().await;
-    config_lock
-      .installation_dir
-      .as_ref()
-      .cloned()
-      .ok_or_else(|| {
-        "No installation directory set, can't determine if base game ISO exists".to_owned()
-      })?
+    config_lock.install_dir()?
   };
   Ok(
     install_path

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -7,6 +7,7 @@ use std::{
   process::Stdio,
 };
 
+use anyhow::ensure;
 use serde::{Deserialize, Serialize};
 use tauri::Emitter;
 use tokio::process::Command;
@@ -169,32 +170,31 @@ pub async fn base_game_iso_exists(
 }
 
 fn get_mod_exec_location(
-  install_path: PathBuf,
+  install_path: &Path,
   executable_name: &str,
   game_name: SupportedGame,
   mod_name: &str,
   source_name: &str,
-) -> Result<ExecutableLocation, CommandError> {
+) -> anyhow::Result<ExecutableLocation> {
   let exec_dir = install_path
     .join("features")
     .join(game_name.to_string())
     .join("mods")
     .join(source_name)
     .join(mod_name);
-  let mut exec_path: PathBuf = exec_dir.join(executable_name);
-  if cfg!(windows) {
-    exec_path.set_extension("exe");
-  }
-  if !exec_path.exists() {
-    log::error!(
-      "Could not find the required binary '{}', can't perform operation",
-      exec_path.to_string_lossy()
-    );
-    return Err(CommandError::BinaryExecution(format!(
-      "Could not find the required binary '{}', can't perform operation",
-      exec_path.to_string_lossy()
-    )));
-  }
+
+  #[cfg(windows)]
+  let exec_path = exec_dir.join(executable_name).with_extension("exe");
+
+  #[cfg(not(windows))]
+  let exec_path = exec_dir.join(executable_name);
+
+  ensure!(
+    exec_path.exists(),
+    "Executable not found at expected path: {}",
+    exec_path.display()
+  );
+
   Ok(ExecutableLocation {
     executable_dir: exec_dir,
     executable_path: exec_path,
@@ -225,7 +225,7 @@ pub async fn extract_iso_for_mod_install(
     Some(path) => Path::new(path),
   };
   let exec_info = match get_mod_exec_location(
-    install_path.to_path_buf(),
+    &install_path,
     "extractor",
     game_name,
     &mod_name,
@@ -326,7 +326,7 @@ pub async fn decompile_for_mod_install(
     Some(path) => Path::new(path),
   };
   let exec_info = match get_mod_exec_location(
-    install_path.to_path_buf(),
+    &install_path,
     "extractor",
     game_name,
     &mod_name,
@@ -420,7 +420,7 @@ pub async fn compile_for_mod_install(
     Some(path) => Path::new(path),
   };
   let exec_info = match get_mod_exec_location(
-    install_path.to_path_buf(),
+    &install_path,
     "extractor",
     game_name,
     &mod_name,
@@ -585,13 +585,7 @@ pub async fn launch_mod(
     .join(&source_name)
     .join("_settings")
     .join(&mod_name);
-  let exec_info = get_mod_exec_location(
-    install_path.to_path_buf(),
-    "gk",
-    game_name,
-    &mod_name,
-    &source_name,
-  )?;
+  let exec_info = get_mod_exec_location(&install_path, "gk", game_name, &mod_name, &source_name)?;
   let args = generate_launch_mod_args(game_name, in_debug, config_dir, false)?;
 
   log::info!("Launching gk args: {:?}", args);
@@ -738,13 +732,7 @@ pub async fn get_launch_mod_string(
     }
     Some(path) => Path::new(path),
   };
-  let exec_info = get_mod_exec_location(
-    install_path.to_path_buf(),
-    "gk",
-    game_name,
-    &mod_name,
-    &source_name,
-  )?;
+  let exec_info = get_mod_exec_location(&install_path, "gk", game_name, &mod_name, &source_name)?;
   let config_dir = install_path
     .join("features")
     .join(game_name.to_string())
@@ -791,13 +779,8 @@ pub async fn open_repl_for_mod(
     .join("iso_data")
     .join(game_name.to_string())
     .to_path_buf();
-  let exec_info = get_mod_exec_location(
-    install_path.to_path_buf(),
-    "goalc",
-    game_name,
-    &mod_name,
-    &source_name,
-  )?;
+  let exec_info =
+    get_mod_exec_location(&install_path, "goalc", game_name, &mod_name, &source_name)?;
   let mut command;
   #[cfg(windows)]
   {

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -8,7 +8,6 @@ use std::{
 };
 
 use anyhow::ensure;
-use serde::{Deserialize, Serialize};
 use tauri::Emitter;
 use tokio::process::Command;
 
@@ -199,11 +198,6 @@ fn get_mod_exec_location(
     executable_dir: exec_dir,
     executable_path: exec_path,
   })
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct LauncherErrorCode {
-  msg: String,
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -13,7 +13,7 @@ use tauri::Emitter;
 use tokio::process::Command;
 
 use crate::{
-  cache::{LauncherCache, ModInfo},
+  cache::{ModCache, ModInfo},
   commands::{CommandError, binaries::InstallStepOutput},
   config::{ExecutableLocation, LauncherConfig, SupportedGame},
   util::{
@@ -63,7 +63,7 @@ pub async fn extract_new_mod(
 #[tauri::command]
 pub async fn download_and_extract_new_mod(
   config: tauri::State<'_, tokio::sync::Mutex<LauncherConfig>>,
-  cache: tauri::State<'_, tokio::sync::Mutex<LauncherCache>>,
+  cache: tauri::State<'_, tokio::sync::Mutex<ModCache>>,
   game_name: SupportedGame,
   download_url: String,
   mod_name: String,

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -19,67 +19,45 @@ use crate::{
     file::{create_dir, delete_dir, to_image_base64},
     network::download_file,
     process::{create_log_file, create_std_log_file, watch_process},
-    tar::{extract_and_delete_tar_ball, extract_tar_ball},
-    zip::{extract_and_delete_zip_file, extract_zip_file},
+    tar::{extract_and_delete_tar_ball, extract_archive},
+    zip::extract_and_delete_zip_file,
   },
 };
-
-fn strip_tar_gz(path: &String) -> String {
-  if path.ends_with(".tar") {
-    return path.strip_suffix(".tar").unwrap().to_string();
-  }
-  return path.to_string();
-}
 
 #[tauri::command]
 pub async fn extract_new_mod(
   config: tauri::State<'_, tokio::sync::Mutex<LauncherConfig>>,
   game_name: SupportedGame,
-  bundle_path: String,
+  bundle_path: PathBuf,
   mod_source: String,
-) -> Result<InstallStepOutput, CommandError> {
-  let config_lock = config.lock().await;
-  let install_path = match &config_lock.installation_dir {
-    None => {
-      return Err(CommandError::GameFeatures(
-        "No installation directory set, can't extract mod".to_string(),
-      ));
-    }
-    Some(path) => Path::new(path),
+) -> Result<InstallStepOutput, String> {
+  let install_path = {
+    let config_lock = config.lock().await;
+    config_lock
+      .installation_dir
+      .as_ref()
+      .cloned()
+      .ok_or_else(|| "No installation directory set, can't extract mod".to_owned())?
   };
 
   // The name of the zip becomes the folder, if one already exists it will be deleted!
-  let bundle_path_buf = PathBuf::from(bundle_path);
-  let mut mod_name = match bundle_path_buf.file_stem() {
-    Some(name) => name.to_string_lossy().to_string(),
-    None => {
-      return Err(CommandError::GameFeatures(
-        "Unable to get mod name from zip file path".to_string(),
-      ));
-    }
-  };
-  // .tar.gz files will only get the .gz portion stripped
-  mod_name = strip_tar_gz(&mod_name);
-  let destination_dir = &install_path
+  let mod_name = bundle_path
+    .file_stem()
+    .and_then(|stem| stem.to_str())
+    .map(|s| s.strip_suffix(".tar").unwrap_or(s))
+    .ok_or_else(|| "Unable to get mod name from archive path".to_owned())?;
+
+  let destination_dir = install_path
     .join("features")
     .join(game_name.to_string())
     .join("mods")
     .join(mod_source)
     .join(&mod_name);
-  delete_dir(destination_dir)?;
-  create_dir(destination_dir)?;
-  if cfg!(windows) {
-    extract_zip_file(&bundle_path_buf, destination_dir, false).map_err(|err| {
-      log::error!("Unable to extract mod: {}", err);
-      CommandError::GameFeatures(format!("Unable to extract mod: {}", err))
-    })?;
-  } else if cfg!(unix) {
-    extract_tar_ball(&bundle_path_buf, destination_dir)?;
-  } else {
-    Err(CommandError::VersionManagement(
-      "Unknown operating system, unable to download and extract mod".to_owned(),
-    ))?;
-  }
+
+  delete_dir(&destination_dir).map_err(|e| e.to_string())?;
+  create_dir(&destination_dir).map_err(|e| e.to_string())?;
+  extract_archive(&bundle_path, &destination_dir).map_err(|e| e.to_string())?;
+
   Ok(InstallStepOutput {
     success: true,
     msg: None,

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -147,16 +147,16 @@ pub async fn get_locally_persisted_mod_info(
   game_name: SupportedGame,
   mod_name: String,
   source_name: String,
-) -> Result<ModInfo, CommandError> {
-  let config_lock = config.lock().await;
-  let install_path = match &config_lock.installation_dir {
-    None => {
-      return Err(CommandError::GameFeatures(
-        "No installation directory set, can't find mod metadata".to_string(),
-      ));
-    }
-    Some(path) => Path::new(path),
+) -> Result<ModInfo, String> {
+  let install_path = {
+    let config_lock = config.lock().await;
+    config_lock
+      .installation_dir
+      .as_ref()
+      .cloned()
+      .ok_or_else(|| "No installation directory set, can't get mod info".to_owned())?
   };
+
   let metadata_path = &install_path
     .join("features")
     .join(game_name.to_string())
@@ -164,31 +164,30 @@ pub async fn get_locally_persisted_mod_info(
     .join(&source_name)
     .join(&mod_name)
     .join("_metadata.json");
+
   if metadata_path.exists() {
-    let file = fs::File::open(metadata_path)?;
-    let mod_info = serde_json::from_reader(file).map_err(|_| {
-      CommandError::GameFeatures("Unable to deserialize local mod metadata".to_string())
-    })?;
+    let file = fs::File::open(metadata_path).map_err(|e| e.to_string())?;
+    let mod_info = serde_json::from_reader(file)
+      .map_err(|e| format!("Unable to deserialize local mod metadata: {}", e))?;
     return Ok(mod_info);
   }
-  Err(CommandError::GameFeatures(
-    "Locally persisted mod metadata does not exist".to_string(),
-  ))
+  Err("Locally persisted mod metadata does not exist".into())
 }
 
 #[tauri::command]
 pub async fn base_game_iso_exists(
   config: tauri::State<'_, tokio::sync::Mutex<LauncherConfig>>,
   game_name: SupportedGame,
-) -> Result<bool, CommandError> {
-  let config_lock = config.lock().await;
-  let install_path = match &config_lock.installation_dir {
-    None => {
-      return Err(CommandError::GameFeatures(
-        "No installation directory set, can't extract mod".to_string(),
-      ));
-    }
-    Some(path) => Path::new(path),
+) -> Result<bool, String> {
+  let install_path = {
+    let config_lock = config.lock().await;
+    config_lock
+      .installation_dir
+      .as_ref()
+      .cloned()
+      .ok_or_else(|| {
+        "No installation directory set, can't determine if base game ISO exists".to_owned()
+      })?
   };
   Ok(
     install_path

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -602,6 +602,14 @@ impl LauncherConfig {
     Ok(())
   }
 
+  pub fn install_dir(&self) -> Result<PathBuf, String> {
+    self
+      .installation_dir
+      .as_ref()
+      .cloned()
+      .ok_or_else(|| "No installation directory set".to_owned())
+  }
+
   pub fn common_prelude(&self) -> Result<CommonConfigData, CommandError> {
     let install_path = self.installation_dir.as_ref().ok_or_else(|| {
       CommandError::BinaryExecution(

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -602,12 +602,12 @@ impl LauncherConfig {
     Ok(())
   }
 
-  pub fn install_dir(&self) -> Result<PathBuf, String> {
+  pub fn install_dir(&self) -> anyhow::Result<PathBuf> {
     self
       .installation_dir
       .as_ref()
       .cloned()
-      .ok_or_else(|| "No installation directory set".to_owned())
+      .ok_or_else(|| anyhow::anyhow!("No installation directory set"))
   }
 
   pub fn common_prelude(&self) -> Result<CommonConfigData, CommandError> {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -165,7 +165,7 @@ fn main() {
         app.path().app_config_dir().ok(),
       ));
       app.manage(config);
-      let cache = tokio::sync::Mutex::new(cache::LauncherCache::default());
+      let cache = tokio::sync::Mutex::new(cache::ModCache::default());
       app.manage(cache);
       Ok(())
     })

--- a/src-tauri/src/util/tar.rs
+++ b/src-tauri/src/util/tar.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use std::path::Path;
 
-use crate::util::zip::extract_zip_file;
+use crate::util::zip::{extract_and_delete_zip_file, extract_zip_file};
 
 pub fn extract_tar_ball(tar_path: impl AsRef<Path>, extract_dir: impl AsRef<Path>) -> Result<()> {
   let tar_path = tar_path.as_ref();
@@ -36,6 +36,14 @@ pub fn extract_archive(archive: &Path, dest: &Path) -> Result<()> {
   match archive.extension().and_then(|e| e.to_str()) {
     Some("zip") => extract_zip_file(archive, dest, false),
     Some("gz") => extract_tar_ball(archive, dest),
+    _ => anyhow::bail!("Unsupported archive format (expected .zip or .tar.gz)"),
+  }
+}
+
+pub fn extract_and_delete_archive(archive: &Path, dest: &Path) -> Result<()> {
+  match archive.extension().and_then(|e| e.to_str()) {
+    Some("zip") => extract_and_delete_zip_file(archive, dest, false),
+    Some("gz") => extract_and_delete_tar_ball(archive, dest),
     _ => anyhow::bail!("Unsupported archive format (expected .zip or .tar.gz)"),
   }
 }

--- a/src-tauri/src/util/tar.rs
+++ b/src-tauri/src/util/tar.rs
@@ -1,6 +1,8 @@
 use anyhow::{Context, Result};
 use std::path::Path;
 
+use crate::util::zip::extract_zip_file;
+
 pub fn extract_tar_ball(tar_path: impl AsRef<Path>, extract_dir: impl AsRef<Path>) -> Result<()> {
   let tar_path = tar_path.as_ref();
   let extract_dir = extract_dir.as_ref();
@@ -28,4 +30,12 @@ pub fn extract_and_delete_tar_ball(
   std::fs::remove_file(tar_path)
     .with_context(|| format!("failed to delete: {}", tar_path.display()))?;
   Ok(())
+}
+
+pub fn extract_archive(archive: &Path, dest: &Path) -> Result<()> {
+  match archive.extension().and_then(|e| e.to_str()) {
+    Some("zip") => extract_zip_file(archive, dest, false),
+    Some("gz") => extract_tar_ball(archive, dest),
+    _ => anyhow::bail!("Unsupported archive format (expected .zip or .tar.gz)"),
+  }
 }

--- a/src-tauri/src/util/zip.rs
+++ b/src-tauri/src/util/zip.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use log::info;
 use std::io::{BufReader, Cursor};
-use std::path::PathBuf;
 use std::{
   fs::File,
   io::{Read, Write},
@@ -105,12 +104,12 @@ pub fn extract_zip_file(
 }
 
 pub fn extract_and_delete_zip_file(
-  zip_path: &PathBuf,
+  zip_path: impl AsRef<Path>,
   extract_dir: &Path,
   strip_top_dir: bool,
 ) -> Result<()> {
-  extract_zip_file(zip_path, extract_dir, strip_top_dir)?;
-  std::fs::remove_file(zip_path)?;
+  extract_zip_file(&zip_path, extract_dir, strip_top_dir)?;
+  std::fs::remove_file(&zip_path)?;
   Ok(())
 }
 

--- a/src-tauri/src/util/zip.rs
+++ b/src-tauri/src/util/zip.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use log::info;
 use std::io::{BufReader, Cursor};
 use std::path::PathBuf;
@@ -94,10 +95,10 @@ pub fn append_file_to_zip(
 }
 
 pub fn extract_zip_file(
-  zip_path: &PathBuf,
+  zip_path: impl AsRef<Path>,
   extract_dir: &Path,
   strip_top_dir: bool,
-) -> Result<(), zip_extract::ZipExtractError> {
+) -> Result<()> {
   let archive: Vec<u8> = std::fs::read(zip_path)?;
   zip_extract::extract(Cursor::new(archive), extract_dir, strip_top_dir)?;
   Ok(())
@@ -107,7 +108,7 @@ pub fn extract_and_delete_zip_file(
   zip_path: &PathBuf,
   extract_dir: &Path,
   strip_top_dir: bool,
-) -> Result<(), zip_extract::ZipExtractError> {
+) -> Result<()> {
   extract_zip_file(zip_path, extract_dir, strip_top_dir)?;
   std::fs::remove_file(zip_path)?;
   Ok(())
@@ -116,7 +117,7 @@ pub fn extract_and_delete_zip_file(
 pub fn check_if_zip_contains_top_level_entry<P: AsRef<Path>>(
   path: P,
   expected: &str,
-) -> Result<bool, Box<dyn std::error::Error>> {
+) -> Result<bool> {
   let file = File::open(path)?;
   let reader = BufReader::new(file);
   let mut zip = zip::ZipArchive::new(reader)?;


### PR DESCRIPTION
- Refactor mods error handling to use `anyhow::Result` and simplify error propagation
- Reduce duplication in mod install/extraction logic by introducing shared archive helpers `extract_archive` and `extract_and_delete_archive`
- Reduce nested mod cache refresh logic, and rename `LauncherCache` to `ModCache` for clarity