### PR TITLE
Refactor fn download_file

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -29,8 +29,6 @@ pub enum CommandError {
   #[error("{0}")]
   GameManagement(String),
   #[error("{0}")]
-  OSOperation(String),
-  #[error("{0}")]
   WindowManagement(String),
   #[error("{0}")]
   BinaryExecution(String),

--- a/src-tauri/src/commands/download.rs
+++ b/src-tauri/src/commands/download.rs
@@ -1,20 +1,11 @@
 use std::path::PathBuf;
 
-use crate::util::{file::create_dir, network};
+use crate::util::network;
 
 use super::CommandError;
 
-// TODO: Finish refactoring this function to use anyhow result, after refactoring download_file
 #[tauri::command]
 pub async fn download_file(url: String, destination: PathBuf) -> Result<(), CommandError> {
-  if let Some(parent) = destination.parent() {
-    create_dir(parent)?;
-    network::download_file(&url, &destination).await?;
-    Ok(())
-  } else {
-    return Err(CommandError::OSOperation(
-      "Destination path has no parent directory".to_owned(),
-    ));
-    // TODO: anyhow::bail!("Destination path has no parent directory")
-  }
+  network::download_file(&url, &destination).await?;
+  Ok(())
 }

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -16,7 +16,7 @@ use crate::{
   commands::{CommandError, binaries::InstallStepOutput},
   config::{ExecutableLocation, LauncherConfig, SupportedGame},
   util::{
-    file::{create_dir, delete_dir, to_image_base64},
+    file::{delete_dir, to_image_base64},
     network::download_file,
     process::{create_log_file, create_std_log_file, watch_process},
     tar::{extract_and_delete_archive, extract_archive},
@@ -50,7 +50,6 @@ pub async fn extract_new_mod(
     .join(&mod_name);
 
   delete_dir(&destination_dir)?;
-  create_dir(&destination_dir)?;
   extract_archive(&bundle_path, &destination_dir)?;
 
   Ok(InstallStepOutput {
@@ -83,7 +82,6 @@ pub async fn download_and_extract_new_mod(
   let download_path = &destination_dir.join(format!("{mod_name}.zip"));
 
   delete_dir(&destination_dir)?;
-  create_dir(&destination_dir)?;
   download_file(&download_url, &download_path).await?;
   extract_and_delete_archive(&download_path, &destination_dir)?;
 
@@ -100,11 +98,6 @@ pub async fn download_and_extract_new_mod(
   };
 
   let metadata_path = destination_dir.join("_metadata.json");
-  let parent = metadata_path
-    .parent()
-    .ok_or_else(|| anyhow::anyhow!("Unable to get parent directory for mod metadata"))?;
-
-  create_dir(parent)?;
   let file = fs::File::create(&metadata_path)?;
 
   log::info!("saving mod info to: {}", &metadata_path.display());
@@ -238,8 +231,6 @@ pub async fn extract_iso_for_mod_install(
     .join(game_name.to_string())
     .join("data")
     .join("iso_data");
-
-  create_dir(&iso_extraction_dir)?;
 
   let args = vec![
     path_to_iso,

--- a/src-tauri/src/commands/versions.rs
+++ b/src-tauri/src/commands/versions.rs
@@ -6,9 +6,7 @@ use serde_json::Value;
 use crate::{
   config::LauncherConfig,
   util::{
-    file::{create_dir, delete_dir},
-    network::download_file,
-    tar::extract_and_delete_tar_ball,
+    file::delete_dir, network::download_file, tar::extract_and_delete_tar_ball,
     zip::extract_and_delete_zip_file,
   },
 };
@@ -85,9 +83,8 @@ pub async fn download_version(
     .join(&version_folder)
     .join(&version);
 
-  // Delete the directory if it exists, and create it from scratch
+  // Delete the directory if it exists
   delete_dir(&dest_dir)?;
-  create_dir(&dest_dir)?;
 
   if cfg!(windows) {
     let download_path = install_path

--- a/src-tauri/src/util/file.rs
+++ b/src-tauri/src/util/file.rs
@@ -14,13 +14,9 @@ pub fn delete_dir(path: impl AsRef<Path>) -> Result<()> {
   Ok(())
 }
 
-pub fn create_dir(path: impl AsRef<Path>) -> Result<()> {
-  let path = path.as_ref();
-  if !path.exists() {
-    std::fs::create_dir_all(path)
-      .with_context(|| format!("Failed to create directory: {}", path.display()))?;
-  }
-  Ok(())
+pub fn create_dir(path: &Path) -> Result<()> {
+  std::fs::create_dir_all(path)
+    .with_context(|| format!("Failed to create directory: {}", path.display()))
 }
 
 pub fn overwrite_dir(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<()> {

--- a/src-tauri/src/util/network.rs
+++ b/src-tauri/src/util/network.rs
@@ -3,15 +3,18 @@ use std::path::Path;
 use tokio;
 use tokio::io::AsyncWriteExt;
 
-pub async fn download_file(url: &str, destination: impl AsRef<Path>) -> Result<()> {
-  let destination = destination.as_ref();
+pub async fn download_file(url: &str, destination: &Path) -> Result<()> {
+  if let Some(parent) = destination.parent() {
+    tokio::fs::create_dir_all(parent).await?;
+  }
+
   let mut response = reqwest::get(url)
     .await
     .with_context(|| format!("Failed to download file from: {url}"))?
     .error_for_status()
     .with_context(|| format!("Server returned error for {url}"))?;
 
-  let mut file = tokio::fs::File::create(&destination)
+  let mut file = tokio::fs::File::create(destination)
     .await
     .with_context(|| {
       format!(

--- a/src-tauri/src/util/tar.rs
+++ b/src-tauri/src/util/tar.rs
@@ -33,17 +33,19 @@ pub fn extract_and_delete_tar_ball(
 }
 
 pub fn extract_archive(archive: &Path, dest: &Path) -> Result<()> {
-  match archive.extension().and_then(|e| e.to_str()) {
-    Some("zip") => extract_zip_file(archive, dest, false),
-    Some("gz") => extract_tar_ball(archive, dest),
+  std::fs::create_dir_all(dest)?;
+  match archive.file_name().and_then(|n| n.to_str()) {
+    Some(name) if name.ends_with(".zip") => extract_zip_file(archive, dest, false),
+    Some(name) if name.ends_with(".tar.gz") => extract_tar_ball(archive, dest),
     _ => anyhow::bail!("Unsupported archive format (expected .zip or .tar.gz)"),
   }
 }
 
 pub fn extract_and_delete_archive(archive: &Path, dest: &Path) -> Result<()> {
-  match archive.extension().and_then(|e| e.to_str()) {
-    Some("zip") => extract_and_delete_zip_file(archive, dest, false),
-    Some("gz") => extract_and_delete_tar_ball(archive, dest),
+  std::fs::create_dir_all(dest)?;
+  match archive.file_name().and_then(|n| n.to_str()) {
+    Some(name) if name.ends_with(".zip") => extract_and_delete_zip_file(archive, dest, false),
+    Some(name) if name.ends_with(".tar.gz") => extract_and_delete_tar_ball(archive, dest),
     _ => anyhow::bail!("Unsupported archive format (expected .zip or .tar.gz)"),
   }
 }

--- a/src-tauri/src/util/tar.rs
+++ b/src-tauri/src/util/tar.rs
@@ -34,18 +34,18 @@ pub fn extract_and_delete_tar_ball(
 
 pub fn extract_archive(archive: &Path, dest: &Path) -> Result<()> {
   std::fs::create_dir_all(dest)?;
-  match archive.file_name().and_then(|n| n.to_str()) {
-    Some(name) if name.ends_with(".zip") => extract_zip_file(archive, dest, false),
-    Some(name) if name.ends_with(".tar.gz") => extract_tar_ball(archive, dest),
+  match archive.extension().and_then(|e| e.to_str()) {
+    Some("zip") => extract_zip_file(archive, dest, false),
+    Some("gz") => extract_tar_ball(archive, dest),
     _ => anyhow::bail!("Unsupported archive format (expected .zip or .tar.gz)"),
   }
 }
 
 pub fn extract_and_delete_archive(archive: &Path, dest: &Path) -> Result<()> {
   std::fs::create_dir_all(dest)?;
-  match archive.file_name().and_then(|n| n.to_str()) {
-    Some(name) if name.ends_with(".zip") => extract_and_delete_zip_file(archive, dest, false),
-    Some(name) if name.ends_with(".tar.gz") => extract_and_delete_tar_ball(archive, dest),
+  match archive.extension().and_then(|e| e.to_str()) {
+    Some("zip") => extract_and_delete_zip_file(archive, dest, false),
+    Some("gz") => extract_and_delete_tar_ball(archive, dest),
     _ => anyhow::bail!("Unsupported archive format (expected .zip or .tar.gz)"),
   }
 }


### PR DESCRIPTION
- moves `create_dir_all` into the functions `download_file` and `extract_archive` because the behavior is paired, simplifying usage at each call site