### PR TITLE
refactor download_version

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -24,8 +24,6 @@ pub enum CommandError {
   #[error(transparent)]
   TauriEvent(#[from] tauri::Error),
   #[error("{0}")]
-  VersionManagement(String),
-  #[error("{0}")]
   GameManagement(String),
   #[error("{0}")]
   WindowManagement(String),

--- a/src-tauri/src/commands/versions.rs
+++ b/src-tauri/src/commands/versions.rs
@@ -29,34 +29,16 @@ pub async fn download_version(
     .join(&version_folder);
   let dest_dir = versions_dir.join(&version);
 
-  #[cfg(target_os = "windows")]
-  let (download_path, expected_extractor_path) = (
-    versions_dir.join(format!("{version}.zip")),
-    dest_dir.join("extractor.exe"),
-  );
+  #[cfg(windows)]
+  let download_path = versions_dir.join(format!("{version}.zip"));
 
   #[cfg(unix)]
-  let (download_path, expected_extractor_path) = (
-    versions_dir.join(format!("{version}.tar.gz")),
-    dest_dir.join("extractor"),
-  );
+  let download_path = versions_dir.join(format!("{version}.tar.gz"));
 
   delete_dir(&dest_dir)?;
   download_file(&url, &download_path).await?;
   extract_and_delete_archive(&download_path, &dest_dir, true)?;
-
-  if !expected_extractor_path.exists() {
-    log::error!(
-      "Version did not extract properly, {} is missing!",
-      expected_extractor_path.display()
-    );
-    delete_dir(&dest_dir)?;
-    return Err(CommandError::VersionManagement(
-    "Version did not extract properly, critical files are missing. An antivirus may have deleted the files!"
-      .to_owned(),
-  ));
-  }
-  return Ok(());
+  Ok(())
 }
 
 #[tauri::command]


### PR DESCRIPTION
Follow up of a previous pull request. I removed the redundant extractor exists check from `download_version`. If the extractor doesn't exist then `binaries::extract_and_validate_iso` will fail and display the correct error.