### PR TITLE
Refactor binaries.rs, texture_packs.rs, toast

### DIFF
--- a/src-tauri/src/commands/binaries.rs
+++ b/src-tauri/src/commands/binaries.rs
@@ -129,13 +129,13 @@ pub async fn extract_and_validate_iso(
 ) -> Result<(), CommandError> {
   let config_lock = config.lock().await;
   let config_info = config_lock.common_prelude()?;
-
   let data_folder = get_data_dir(&config_info, game_name, true)?;
+  let exec_info = config_info.get_exec_location("extractor")?;
+
   log::info!(
     "extracting using data folder: {}",
     data_folder.to_string_lossy()
   );
-  let exec_info = config_info.get_exec_location("extractor")?;
 
   let mut args = vec![
     path_to_iso.clone(),
@@ -218,35 +218,6 @@ pub async fn run_decompiler(
 
   let mut command = Command::new(exec_info.executable_path);
 
-  let mut decomp_config_overrides = vec![];
-  if use_decomp_settings {
-    let decomp_settings = &config_lock.decompiler_settings;
-    if decomp_settings.rip_levels_enabled {
-      decomp_config_overrides.push(format!(
-        "\"rip_levels\": {}",
-        decomp_settings.rip_levels_enabled
-      ));
-    }
-    if decomp_settings.rip_collision_enabled {
-      decomp_config_overrides.push(format!(
-        "\"rip_collision\": {}",
-        decomp_settings.rip_collision_enabled
-      ));
-    }
-    if decomp_settings.rip_textures_enabled {
-      decomp_config_overrides.push(format!(
-        "\"save_texture_pngs\": {}",
-        decomp_settings.rip_textures_enabled
-      ));
-    }
-    if decomp_settings.rip_streamed_audio_enabled {
-      decomp_config_overrides.push(format!(
-        "\"rip_streamed_audio\": {}",
-        decomp_settings.rip_streamed_audio_enabled
-      ));
-    }
-  }
-
   let mut args = vec![
     source_path,
     "--decompile".to_string(),
@@ -260,9 +231,25 @@ pub async fn run_decompiler(
     args.push(game_name.to_string());
   }
 
-  if !decomp_config_overrides.is_empty() {
-    args.push("--decomp-config-override".to_string());
-    args.push(format!("{{{}}}", decomp_config_overrides.join(", ")));
+  if use_decomp_settings {
+    let settings = &config_lock.decompiler_settings;
+    let mut overrides = serde_json::Map::new();
+
+    for (key, enabled) in [
+      ("rip_levels", settings.rip_levels_enabled),
+      ("rip_collision", settings.rip_collision_enabled),
+      ("save_texture_pngs", settings.rip_textures_enabled),
+      ("rip_streamed_audio", settings.rip_streamed_audio_enabled),
+    ] {
+      if enabled {
+        overrides.insert(key.to_string(), true.into());
+      }
+    }
+
+    if !overrides.is_empty() {
+      args.push("--decomp-config-override".to_string());
+      args.push(serde_json::Value::Object(overrides).to_string());
+    }
   }
 
   log::info!("Running extractor with args: {:?}", args);

--- a/src-tauri/src/commands/binaries.rs
+++ b/src-tauri/src/commands/binaries.rs
@@ -36,13 +36,6 @@ struct LauncherErrorCode {
   msg: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct InstallStepOutput {
-  pub success: bool,
-  pub msg: Option<String>,
-}
-
 #[cfg(windows)]
 fn format_exit_code(code: i32) -> String {
   format!("{code} ({:#010X})", code as u32)
@@ -126,16 +119,11 @@ fn get_data_dir(
 pub async fn update_data_directory(
   config: tauri::State<'_, tokio::sync::Mutex<LauncherConfig>>,
   game_name: SupportedGame,
-) -> Result<InstallStepOutput, CommandError> {
+) -> Result<(), CommandError> {
   let config_lock = config.lock().await;
   let config_info = config_lock.common_prelude()?;
-
   copy_data_dir(&config_info, game_name)?;
-
-  Ok(InstallStepOutput {
-    success: true,
-    msg: None,
-  })
+  Ok(())
 }
 
 #[tauri::command]
@@ -144,7 +132,7 @@ pub async fn extract_and_validate_iso(
   app_handle: tauri::AppHandle,
   path_to_iso: String,
   game_name: SupportedGame,
-) -> Result<InstallStepOutput, CommandError> {
+) -> Result<(), CommandError> {
   let config_lock = config.lock().await;
   let config_info = config_lock.common_prelude()?;
 
@@ -157,10 +145,9 @@ pub async fn extract_and_validate_iso(
     Ok(exec_info) => exec_info,
     Err(_) => {
       error!("extractor executable not found");
-      return Ok(InstallStepOutput {
-        success: false,
-        msg: Some("Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again.".to_string()),
-      });
+      return Err(CommandError::BinaryExecution(format!(
+        "Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again."
+      )));
     }
   };
 
@@ -201,26 +188,19 @@ pub async fn extract_and_validate_iso(
   let status = watch_process(&mut log_file, &mut child, &app_handle).await?;
   if status.success() {
     log::info!("extraction and validation was successful");
-    return Ok(InstallStepOutput {
-      success: true,
-      msg: None,
-    });
+    return Ok(());
   }
 
   if let Some(code) = status.code() {
     let message = get_error_code_message(&config_info, game_name, code);
     error!("extraction and validation was not successful. Code {code}");
-    return Ok(InstallStepOutput {
-      success: false,
-      msg: Some(message),
-    });
+    return Err(CommandError::BinaryExecution(message));
   }
 
   error!("extraction and validation was not successful. No status code");
-  Ok(InstallStepOutput {
-    success: false,
-    msg: Some("Unexpected error occurred".to_owned()),
-  })
+  return Err(CommandError::BinaryExecution(
+    "Unexpected error occurred".to_owned(),
+  ));
 }
 
 #[tauri::command]
@@ -231,7 +211,7 @@ pub async fn run_decompiler(
   game_name: SupportedGame,
   truncate_logs: bool,
   use_decomp_settings: bool,
-) -> Result<InstallStepOutput, CommandError> {
+) -> Result<(), CommandError> {
   let config_lock = config.lock().await;
   let config_info = config_lock.common_prelude()?;
 
@@ -244,10 +224,7 @@ pub async fn run_decompiler(
     Ok(exec_info) => exec_info,
     Err(_) => {
       error!("extractor executable not found");
-      return Ok(InstallStepOutput {
-        success: false,
-        msg: Some("Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again.".to_string()),
-      });
+      return Err(CommandError::BinaryExecution("Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again.".to_string()));
     }
   };
 
@@ -332,26 +309,19 @@ pub async fn run_decompiler(
   let status = watch_process(&mut log_file, &mut child, &app_handle).await?;
   if status.success() {
     log::info!("decompilation was successful");
-    return Ok(InstallStepOutput {
-      success: true,
-      msg: None,
-    });
+    return Ok(());
   }
 
   if let Some(code) = status.code() {
     let message = get_error_code_message(&config_info, game_name, code);
     error!("decompilation was not successful. Code {code}");
-    return Ok(InstallStepOutput {
-      success: false,
-      msg: Some(message),
-    });
+    return Err(CommandError::BinaryExecution(message));
   }
 
   error!("decompilation was not successful. No status code");
-  Ok(InstallStepOutput {
-    success: false,
-    msg: Some("Unexpected error occurred".to_owned()),
-  })
+  return Err(CommandError::BinaryExecution(
+    "Unexpected error occurred".to_owned(),
+  ));
 }
 
 #[tauri::command]
@@ -361,7 +331,7 @@ pub async fn run_compiler(
   path_to_iso: Option<String>,
   game_name: SupportedGame,
   truncate_logs: bool,
-) -> Result<InstallStepOutput, CommandError> {
+) -> Result<(), CommandError> {
   let config_lock = config.lock().await;
   let config_info = config_lock.common_prelude()?;
 
@@ -373,10 +343,9 @@ pub async fn run_compiler(
   let exec_info = match config_info.get_exec_location("extractor") {
     Ok(exec_info) => exec_info,
     Err(_) => {
-      return Ok(InstallStepOutput {
-        success: false,
-        msg: Some("Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again.".to_string()),
-      })
+      return Err(CommandError::BinaryExecution(format!(
+        "Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again."
+      )));
     }
   };
 
@@ -424,26 +393,19 @@ pub async fn run_compiler(
   let status = watch_process(&mut log_file, &mut child, &app_handle).await?;
   if status.success() {
     log::info!("compilation was successful");
-    return Ok(InstallStepOutput {
-      success: true,
-      msg: None,
-    });
+    return Ok(());
   }
 
   if let Some(code) = status.code() {
     let message = get_error_code_message(&config_info, game_name, code);
     error!("compilation was not successful. Code {code}");
-    return Ok(InstallStepOutput {
-      success: false,
-      msg: Some(message),
-    });
+    return Err(CommandError::BinaryExecution(message));
   }
 
   error!("compilation was not successful. No status code");
-  Ok(InstallStepOutput {
-    success: false,
-    msg: Some("Unexpected error occurred".to_owned()),
-  })
+  return Err(CommandError::BinaryExecution(
+    "Unexpected error occurred".to_owned(),
+  ));
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/binaries.rs
+++ b/src-tauri/src/commands/binaries.rs
@@ -1,8 +1,8 @@
+use anyhow::Context;
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
 use std::{
   collections::HashMap,
-  io::ErrorKind,
   path::{Path, PathBuf},
   process::Stdio,
   time::Instant,
@@ -24,12 +24,6 @@ use crate::{
 };
 
 use super::CommandError;
-
-#[derive(Clone, serde::Serialize)]
-struct ToastPayload {
-  toast: String,
-  level: String,
-}
 
 #[derive(Debug, Serialize, Deserialize)]
 struct LauncherErrorCode {
@@ -141,15 +135,7 @@ pub async fn extract_and_validate_iso(
     "extracting using data folder: {}",
     data_folder.to_string_lossy()
   );
-  let exec_info = match config_info.get_exec_location("extractor") {
-    Ok(exec_info) => exec_info,
-    Err(_) => {
-      error!("extractor executable not found");
-      return Err(CommandError::BinaryExecution(format!(
-        "Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again."
-      )));
-    }
-  };
+  let exec_info = config_info.get_exec_location("extractor")?;
 
   let mut args = vec![
     path_to_iso.clone(),
@@ -214,19 +200,13 @@ pub async fn run_decompiler(
 ) -> Result<(), CommandError> {
   let config_lock = config.lock().await;
   let config_info = config_lock.common_prelude()?;
-
   let data_folder = get_data_dir(&config_info, game_name, false)?;
+  let exec_info = config_info.get_exec_location("extractor")?;
+
   log::info!(
     "decompiling using data folder: {}",
     data_folder.to_string_lossy()
   );
-  let exec_info = match config_info.get_exec_location("extractor") {
-    Ok(exec_info) => exec_info,
-    Err(_) => {
-      error!("extractor executable not found");
-      return Err(CommandError::BinaryExecution("Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again.".to_string()));
-    }
-  };
 
   let source_path = path_to_iso.unwrap_or_else(|| {
     data_folder
@@ -334,20 +314,13 @@ pub async fn run_compiler(
 ) -> Result<(), CommandError> {
   let config_lock = config.lock().await;
   let config_info = config_lock.common_prelude()?;
-
+  let exec_info = config_info.get_exec_location("extractor")?;
   let data_folder = get_data_dir(&config_info, game_name, false)?;
+
   log::info!(
     "compiling using data folder: {}",
     data_folder.to_string_lossy()
   );
-  let exec_info = match config_info.get_exec_location("extractor") {
-    Ok(exec_info) => exec_info,
-    Err(_) => {
-      return Err(CommandError::BinaryExecution(format!(
-        "Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again."
-      )));
-    }
-  };
 
   let source_path = path_to_iso.unwrap_or_else(|| {
     data_folder
@@ -399,19 +372,16 @@ pub async fn run_compiler(
   if let Some(code) = status.code() {
     let message = get_error_code_message(&config_info, game_name, code);
     error!("compilation was not successful. Code {code}");
-    return Err(CommandError::BinaryExecution(message));
+    return Err(anyhow::anyhow!(message).into());
   }
 
   error!("compilation was not successful. No status code");
-  return Err(CommandError::BinaryExecution(
-    "Unexpected error occurred".to_owned(),
-  ));
+  return Err(anyhow::anyhow!("compilation was not successful. No status code").into());
 }
 
 #[tauri::command]
 pub async fn open_repl(
   config: tauri::State<'_, tokio::sync::Mutex<LauncherConfig>>,
-  app_handle: tauri::AppHandle,
   game_name: SupportedGame,
 ) -> Result<(), CommandError> {
   let config_lock = config.lock().await;
@@ -456,23 +426,9 @@ pub async fn open_repl(
       ])
       .current_dir(exec_info.executable_dir);
   }
-  match command.spawn() {
-    Ok(_) => Ok(()),
-    Err(e) => {
-      if let ErrorKind::NotFound = e.kind() {
-        let _ = app_handle.emit(
-          "toast_msg",
-          ToastPayload {
-            toast: format!("'{:?}' not found in PATH!", command.get_program()),
-            level: "error".to_string(),
-          },
-        );
-      }
-      Err(CommandError::BinaryExecution(
-        "Unable to launch REPL".to_owned(),
-      ))
-    }
-  }
+
+  command.spawn().context("Unable to launch REPL")?;
+  Ok(())
 }
 
 fn generate_launch_game_string(
@@ -526,7 +482,6 @@ pub async fn get_launch_game_string(
 ) -> Result<String, CommandError> {
   let config_lock = config.lock().await;
   let config_info = config_lock.common_prelude()?;
-
   let exec_info = config_info.get_exec_location("gk")?;
   let args = generate_launch_game_string(&config_info, game_name, false, true)?;
 
@@ -571,47 +526,44 @@ pub async fn launch_game(
   let log_file = create_std_log_file(&app_handle, format!("game-{game_name}.log"), false)?;
   let log_file_err = log_file.try_clone()?;
 
-  let mut command = std::process::Command::new(exec_info.executable_path);
+  let mut command = tokio::process::Command::new(exec_info.executable_path);
   command
     .args(args)
     .stdout(log_file)
     .stderr(log_file_err)
     .current_dir(exec_info.executable_dir);
+
   #[cfg(windows)]
   {
-    std::os::windows::process::CommandExt::creation_flags(&mut command, 0x08000000);
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+    command.creation_flags(CREATE_NO_WINDOW);
   }
+  drop(config_lock);
   let mut child = command.spawn()?;
-  // wait for the child to exit in the background
-  tokio::spawn(async move {
+  let handle = tokio::spawn(async move {
     let start_time = Instant::now();
-    let status = match child.wait() {
+    let status = match child.wait().await {
       Ok(status) => status,
       Err(err) => {
         error!("Error occurred when waiting for game to exit: {err}");
-        return;
+        anyhow::bail!("Error occurred when waiting for game to exit: {err}");
       }
     };
 
-    if let Err(err) = track_playtime(start_time, game_name).await {
-      error!("Failed to track playtime: {err}");
-    }
+    track_playtime(start_time, game_name)
+      .await
+      .map_err(|err| anyhow::anyhow!("Failed to track playtime: {err}"))?;
 
-    let Some(exit_code) = status.code() else {
-      return;
-    };
-
-    if exit_code != 0 {
+    if let Some(exit_code) = status.code()
+      && exit_code != 0
+    {
       error!("Game crashed with code: {}", format_exit_code(exit_code));
-      let _ = app_handle.emit(
-        "toast_msg",
-        ToastPayload {
-          toast: format!("Game crashed with code: {}", format_exit_code(exit_code)),
-          level: "error".to_string(),
-        },
-      );
+      anyhow::bail!("Game crashed with code: {}", format_exit_code(exit_code));
     }
+    Ok(())
   });
+
+  handle.await.map_err(|e| anyhow::anyhow!("{:#?}", e))??;
   Ok(())
 }
 

--- a/src-tauri/src/commands/binaries.rs
+++ b/src-tauri/src/commands/binaries.rs
@@ -650,7 +650,7 @@ pub async fn launch_game(
     }
     // once the game exits pass the time the game started to the track_playtine function
     if let Err(err) = track_playtime(start_time, game_name).await {
-      log::error!("Error occurred when tracking playtime: {}", err);
+      log::error!("Failed to track playtime: {err}");
     }
   });
   Ok(())
@@ -659,32 +659,18 @@ pub async fn launch_game(
 async fn track_playtime(
   start_time: std::time::Instant,
   game_name: SupportedGame,
-) -> Result<(), CommandError> {
+) -> anyhow::Result<()> {
   let app_handle = TAURI_APP
     .get()
-    .ok_or_else(|| {
-      CommandError::BinaryExecution("Cannot access global app state to persist playtime".to_owned())
-    })?
+    .expect("Can't access global app state")
     .app_handle();
+
+  let elapsed_seconds = start_time.elapsed().as_secs().into();
+
   let config = app_handle.state::<tokio::sync::Mutex<LauncherConfig>>();
   let mut config_lock = config.lock().await;
+  config_lock.update_setting_value("seconds_played", elapsed_seconds, Some(game_name))?;
 
-  // get the playtime of the session
-  let elapsed_time = start_time.elapsed().as_secs().into();
-  log::info!("elapsed time: {}", elapsed_time);
-
-  config_lock
-    .update_setting_value("seconds_played", elapsed_time, Some(game_name))
-    .map_err(|_| CommandError::Configuration("Unable to persist time played".to_owned()))?;
-
-  // send an event to the front end so that it can refresh the playtime on screen
-  if let Err(err) = app_handle.emit("playtimeUpdated", ()) {
-    log::error!("Failed to emit playtimeUpdated event: {}", err);
-    return Err(CommandError::BinaryExecution(format!(
-      "Failed to emit playtimeUpdated event: {}",
-      err
-    )));
-  }
-
+  app_handle.emit("playtimeUpdated", ())?;
   Ok(())
 }

--- a/src-tauri/src/commands/binaries.rs
+++ b/src-tauri/src/commands/binaries.rs
@@ -218,7 +218,7 @@ pub async fn extract_and_validate_iso(
 pub async fn run_decompiler(
   config: tauri::State<'_, tokio::sync::Mutex<LauncherConfig>>,
   app_handle: tauri::AppHandle,
-  path_to_iso: String,
+  path_to_iso: Option<String>,
   game_name: SupportedGame,
   truncate_logs: bool,
   use_decomp_settings: bool,
@@ -242,14 +242,13 @@ pub async fn run_decompiler(
     }
   };
 
-  let mut source_path = path_to_iso;
-  if source_path.is_empty() {
-    source_path = data_folder
+  let source_path = path_to_iso.unwrap_or_else(|| {
+    data_folder
       .join("iso_data")
       .join(game_name.to_string())
       .to_string_lossy()
-      .to_string();
-  }
+      .into_owned()
+  });
 
   let mut command = Command::new(exec_info.executable_path);
 
@@ -350,7 +349,7 @@ pub async fn run_decompiler(
 pub async fn run_compiler(
   config: tauri::State<'_, tokio::sync::Mutex<LauncherConfig>>,
   app_handle: tauri::AppHandle,
-  path_to_iso: String,
+  path_to_iso: Option<String>,
   game_name: SupportedGame,
   truncate_logs: bool,
 ) -> Result<InstallStepOutput, CommandError> {
@@ -372,14 +371,13 @@ pub async fn run_compiler(
     }
   };
 
-  let mut source_path = path_to_iso;
-  if source_path.is_empty() {
-    source_path = data_folder
+  let source_path = path_to_iso.unwrap_or_else(|| {
+    data_folder
       .join("iso_data")
       .join(game_name.to_string())
       .to_string_lossy()
-      .to_string();
-  }
+      .into_owned()
+  });
 
   let mut args = vec![
     source_path,

--- a/src-tauri/src/commands/binaries.rs
+++ b/src-tauri/src/commands/binaries.rs
@@ -13,7 +13,6 @@ use tokio::process::Command;
 use log::{info, warn};
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use tauri::{Emitter, Manager};
 
 use crate::{
@@ -38,10 +37,18 @@ struct LauncherErrorCode {
   msg: String,
 }
 
-fn get_error_codes(
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstallStepOutput {
+  pub success: bool,
+  pub msg: Option<String>,
+}
+
+fn get_error_code_message(
   config: &CommonConfigData,
   game_name: SupportedGame,
-) -> HashMap<i32, LauncherErrorCode> {
+  code: i32,
+) -> String {
   let json_file = config
     .install_path
     .join("active")
@@ -49,45 +56,17 @@ fn get_error_codes(
     .join("data")
     .join("launcher")
     .join("error-code-metadata.json");
-  if !json_file.exists() {
-    warn!("couldn't locate error code file at {}", json_file.display());
-    return HashMap::new();
-  }
-  let file_contents = match std::fs::read_to_string(&json_file) {
-    Ok(content) => content,
-    Err(_err) => {
-      warn!("couldn't read error code file at {}", &json_file.display());
-      return HashMap::new();
-    }
-  };
-  let json: Value = match serde_json::from_str(&file_contents) {
-    Ok(json) => json,
-    Err(_err) => {
-      warn!("couldn't parse error code file at {}", &json_file.display());
-      return HashMap::new();
-    }
-  };
 
-  if let Value::Object(map) = json {
-    let mut result: HashMap<i32, LauncherErrorCode> = HashMap::new();
-    for (key, value) in map {
-      let Ok(error_code) = serde_json::from_value(value) else {
-        continue;
-      };
-      let Ok(code) = key.parse::<i32>() else {
-        continue;
-      };
-      result.insert(code, error_code);
-    }
-    return result;
-  }
-
-  warn!(
-    "couldn't convert error code file at {}",
-    &json_file.display()
-  );
-
-  HashMap::new()
+  std::fs::File::open(&json_file)
+    .inspect_err(|e| warn!("{}", e))
+    .ok()
+    .and_then(|file| {
+      serde_json::from_reader::<_, HashMap<i32, LauncherErrorCode>>(file)
+        .inspect_err(|e| warn!("{}", e))
+        .ok()
+    })
+    .and_then(|map| map.get(&code).map(|e| e.msg.clone()))
+    .unwrap_or_else(|| format!("Unexpected error occurred with code {code}"))
 }
 
 fn copy_data_dir(
@@ -132,13 +111,6 @@ fn get_data_dir(
     copy_data_dir(config_info, game_name)?;
   }
   Ok(data_folder)
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct InstallStepOutput {
-  pub success: bool,
-  pub msg: Option<String>,
 }
 
 #[tauri::command]
@@ -227,15 +199,11 @@ pub async fn extract_and_validate_iso(
   }
 
   if let Some(code) = status.code() {
-    let error_code_map = get_error_codes(&config_info, game_name);
-    let default_error = LauncherErrorCode {
-      msg: format!("Unexpected error occured with code {code}"),
-    };
-    let message = error_code_map.get(&code).unwrap_or(&default_error);
+    let message = get_error_code_message(&config_info, game_name, code);
     log::error!("extraction and validation was not successful. Code {code}");
     return Ok(InstallStepOutput {
       success: false,
-      msg: Some(message.msg.clone()),
+      msg: Some(message),
     });
   }
 
@@ -363,15 +331,11 @@ pub async fn run_decompiler(
   }
 
   if let Some(code) = status.code() {
-    let error_code_map = get_error_codes(&config_info, game_name);
-    let default_error = LauncherErrorCode {
-      msg: format!("Unexpected error occured with code {code}"),
-    };
-    let message = error_code_map.get(&code).unwrap_or(&default_error);
+    let message = get_error_code_message(&config_info, game_name, code);
     log::error!("decompilation was not successful. Code {code}");
     return Ok(InstallStepOutput {
       success: false,
-      msg: Some(message.msg.clone()),
+      msg: Some(message),
     });
   }
 
@@ -460,15 +424,11 @@ pub async fn run_compiler(
   }
 
   if let Some(code) = status.code() {
-    let error_code_map = get_error_codes(&config_info, game_name);
-    let default_error = LauncherErrorCode {
-      msg: format!("Unexpected error occured with code {code}"),
-    };
-    let message = error_code_map.get(&code).unwrap_or(&default_error);
+    let message = get_error_code_message(&config_info, game_name, code);
     log::error!("compilation was not successful. Code {code}");
     return Ok(InstallStepOutput {
       success: false,
-      msg: Some(message.msg.clone()),
+      msg: Some(message),
     });
   }
 
@@ -686,13 +646,13 @@ pub async fn launch_game(
         }
       }
       Err(err) => {
-        log::error!("Error occured when waiting for game to exit: {}", err);
+        log::error!("Error occurred when waiting for game to exit: {}", err);
         return;
       }
     }
     // once the game exits pass the time the game started to the track_playtine function
     if let Err(err) = track_playtime(start_time, game_name).await {
-      log::error!("Error occured when tracking playtime: {}", err);
+      log::error!("Error occurred when tracking playtime: {}", err);
     }
   });
   Ok(())

--- a/src-tauri/src/commands/binaries.rs
+++ b/src-tauri/src/commands/binaries.rs
@@ -31,12 +31,12 @@ struct LauncherErrorCode {
 }
 
 #[cfg(windows)]
-fn format_exit_code(code: i32) -> String {
+pub fn format_exit_code(code: i32) -> String {
   format!("{code} ({:#010X})", code as u32)
 }
 
 #[cfg(not(windows))]
-fn format_exit_code(code: i32) -> String {
+pub fn format_exit_code(code: i32) -> String {
   code.to_string()
 }
 

--- a/src-tauri/src/commands/binaries.rs
+++ b/src-tauri/src/commands/binaries.rs
@@ -561,7 +561,7 @@ pub async fn get_launch_game_string(
 
   Ok(format!(
     "{} {}",
-    exec_info.executable_path.display(),
+    format!("\"{}\"", exec_info.executable_path.display()),
     args.join(" ")
   ))
 }

--- a/src-tauri/src/commands/binaries.rs
+++ b/src-tauri/src/commands/binaries.rs
@@ -5,12 +5,11 @@ use std::{
   io::ErrorKind,
   path::{Path, PathBuf},
   process::Stdio,
-  str::FromStr,
   time::Instant,
 };
 use tokio::process::Command;
 
-use log::{info, warn};
+use log::{error, info, warn};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use tauri::{Emitter, Manager};
@@ -42,6 +41,16 @@ struct LauncherErrorCode {
 pub struct InstallStepOutput {
   pub success: bool,
   pub msg: Option<String>,
+}
+
+#[cfg(windows)]
+fn format_exit_code(code: i32) -> String {
+  format!("{code} ({:#010X})", code as u32)
+}
+
+#[cfg(not(windows))]
+fn format_exit_code(code: i32) -> String {
+  code.to_string()
 }
 
 fn get_error_code_message(
@@ -147,7 +156,7 @@ pub async fn extract_and_validate_iso(
   let exec_info = match config_info.get_exec_location("extractor") {
     Ok(exec_info) => exec_info,
     Err(_) => {
-      log::error!("extractor executable not found");
+      error!("extractor executable not found");
       return Ok(InstallStepOutput {
         success: false,
         msg: Some("Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again.".to_string()),
@@ -200,14 +209,14 @@ pub async fn extract_and_validate_iso(
 
   if let Some(code) = status.code() {
     let message = get_error_code_message(&config_info, game_name, code);
-    log::error!("extraction and validation was not successful. Code {code}");
+    error!("extraction and validation was not successful. Code {code}");
     return Ok(InstallStepOutput {
       success: false,
       msg: Some(message),
     });
   }
 
-  log::error!("extraction and validation was not successful. No status code");
+  error!("extraction and validation was not successful. No status code");
   Ok(InstallStepOutput {
     success: false,
     msg: Some("Unexpected error occurred".to_owned()),
@@ -234,7 +243,7 @@ pub async fn run_decompiler(
   let exec_info = match config_info.get_exec_location("extractor") {
     Ok(exec_info) => exec_info,
     Err(_) => {
-      log::error!("extractor executable not found");
+      error!("extractor executable not found");
       return Ok(InstallStepOutput {
         success: false,
         msg: Some("Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again.".to_string()),
@@ -331,14 +340,14 @@ pub async fn run_decompiler(
 
   if let Some(code) = status.code() {
     let message = get_error_code_message(&config_info, game_name, code);
-    log::error!("decompilation was not successful. Code {code}");
+    error!("decompilation was not successful. Code {code}");
     return Ok(InstallStepOutput {
       success: false,
       msg: Some(message),
     });
   }
 
-  log::error!("decompilation was not successful. No status code");
+  error!("decompilation was not successful. No status code");
   Ok(InstallStepOutput {
     success: false,
     msg: Some("Unexpected error occurred".to_owned()),
@@ -423,14 +432,14 @@ pub async fn run_compiler(
 
   if let Some(code) = status.code() {
     let message = get_error_code_message(&config_info, game_name, code);
-    log::error!("compilation was not successful. Code {code}");
+    error!("compilation was not successful. Code {code}");
     return Ok(InstallStepOutput {
       success: false,
       msg: Some(message),
     });
   }
 
-  log::error!("compilation was not successful. No status code");
+  error!("compilation was not successful. No status code");
   Ok(InstallStepOutput {
     success: false,
     msg: Some("Unexpected error occurred".to_owned()),
@@ -572,34 +581,19 @@ pub async fn launch_game(
   app_handle: tauri::AppHandle,
   game_name: SupportedGame,
   in_debug: bool,
-  executable_location: Option<String>,
+  executable_location: Option<PathBuf>,
 ) -> Result<(), CommandError> {
   let config_lock = config.lock().await;
   let config_info = config_lock.common_prelude()?;
 
-  let mut exec_info = config_info.get_exec_location("gk")?;
-  if let Some(custom_exec_location) = executable_location {
-    match PathBuf::from_str(custom_exec_location.as_str()) {
-      Ok(exec_path) => {
-        let path_copy = exec_path.clone();
-        if path_copy.parent().is_none() {
-          return Err(CommandError::BinaryExecution(
-            "Failed to resolve custom binary parent directory".to_string(),
-          ));
-        }
-        exec_info = ExecutableLocation {
-          executable_dir: exec_path.clone().parent().unwrap().to_path_buf(),
-          executable_path: exec_path.clone(),
-        };
-      }
-      Err(err) => {
-        return Err(CommandError::BinaryExecution(format!(
-          "Failed to resolve custom binary location {}",
-          err
-        )));
-      }
+  let exec_info = if let Some(exec_path) = executable_location {
+    ExecutableLocation {
+      executable_dir: exec_path.parent().unwrap().to_path_buf(),
+      executable_path: exec_path,
     }
-  }
+  } else {
+    config_info.get_exec_location("gk")?
+  };
 
   let args = generate_launch_game_string(&config_info, game_name, in_debug, false)?;
 
@@ -625,32 +619,35 @@ pub async fn launch_game(
   {
     std::os::windows::process::CommandExt::creation_flags(&mut command, 0x08000000);
   }
-  // Start the process here so if there is an error, we can return immediately
   let mut child = command.spawn()?;
-  // if all goes well, we await the child to exit in the background (separate thread)
+  // wait for the child to exit in the background
   tokio::spawn(async move {
-    let start_time = Instant::now(); // get the start time of the game
-    // start waiting for the game to exit
-    match child.wait() {
-      Ok(status_code) => {
-        if status_code.code().is_none() || status_code.code().unwrap() != 0 {
-          let _ = app_handle.emit(
-            "toast_msg",
-            ToastPayload {
-              toast: "Game crashed unexpectedly!".to_string(),
-              level: "error".to_string(),
-            },
-          );
-        }
-      }
+    let start_time = Instant::now();
+    let status = match child.wait() {
+      Ok(status) => status,
       Err(err) => {
-        log::error!("Error occurred when waiting for game to exit: {}", err);
+        error!("Error occurred when waiting for game to exit: {err}");
         return;
       }
-    }
-    // once the game exits pass the time the game started to the track_playtine function
+    };
+
     if let Err(err) = track_playtime(start_time, game_name).await {
-      log::error!("Failed to track playtime: {err}");
+      error!("Failed to track playtime: {err}");
+    }
+
+    let Some(exit_code) = status.code() else {
+      return;
+    };
+
+    if exit_code != 0 {
+      error!("Game crashed with code: {}", format_exit_code(exit_code));
+      let _ = app_handle.emit(
+        "toast_msg",
+        ToastPayload {
+          toast: format!("Game crashed with code: {}", format_exit_code(exit_code)),
+          level: "error".to_string(),
+        },
+      );
     }
   });
   Ok(())

--- a/src-tauri/src/commands/binaries.rs
+++ b/src-tauri/src/commands/binaries.rs
@@ -62,7 +62,12 @@ fn get_error_code_message(
         .ok()
     })
     .and_then(|map| map.get(&code).map(|e| e.msg.clone()))
-    .unwrap_or_else(|| format!("Unexpected error occurred with code {code}"))
+    .unwrap_or_else(|| {
+      format!(
+        "Unexpected error occurred with code {}",
+        format_exit_code(code)
+      )
+    })
 }
 
 fn copy_data_dir(

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -201,23 +201,13 @@ pub async fn extract_iso_for_mod_install(
     config_lock.install_dir()?
   };
 
-  let exec_info = match get_mod_exec_location(
+  let exec_info = get_mod_exec_location(
     &install_path,
     "extractor",
     game_name,
     &mod_name,
     &source_name,
-  ) {
-    Ok(exec_info) => exec_info,
-    Err(e) => {
-      return Err(CommandError::GameFeatures(
-        format!(
-          "Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again. {}",
-          e
-        ),
-      ));
-    }
-  };
+  )?;
 
   let iso_extraction_dir = install_path
     .join("active")
@@ -284,21 +274,13 @@ pub async fn decompile_for_mod_install(
     config_lock.install_dir()?
   };
 
-  let exec_info = match get_mod_exec_location(
+  let exec_info = get_mod_exec_location(
     &install_path,
     "extractor",
     game_name,
     &mod_name,
     &source_name,
-  ) {
-    Ok(exec_info) => exec_info,
-    Err(e) => {
-      return Err(CommandError::GameFeatures(format!(
-        "Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again. {}",
-        e
-      )));
-    }
-  };
+  )?;
 
   let iso_dir = install_path
     .join("active")
@@ -358,22 +340,13 @@ pub async fn compile_for_mod_install(
     let config_lock = config.lock().await;
     config_lock.install_dir()?
   };
-  let exec_info = match get_mod_exec_location(
+  let exec_info = get_mod_exec_location(
     &install_path,
     "extractor",
     game_name,
     &mod_name,
     &source_name,
-  ) {
-    Ok(exec_info) => exec_info,
-    Err(e) => {
-      log::error!("extractor executable not found");
-      return Err(CommandError::GameFeatures(format!(
-        "Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again. {}",
-        e
-      )));
-    }
-  };
+  )?;
 
   let iso_dir = install_path
     .join("active")

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -13,7 +13,7 @@ use tokio::process::Command;
 
 use crate::{
   cache::{ModCache, ModInfo},
-  commands::CommandError,
+  commands::{CommandError, binaries::format_exit_code},
   config::{ExecutableLocation, LauncherConfig, SupportedGame},
   util::{
     file::{delete_dir, to_image_base64},
@@ -255,6 +255,7 @@ pub async fn extract_iso_for_mod_install(
 
   let msg = status
     .code()
+    .map(|code| format_exit_code(code))
     .map(|code| format!("Unexpected error occurred with code {code}"))
     .unwrap_or_else(|| "Unexpected error occurred".to_owned());
 
@@ -322,6 +323,7 @@ pub async fn decompile_for_mod_install(
 
   let msg = status
     .code()
+    .map(|code| format_exit_code(code))
     .map(|code| format!("Unexpected error occurred with code {code}"))
     .unwrap_or_else(|| "Unexpected error occurred".to_owned());
 
@@ -388,6 +390,7 @@ pub async fn compile_for_mod_install(
 
   let msg = status
     .code()
+    .map(|code| format_exit_code(code))
     .map(|code| format!("Unexpected error occurred with code {code}"))
     .unwrap_or_else(|| "Unexpected error occurred".to_owned());
 

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -8,12 +8,13 @@ use std::{
 };
 
 use anyhow::ensure;
+use serde::{Deserialize, Serialize};
 use tauri::Emitter;
 use tokio::process::Command;
 
 use crate::{
   cache::{ModCache, ModInfo},
-  commands::{CommandError, binaries::InstallStepOutput},
+  commands::CommandError,
   config::{ExecutableLocation, LauncherConfig, SupportedGame},
   util::{
     file::{delete_dir, to_image_base64},
@@ -22,6 +23,13 @@ use crate::{
     tar::{extract_and_delete_archive, extract_archive},
   },
 };
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstallStepOutput {
+  pub success: bool,
+  pub msg: Option<String>,
+}
 
 #[tauri::command]
 pub async fn extract_new_mod(

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -8,7 +8,6 @@ use std::{
 };
 
 use anyhow::ensure;
-use serde::{Deserialize, Serialize};
 use tauri::Emitter;
 use tokio::process::Command;
 
@@ -24,20 +23,13 @@ use crate::{
   },
 };
 
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct InstallStepOutput {
-  pub success: bool,
-  pub msg: Option<String>,
-}
-
 #[tauri::command]
 pub async fn extract_new_mod(
   config: tauri::State<'_, tokio::sync::Mutex<LauncherConfig>>,
   game_name: SupportedGame,
   bundle_path: PathBuf,
   mod_source: String,
-) -> Result<InstallStepOutput, CommandError> {
+) -> Result<(), CommandError> {
   let install_path = {
     let config_lock = config.lock().await;
     config_lock.install_dir()?
@@ -60,10 +52,7 @@ pub async fn extract_new_mod(
   delete_dir(&destination_dir)?;
   extract_archive(&bundle_path, &destination_dir)?;
 
-  Ok(InstallStepOutput {
-    success: true,
-    msg: None,
-  })
+  Ok(())
 }
 
 #[tauri::command]
@@ -74,7 +63,7 @@ pub async fn download_and_extract_new_mod(
   download_url: String,
   mod_name: String,
   source_name: String,
-) -> Result<InstallStepOutput, CommandError> {
+) -> Result<(), CommandError> {
   let install_path = {
     let config_lock = config.lock().await;
     config_lock.install_dir()?
@@ -112,10 +101,7 @@ pub async fn download_and_extract_new_mod(
   serde_json::to_writer_pretty(file, &mod_info)
     .map_err(|e| anyhow::anyhow!("Unable to save mod metadata: {}", e))?;
 
-  Ok(InstallStepOutput {
-    success: true,
-    msg: None,
-  })
+  Ok(())
 }
 
 #[tauri::command]
@@ -209,7 +195,7 @@ pub async fn extract_iso_for_mod_install(
   mod_name: String,
   source_name: String,
   path_to_iso: String,
-) -> Result<InstallStepOutput, CommandError> {
+) -> Result<(), CommandError> {
   let install_path = {
     let config_lock = config.lock().await;
     config_lock.install_dir()?
@@ -224,13 +210,12 @@ pub async fn extract_iso_for_mod_install(
   ) {
     Ok(exec_info) => exec_info,
     Err(e) => {
-      return Ok(InstallStepOutput {
-        success: false,
-        msg: Some(format!(
+      return Err(CommandError::GameFeatures(
+        format!(
           "Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again. {}",
           e
-        )),
-      });
+        ),
+      ));
     }
   };
 
@@ -275,10 +260,7 @@ pub async fn extract_iso_for_mod_install(
   let status = watch_process(&mut log_file, &mut child, &app_handle).await?;
   if status.success() {
     log::info!("extraction and validation was successful");
-    return Ok(InstallStepOutput {
-      success: true,
-      msg: None,
-    });
+    return Ok(());
   }
 
   let msg = status
@@ -286,10 +268,7 @@ pub async fn extract_iso_for_mod_install(
     .map(|code| format!("Unexpected error occurred with code {code}"))
     .unwrap_or_else(|| "Unexpected error occurred".to_owned());
 
-  Ok(InstallStepOutput {
-    success: false,
-    msg: Some(msg),
-  })
+  return Err(CommandError::GameFeatures(msg));
 }
 
 #[tauri::command]
@@ -299,7 +278,7 @@ pub async fn decompile_for_mod_install(
   game_name: SupportedGame,
   mod_name: String,
   source_name: String,
-) -> Result<InstallStepOutput, CommandError> {
+) -> Result<(), CommandError> {
   let install_path = {
     let config_lock = config.lock().await;
     config_lock.install_dir()?
@@ -314,13 +293,10 @@ pub async fn decompile_for_mod_install(
   ) {
     Ok(exec_info) => exec_info,
     Err(e) => {
-      return Ok(InstallStepOutput {
-        success: false,
-        msg: Some(format!(
-          "Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again. {}",
-          e
-        )),
-      });
+      return Err(CommandError::GameFeatures(format!(
+        "Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again. {}",
+        e
+      )));
     }
   };
 
@@ -359,10 +335,7 @@ pub async fn decompile_for_mod_install(
   let status = watch_process(&mut log_file, &mut child, &app_handle).await?;
   if status.success() {
     log::info!("decompilation was successful");
-    return Ok(InstallStepOutput {
-      success: true,
-      msg: None,
-    });
+    return Ok(());
   }
 
   let msg = status
@@ -370,10 +343,7 @@ pub async fn decompile_for_mod_install(
     .map(|code| format!("Unexpected error occurred with code {code}"))
     .unwrap_or_else(|| "Unexpected error occurred".to_owned());
 
-  Ok(InstallStepOutput {
-    success: false,
-    msg: Some(msg),
-  })
+  return Err(CommandError::GameFeatures(msg));
 }
 
 #[tauri::command]
@@ -383,7 +353,7 @@ pub async fn compile_for_mod_install(
   game_name: SupportedGame,
   mod_name: String,
   source_name: String,
-) -> Result<InstallStepOutput, CommandError> {
+) -> Result<(), CommandError> {
   let install_path = {
     let config_lock = config.lock().await;
     config_lock.install_dir()?
@@ -398,13 +368,10 @@ pub async fn compile_for_mod_install(
     Ok(exec_info) => exec_info,
     Err(e) => {
       log::error!("extractor executable not found");
-      return Ok(InstallStepOutput {
-        success: false,
-        msg: Some(format!(
-          "Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again. {}",
-          e
-        )),
-      });
+      return Err(CommandError::GameFeatures(format!(
+        "Tooling appears to be missing critical files. This may be caused by antivirus software. You will need to redownload the version and try again. {}",
+        e
+      )));
     }
   };
 
@@ -443,10 +410,7 @@ pub async fn compile_for_mod_install(
   let status = watch_process(&mut log_file, &mut child, &app_handle).await?;
   if status.success() {
     log::info!("compilation was successful");
-    return Ok(InstallStepOutput {
-      success: true,
-      msg: None,
-    });
+    return Ok(());
   }
 
   let msg = status
@@ -454,10 +418,7 @@ pub async fn compile_for_mod_install(
     .map(|code| format!("Unexpected error occurred with code {code}"))
     .unwrap_or_else(|| "Unexpected error occurred".to_owned());
 
-  Ok(InstallStepOutput {
-    success: false,
-    msg: Some(msg),
-  })
+  return Err(CommandError::GameFeatures(msg));
 }
 
 #[tauri::command]
@@ -467,7 +428,7 @@ pub async fn save_mod_install_info(
   mod_name: String,
   source_name: String,
   version_name: String,
-) -> Result<InstallStepOutput, CommandError> {
+) -> Result<(), CommandError> {
   let mut config_lock = config.lock().await;
   log::info!(
     "Saving mod install info {}, {}, {}, {}",
@@ -489,10 +450,7 @@ pub async fn save_mod_install_info(
       log::error!("Unable to remove mod source: {:?}", err);
       CommandError::Configuration("Unable to remove mod source".to_owned())
     })?;
-  Ok(InstallStepOutput {
-    success: true,
-    msg: None,
-  })
+  Ok(())
 }
 
 fn generate_launch_mod_args(
@@ -685,7 +643,7 @@ pub async fn get_launch_mod_string(
 
   Ok(format!(
     "{} {}",
-    exec_info.executable_path.display(),
+    format!("\"{}\"", exec_info.executable_path.display()),
     args.join(" ")
   ))
 }

--- a/src-tauri/src/commands/features/texture_packs.rs
+++ b/src-tauri/src/commands/features/texture_packs.rs
@@ -3,6 +3,7 @@ use std::{
   path::{Path, PathBuf},
 };
 
+use anyhow::Context;
 use serde_json::Value;
 
 use crate::{
@@ -162,55 +163,32 @@ pub async fn list_extracted_texture_pack_info(
 pub async fn extract_new_texture_pack(
   config: tauri::State<'_, tokio::sync::Mutex<LauncherConfig>>,
   game_name: SupportedGame,
-  zip_path: String,
-) -> Result<bool, CommandError> {
-  let config_lock = config.lock().await;
-  let install_path = match &config_lock.installation_dir {
-    None => {
-      return Err(CommandError::GameFeatures(
-        "No installation directory set, can't extract texture pack".to_string(),
-      ));
-    }
-    Some(path) => Path::new(path),
+  zip_path: PathBuf,
+) -> Result<(), CommandError> {
+  let install_dir = {
+    let config_lock = config.lock().await;
+    config_lock.install_dir()?
   };
 
   // First, we'll check the zip file to make sure it has a `custom_assets/<game>/texture_replacements` folder before extracting
-  let zip_path_buf = PathBuf::from(zip_path);
-  let texture_pack_name = match zip_path_buf.file_stem() {
-    Some(name) => name.to_string_lossy().to_string(),
-    None => {
-      return Err(CommandError::GameFeatures(
-        "Unable to get texture pack name from zip file path".to_string(),
-      ));
-    }
-  };
+  let texture_pack_name = zip_path
+    .file_stem()
+    .context("Unable to get texture pack name from zip file path")?
+    .to_string_lossy()
+    .into_owned();
   let expected_top_level_dir = format!("custom_assets/{game_name}/texture_replacements");
-  let valid_zip = check_if_zip_contains_top_level_entry(&zip_path_buf, &expected_top_level_dir)
-    .map_err(|err| {
-      log::error!("Unable to read texture replacement zip file: {}", err);
-      CommandError::GameFeatures(format!("Unable to read texture replacement pack: {}", err))
-    })?;
-  if !valid_zip {
-    log::error!(
-      "Invalid texture pack, no top-level `{}` folder in: {}",
-      &expected_top_level_dir,
-      zip_path_buf.display()
-    );
-    return Ok(false);
-  }
-  // It's valid, let's extract it.  The name of the zip becomes the folder, if one already exists it will be deleted!
-  let destination_dir = &install_path
+  check_if_zip_contains_top_level_entry(&zip_path, &expected_top_level_dir)?;
+
+  // The name of the zip becomes the folder, if one already exists it will be deleted!
+  let destination_dir = &install_dir
     .join("features")
     .join(game_name.to_string())
     .join("texture-packs")
     .join(&texture_pack_name);
   // TODO - delete it
   create_dir(destination_dir)?;
-  extract_zip_file(&zip_path_buf, destination_dir, false).map_err(|err| {
-    log::error!("Unable to extract replacement pack: {}", err);
-    CommandError::GameFeatures(format!("Unable to extract texture pack: {}", err))
-  })?;
-  Ok(true)
+  extract_zip_file(&zip_path, destination_dir, false).context("Unable to extract texture pack")?;
+  Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/features/texture_packs.rs
+++ b/src-tauri/src/commands/features/texture_packs.rs
@@ -44,12 +44,10 @@ pub async fn list_extracted_texture_pack_info(
       .join("texture-packs")
   };
 
-  let entries = std::fs::read_dir(&expected_path).map_err(|_| {
-    CommandError::GameFeatures(format!(
-      "Unable to read texture packs from {}",
-      expected_path.display()
-    ))
-  })?;
+  let entries = match std::fs::read_dir(&expected_path) {
+    Ok(entries) => entries,
+    Err(_) => return Ok(HashMap::new()),
+  };
 
   let mut package_map = HashMap::new();
 

--- a/src-tauri/src/commands/features/texture_packs.rs
+++ b/src-tauri/src/commands/features/texture_packs.rs
@@ -1,7 +1,4 @@
-use std::{
-  collections::HashMap,
-  path::{Path, PathBuf},
-};
+use std::{collections::HashMap, fs, path::PathBuf};
 
 use anyhow::Context;
 use serde_json::Value;
@@ -38,23 +35,14 @@ pub async fn list_extracted_texture_pack_info(
   config: tauri::State<'_, tokio::sync::Mutex<LauncherConfig>>,
   game_name: SupportedGame,
 ) -> Result<HashMap<String, TexturePackInfo>, CommandError> {
-  let config_lock = config.lock().await;
-  let install_path = match &config_lock.installation_dir {
-    None => return Ok(HashMap::new()),
-    Some(path) => Path::new(path),
+  let expected_path = {
+    let config_lock = config.lock().await;
+    config_lock
+      .install_dir()?
+      .join("features")
+      .join(game_name.to_string())
+      .join("texture-packs")
   };
-
-  let expected_path = Path::new(install_path)
-    .join("features")
-    .join(game_name.to_string())
-    .join("texture-packs");
-  if !expected_path.exists() || !expected_path.is_dir() {
-    log::info!(
-      "No {} folder found, returning no texture packs",
-      expected_path.display()
-    );
-    return Ok(HashMap::new());
-  }
 
   let entries = std::fs::read_dir(&expected_path).map_err(|_| {
     CommandError::GameFeatures(format!(
@@ -68,92 +56,86 @@ pub async fn list_extracted_texture_pack_info(
   for entry in entries {
     let entry = entry?;
     let entry_path = entry.path();
-    if entry_path.is_dir() {
-      let directory_name = entry_path
-        .file_name()
-        .and_then(|os_str| os_str.to_str())
-        .map(String::from)
-        .ok_or_else(|| {
-          CommandError::GameFeatures(format!("Unable to get directory name for {:?}", entry_path))
-        })?;
-      // Get a list of all texture files for this pack
-      log::info!("Texture pack dir name: {}", directory_name);
-      let mut file_list = Vec::new();
-      for entry in glob::glob(
-        &entry_path
-          .join("custom_assets")
-          .join(game_name.to_string())
-          .join("texture_replacements/**/*.png")
-          .to_string_lossy(),
-      )
-      .expect("Failed to read glob pattern")
-      {
-        match entry {
-          Ok(path) => {
-            let relative_path = path
-              .strip_prefix(
-                entry_path
-                  .join("custom_assets")
-                  .join(game_name.to_string())
-                  .join("texture_replacements"),
-              )
-              .map_err(|_| {
-                CommandError::GameFeatures(format!(
-                  "Unable to read texture packs from {}",
-                  expected_path.display()
-                ))
-              })?;
-            file_list.push(relative_path.display().to_string().replace("\\", "/"));
-          }
-          Err(e) => println!("{:?}", e),
-        }
-      }
-      let cover_image_path = match entry_path.join("cover.png").exists() {
-        true => Some(entry_path.join("cover.png").to_string_lossy().to_string()),
-        false => None,
-      };
-      let mut pack_info = TexturePackInfo {
-        file_list,
-        has_metadata: false,
-        cover_image_path,
-        name: directory_name.to_owned(),
-        version: "Unknown Version".to_string(),
-        author: "Unknown Author".to_string(),
-        release_date: "Unknown Release Date".to_string(),
-        supported_games: vec![game_name], // if no info, assume it's supported
-        description: "Unknown Description".to_string(),
-        tags: vec![],
-      };
-      // Read metadata if it's available
-      if entry_path.join("metadata.json").exists() {
-        match std::fs::read_to_string(entry_path.join("metadata.json")) {
-          Ok(content) => {
-            // Serialize from json
-            match serde_json::from_str::<TexturePackInfo>(&content) {
-              Ok(pack_metadata) => {
-                pack_info.name = pack_metadata.name;
-                pack_info.version = pack_metadata.version;
-                pack_info.author = pack_metadata.author;
-                pack_info.release_date = pack_metadata.release_date;
-                pack_info.description = pack_metadata.description;
-                pack_info.tags = pack_metadata.tags;
-              }
-              Err(err) => {
-                log::error!("Unable to parse {}: {}", &content, err);
-              }
-            }
-          }
-          Err(err) => {
-            log::error!(
-              "Unable to read {}: {}",
-              entry_path.join("metadata.json").display(),
-              err
-            );
-          }
-        };
-      }
-      package_map.insert(directory_name, pack_info);
+    if !entry_path.is_dir() {
+      continue;
     }
+
+    let directory_name = entry_path
+      .file_name()
+      .and_then(|os_str| os_str.to_str())
+      .map(String::from)
+      .ok_or_else(|| {
+        CommandError::GameFeatures(format!(
+          "Unable to get directory name for {:?}",
+          entry_path.display()
+        ))
+      })?;
+
+    let mut file_list = Vec::new();
+
+    for entry in glob::glob(
+      &entry_path
+        .join("custom_assets")
+        .join(game_name.to_string())
+        .join("texture_replacements/**/*.png")
+        .to_string_lossy(),
+    )
+    .expect("Failed to read glob pattern")
+    {
+      match entry {
+        Ok(path) => {
+          let relative_path = path
+            .strip_prefix(
+              entry_path
+                .join("custom_assets")
+                .join(game_name.to_string())
+                .join("texture_replacements"),
+            )
+            .map_err(|_| {
+              CommandError::GameFeatures(format!(
+                "Unable to read texture packs from {}",
+                expected_path.display()
+              ))
+            })?;
+          file_list.push(relative_path.display().to_string().replace("\\", "/"));
+        }
+        Err(e) => println!("{:?}", e),
+      }
+    }
+    let cover_image_path = match entry_path.join("cover.png").exists() {
+      true => Some(entry_path.join("cover.png").to_string_lossy().to_string()),
+      false => None,
+    };
+    let mut pack_info = TexturePackInfo {
+      file_list,
+      has_metadata: false,
+      cover_image_path,
+      name: directory_name.to_owned(),
+      version: "Unknown Version".to_string(),
+      author: "Unknown Author".to_string(),
+      release_date: "Unknown Release Date".to_string(),
+      supported_games: vec![game_name], // if no info, assume it's supported
+      description: "Unknown Description".to_string(),
+      tags: vec![],
+    };
+
+    let metadata_path = entry_path.join("metadata.json");
+    if let Ok(metadata) = fs::File::open(&metadata_path)
+      .and_then(|f| serde_json::from_reader::<_, TexturePackInfo>(f).map_err(Into::into))
+    {
+      pack_info = TexturePackInfo {
+        has_metadata: true,
+        file_list: pack_info.file_list,
+        cover_image_path: pack_info.cover_image_path,
+        ..metadata
+      };
+    } else {
+      log::error!(
+        "Unable to load texture pack metadata {}",
+        metadata_path.display()
+      );
+    }
+    package_map.insert(directory_name, pack_info);
   }
 
   Ok(package_map)

--- a/src-tauri/src/commands/features/texture_packs.rs
+++ b/src-tauri/src/commands/features/texture_packs.rs
@@ -3,7 +3,6 @@ use std::{
   path::{Path, PathBuf},
 };
 
-use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
@@ -214,46 +213,31 @@ pub async fn extract_new_texture_pack(
   Ok(true)
 }
 
-// TODO -  remove duplication
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct GameJobStepOutput {
-  pub success: bool,
-  pub msg: Option<String>,
-}
-
 #[tauri::command]
 pub async fn update_texture_pack_data(
   config: tauri::State<'_, tokio::sync::Mutex<LauncherConfig>>,
   game_name: SupportedGame,
-) -> Result<GameJobStepOutput, CommandError> {
+) -> Result<(), CommandError> {
   let config_lock = config.lock().await;
-  let install_path = match &config_lock.installation_dir {
-    None => {
-      return Ok(GameJobStepOutput {
-        success: false,
-        msg: Some("No installation directory set, can't extract texture pack".to_string()),
-      });
-    }
-    Some(path) => Path::new(path),
-  };
+  let install_dir = config_lock.install_dir()?;
 
-  let game_texture_pack_dir = install_path
+  let game_texture_pack_dir = install_dir
     .join("active")
-    .join(game_name.to_string())
+    .join(&game_name.to_string())
     .join("data")
     .join("custom_assets")
-    .join(game_name.to_string())
+    .join(&game_name.to_string())
     .join("texture_replacements");
   // Reset texture replacement directory
   delete_dir(&game_texture_pack_dir)?;
   create_dir(&game_texture_pack_dir)?;
 
+  // TODO: refactor this after the config refactor
   if let Ok(Value::Array(texture_packs)) =
     config_lock.get_setting_value("active_texture_packs", Some(game_name))
   {
     for pack in texture_packs.iter().filter_map(|pack| pack.as_str()).rev() {
-      let texture_pack_dir = install_path
+      let texture_pack_dir = install_dir
         .join("features")
         .join(game_name.to_string())
         .join("texture-packs")
@@ -263,26 +247,11 @@ pub async fn update_texture_pack_data(
         .join("texture_replacements");
 
       log::info!("Appending textures from: {}", texture_pack_dir.display());
-
-      // strange, but I can't worry about it right now.
-      if let Err(err) = overwrite_dir(&texture_pack_dir, &game_texture_pack_dir) {
-        log::error!("{:#}", err);
-        return Ok(GameJobStepOutput {
-          success: false,
-          msg: Some(err.to_string()),
-        });
-      }
+      overwrite_dir(&texture_pack_dir, &game_texture_pack_dir)?
     }
-
-    return Ok(GameJobStepOutput {
-      success: true,
-      msg: None,
-    });
+    return Ok(());
   }
-  Ok(GameJobStepOutput {
-    success: false,
-    msg: None,
-  })
+  return Err(CommandError::GameFeatures(format!("TODO: Some error")));
 }
 
 #[tauri::command]
@@ -290,39 +259,20 @@ pub async fn delete_texture_packs(
   config: tauri::State<'_, tokio::sync::Mutex<LauncherConfig>>,
   game_name: SupportedGame,
   packs: Vec<String>,
-) -> Result<GameJobStepOutput, CommandError> {
-  let config_lock = config.lock().await;
-  let install_path = match &config_lock.installation_dir {
-    None => {
-      return Ok(GameJobStepOutput {
-        success: false,
-        msg: Some("No installation directory set, can't extract texture pack".to_string()),
-      });
-    }
-    Some(path) => Path::new(path),
+) -> Result<(), CommandError> {
+  let texture_pack_dir = {
+    let config_lock = config.lock().await;
+    config_lock
+      .install_dir()?
+      .join("features")
+      .join(game_name.to_string())
+      .join("texture-packs")
   };
-
-  let texture_pack_dir = install_path
-    .join("features")
-    .join(game_name.to_string())
-    .join("texture-packs");
 
   for pack in packs {
     log::info!("Deleting texture pack: {}", pack);
-    match delete_dir(texture_pack_dir.join(&pack)) {
-      Ok(_) => (),
-      Err(err) => {
-        log::error!("Unable to delete texture pack: {}", err);
-        return Ok(GameJobStepOutput {
-          success: false,
-          msg: Some(format!("Unable to delete texture pack: {}", err)),
-        });
-      }
-    }
+    delete_dir(texture_pack_dir.join(&pack))?;
   }
 
-  Ok(GameJobStepOutput {
-    success: true,
-    msg: None,
-  })
+  Ok(())
 }

--- a/src-tauri/src/util/zip.rs
+++ b/src-tauri/src/util/zip.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use log::info;
 use std::io::{BufReader, Cursor};
 use std::{
@@ -117,16 +117,23 @@ pub fn check_if_zip_contains_top_level_entry<P: AsRef<Path>>(
   path: P,
   expected: &str,
 ) -> Result<bool> {
-  let file = File::open(path)?;
+  let file = File::open(&path)
+    .with_context(|| format!("Unable to open zip file {}", path.as_ref().display()))?;
   let reader = BufReader::new(file);
-  let mut zip = zip::ZipArchive::new(reader)?;
+  let mut zip = zip::ZipArchive::new(reader).context("Failed to read zip archive")?;
 
   for i in 0..zip.len() {
-    let file = zip.by_index(i)?;
+    let file = zip
+      .by_index(i)
+      .context("Failed reading entry from zip archive")?;
     info!("{}", file.name());
     if file.name().starts_with(&expected) {
       return Ok(true);
     }
   }
-  Ok(false)
+  anyhow::bail!(
+    "Invalid zip, no top-level '{}' folder in: {}",
+    expected,
+    path.as_ref().display()
+  );
 }

--- a/src/components/games/features/texture-packs/TexturePacks.svelte
+++ b/src/components/games/features/texture-packs/TexturePacks.svelte
@@ -34,7 +34,7 @@
   let availablePacks: PackInfo[] = $state([]);
   let availablePacksOriginal: PackInfo[] = $state([]);
   let addingPack = $state(false);
-  let packAddingError = $state("");
+  // let packAddingError = $state("");
 
   onMount(async () => {
     await updatePackList();
@@ -98,34 +98,36 @@
       return;
     }
     addingPack = true;
-    packAddingError = "";
+    // packAddingError = "";
     const texturePackPath = await filePrompt(
       ["zip"],
       "ZIP",
       "Select a texture pack",
     );
     if (texturePackPath !== null) {
-      const success = await extractNewTexturePack(activeGame, texturePackPath);
-      if (success) {
-        // if the user made any changes, attempt to restore them after
-        let preexistingChanges = undefined;
-        if (areChangesPending(availablePacks, availablePacksOriginal)) {
-          preexistingChanges = JSON.parse(JSON.stringify(availablePacks));
-        }
-        await updatePackList();
-        if (preexistingChanges !== undefined) {
-          for (const preexisingPack of preexistingChanges) {
-            for (const pack of availablePacks) {
-              if (pack.name === preexisingPack.name) {
-                pack.enabled = preexisingPack.enabled;
-                pack.toBeDeleted = preexisingPack.toBeDeleted;
-              }
+      const error = await extractNewTexturePack(activeGame, texturePackPath);
+      if (error) {
+        // packAddingError = $_("features_textures_invalidPack");
+        addingPack = false;
+        return;
+      }
+
+      // if the user made any changes, attempt to restore them after
+      let preexistingChanges = undefined;
+      if (areChangesPending(availablePacks, availablePacksOriginal)) {
+        preexistingChanges = JSON.parse(JSON.stringify(availablePacks));
+      }
+      await updatePackList();
+      if (preexistingChanges !== undefined) {
+        for (const preexisingPack of preexistingChanges) {
+          for (const pack of availablePacks) {
+            if (pack.name === preexisingPack.name) {
+              pack.enabled = preexisingPack.enabled;
+              pack.toBeDeleted = preexisingPack.toBeDeleted;
             }
           }
-          availablePacks = availablePacks;
         }
-      } else {
-        packAddingError = $_("features_textures_invalidPack");
+        availablePacks = availablePacks;
       }
     }
     addingPack = false;
@@ -207,13 +209,13 @@
           >
         {/if}
       </div>
-      {#if packAddingError !== ""}
+      <!-- {#if packAddingError !== ""}
         <div class="flex flex-row font-bold mt-3">
           <Alert class="flex-grow text-red-400">
             {packAddingError}
           </Alert>
         </div>
-      {/if}
+      {/if} -->
       {#if availablePacks.length > 0}
         <div class="flex flex-row font-bold mt-3">
           <h2>{$_("features_textures_listHeading")}</h2>

--- a/src/lib/job/gameJob.ts
+++ b/src/lib/job/gameJob.ts
@@ -76,7 +76,7 @@ export async function setupDecompileJob(activeGame: SupportedGame) {
       status: "queued",
       label: $format("setup_decompile"),
       task: async () => {
-        const resp = await runDecompiler("", activeGame, true, true);
+        const resp = await runDecompiler(null, activeGame, true, true);
         if (!resp.success) {
           jobTracker.updateFailureReason(resp.msg);
           return false;
@@ -100,7 +100,7 @@ export async function setupCompileJob(activeGame: SupportedGame) {
       status: "queued",
       label: $format("setup_compile"),
       task: async () => {
-        const resp = await runCompiler("", activeGame, true);
+        const resp = await runCompiler(null, activeGame, true);
         if (!resp.success) {
           jobTracker.updateFailureReason(resp.msg);
           return false;
@@ -136,7 +136,7 @@ export async function setupUpdateGameJob(activeGame: SupportedGame) {
       status: "queued",
       label: $format("setup_decompile"),
       task: async () => {
-        let resp = await runDecompiler("", activeGame, true, false);
+        let resp = await runDecompiler(null, activeGame, true, false);
         if (!resp.success) {
           jobTracker.updateFailureReason(resp.msg);
           return false;
@@ -148,7 +148,7 @@ export async function setupUpdateGameJob(activeGame: SupportedGame) {
       status: "queued",
       label: $format("setup_compile"),
       task: async () => {
-        let resp = await runCompiler("", activeGame);
+        let resp = await runCompiler(null, activeGame);
         if (!resp.success) {
           jobTracker.updateFailureReason(resp.msg);
           return false;

--- a/src/lib/job/gameJob.ts
+++ b/src/lib/job/gameJob.ts
@@ -22,9 +22,9 @@ export async function setupInstallGame(
       status: "queued",
       label: $format("setup_extractAndVerify"),
       task: async () => {
-        const resp = await extractAndValidateISO(sourcePath, activeGame);
-        if (!resp.success) {
-          jobTracker.updateFailureReason(resp.msg);
+        const error = await extractAndValidateISO(sourcePath, activeGame);
+        if (error) {
+          jobTracker.updateFailureReason(error);
           return false;
         }
         return true;
@@ -34,9 +34,9 @@ export async function setupInstallGame(
       status: "queued",
       label: $format("setup_decompile"),
       task: async () => {
-        const resp = await runDecompiler(sourcePath, activeGame, false, false);
-        if (!resp.success) {
-          jobTracker.updateFailureReason(resp.msg);
+        const error = await runDecompiler(sourcePath, activeGame, false, false);
+        if (error) {
+          jobTracker.updateFailureReason(error);
           return false;
         }
         return true;
@@ -46,9 +46,9 @@ export async function setupInstallGame(
       status: "queued",
       label: $format("setup_compile"),
       task: async () => {
-        const resp = await runCompiler(sourcePath, activeGame);
-        if (!resp.success) {
-          jobTracker.updateFailureReason(resp.msg);
+        const error = await runCompiler(sourcePath, activeGame);
+        if (error) {
+          jobTracker.updateFailureReason(error);
           return false;
         }
         return true;
@@ -76,9 +76,9 @@ export async function setupDecompileJob(activeGame: SupportedGame) {
       status: "queued",
       label: $format("setup_decompile"),
       task: async () => {
-        const resp = await runDecompiler(null, activeGame, true, true);
-        if (!resp.success) {
-          jobTracker.updateFailureReason(resp.msg);
+        const error = await runDecompiler(null, activeGame, true, true);
+        if (error) {
+          jobTracker.updateFailureReason(error);
           return false;
         }
         return true;
@@ -100,9 +100,9 @@ export async function setupCompileJob(activeGame: SupportedGame) {
       status: "queued",
       label: $format("setup_compile"),
       task: async () => {
-        const resp = await runCompiler(null, activeGame, true);
-        if (!resp.success) {
-          jobTracker.updateFailureReason(resp.msg);
+        const error = await runCompiler(null, activeGame, true);
+        if (error) {
+          jobTracker.updateFailureReason(error);
           return false;
         }
         return true;
@@ -124,9 +124,9 @@ export async function setupUpdateGameJob(activeGame: SupportedGame) {
       status: "queued",
       label: $format("setup_copyFiles"),
       task: async () => {
-        let resp = await updateDataDirectory(activeGame);
-        if (!resp.success) {
-          jobTracker.updateFailureReason(resp.msg);
+        let error = await updateDataDirectory(activeGame);
+        if (error) {
+          jobTracker.updateFailureReason(error);
           return false;
         }
         return true;
@@ -136,9 +136,9 @@ export async function setupUpdateGameJob(activeGame: SupportedGame) {
       status: "queued",
       label: $format("setup_decompile"),
       task: async () => {
-        let resp = await runDecompiler(null, activeGame, true, false);
-        if (!resp.success) {
-          jobTracker.updateFailureReason(resp.msg);
+        let error = await runDecompiler(null, activeGame, true, false);
+        if (error) {
+          jobTracker.updateFailureReason(error);
           return false;
         }
         return true;
@@ -148,9 +148,9 @@ export async function setupUpdateGameJob(activeGame: SupportedGame) {
       status: "queued",
       label: $format("setup_compile"),
       task: async () => {
-        let resp = await runCompiler(null, activeGame);
-        if (!resp.success) {
-          jobTracker.updateFailureReason(resp.msg);
+        let error = await runCompiler(null, activeGame);
+        if (error) {
+          jobTracker.updateFailureReason(error);
           return false;
         }
         return true;

--- a/src/lib/job/modJob.ts
+++ b/src/lib/job/modJob.ts
@@ -32,14 +32,14 @@ export async function setupModInstallation(
             $format("setup_prompt_selectISO"),
           );
           if (sourcePath !== undefined) {
-            let resp = await extractIsoForModInstall(
+            let error = await extractIsoForModInstall(
               activeGame,
               modName,
               modSourceName,
               sourcePath,
             );
-            if (!resp.success) {
-              jobTracker.updateFailureReason(resp.msg);
+            if (error) {
+              jobTracker.updateFailureReason(error);
               return false;
             }
           } else {
@@ -55,15 +55,14 @@ export async function setupModInstallation(
       label: $format("setup_download"),
       task: async () => {
         if (modDownloadUrl) {
-          // extract the file into install_dir/features/<game>/<sourceName>/<modName>
-          let resp = await downloadAndExtractNewMod(
+          let error = await downloadAndExtractNewMod(
             activeGame,
             modDownloadUrl,
             modName,
             modSourceName,
           );
-          if (!resp.success) {
-            jobTracker.updateFailureReason(resp.msg);
+          if (error) {
+            jobTracker.updateFailureReason(error);
             return false;
           }
         }
@@ -74,13 +73,13 @@ export async function setupModInstallation(
       status: "queued",
       label: $format("setup_decompile"),
       task: async () => {
-        let resp = await decompileForModInstall(
+        let error = await decompileForModInstall(
           activeGame,
           modName,
           modSourceName,
         );
-        if (!resp.success) {
-          jobTracker.updateFailureReason(resp.msg);
+        if (error) {
+          jobTracker.updateFailureReason(error);
           return false;
         }
         return true;
@@ -90,13 +89,13 @@ export async function setupModInstallation(
       status: "queued",
       label: $format("setup_compile"),
       task: async () => {
-        let resp = await compileForModInstall(
+        let error = await compileForModInstall(
           activeGame,
           modName,
           modSourceName,
         );
-        if (!resp.success) {
-          jobTracker.updateFailureReason(resp.msg);
+        if (error) {
+          jobTracker.updateFailureReason(error);
           return false;
         }
         return true;
@@ -106,14 +105,14 @@ export async function setupModInstallation(
       status: "queued",
       label: $format("setup_done"),
       task: async () => {
-        let resp = await saveModInstallInfo(
+        let error = await saveModInstallInfo(
           activeGame,
           modName,
           modSourceName,
           modVersion,
         );
-        if (!resp.success) {
-          jobTracker.updateFailureReason(resp.msg);
+        if (error) {
+          jobTracker.updateFailureReason(error);
           return false;
         }
         return true;
@@ -133,13 +132,13 @@ export async function setupDecompileModJob(
       status: "queued",
       label: $format("setup_decompile"),
       task: async () => {
-        let resp = await decompileForModInstall(
+        let error = await decompileForModInstall(
           activeGame,
           modName,
           modSourceName,
         );
-        if (!resp.success) {
-          jobTracker.updateFailureReason(resp.msg);
+        if (error) {
+          jobTracker.updateFailureReason(error);
           return false;
         }
         return true;
@@ -166,13 +165,13 @@ export async function setupCompileModJob(
       status: "queued",
       label: $format("setup_compile"),
       task: async () => {
-        let resp = await compileForModInstall(
+        let error = await compileForModInstall(
           activeGame,
           modName,
           modSourceName,
         );
-        if (!resp.success) {
-          jobTracker.updateFailureReason(resp.msg);
+        if (error) {
+          jobTracker.updateFailureReason(error);
           return false;
         }
         return true;

--- a/src/lib/job/texturePackJob.ts
+++ b/src/lib/job/texturePackJob.ts
@@ -56,7 +56,7 @@ export async function setupTexturePacks(
       status: "queued",
       label: $format("setup_decompile"),
       task: async () => {
-        let resp = await runDecompiler("", activeGame, true, false);
+        let resp = await runDecompiler(null, activeGame, true, false);
         if (!resp.success) {
           jobTracker.updateFailureReason(resp.msg);
           return false;

--- a/src/lib/job/texturePackJob.ts
+++ b/src/lib/job/texturePackJob.ts
@@ -18,9 +18,9 @@ export async function setupTexturePacks(
       status: "queued",
       label: $format("gameJob_deleteTexturePacks"),
       task: async () => {
-        let resp = await deleteTexturePacks(activeGame, packsToDelete);
-        if (!resp.success) {
-          jobTracker.updateFailureReason(resp.msg);
+        let error = await deleteTexturePacks(activeGame, packsToDelete);
+        if (error) {
+          jobTracker.updateFailureReason(error);
           return false;
         }
         return true;
@@ -32,9 +32,9 @@ export async function setupTexturePacks(
       status: "queued",
       label: $format("gameJob_enablingTexturePacks"),
       task: async () => {
-        let resp = await setEnabledTexturePacks(activeGame, enabledPacks);
-        if (!resp.success) {
-          jobTracker.updateFailureReason(resp.msg);
+        let error = await setEnabledTexturePacks(activeGame, enabledPacks);
+        if (error) {
+          jobTracker.updateFailureReason(error);
           return false;
         }
         return true;
@@ -44,9 +44,9 @@ export async function setupTexturePacks(
       status: "queued",
       label: $format("gameJob_applyTexturePacks"),
       task: async () => {
-        let resp = await updateTexturePackData(activeGame);
-        if (!resp.success) {
-          jobTracker.updateFailureReason(resp.msg);
+        let error = await updateTexturePackData(activeGame);
+        if (error) {
+          jobTracker.updateFailureReason(error);
           return false;
         }
         return true;
@@ -56,9 +56,9 @@ export async function setupTexturePacks(
       status: "queued",
       label: $format("setup_decompile"),
       task: async () => {
-        let resp = await runDecompiler(null, activeGame, true, false);
-        if (!resp.success) {
-          jobTracker.updateFailureReason(resp.msg);
+        let error = await runDecompiler(null, activeGame, true, false);
+        if (error) {
+          jobTracker.updateFailureReason(error);
           return false;
         }
         return true;

--- a/src/lib/rpc/binaries.ts
+++ b/src/lib/rpc/binaries.ts
@@ -1,33 +1,20 @@
-import { filePrompt, filePromptNoFilters } from "$lib/utils/file-dialogs";
+import { filePromptNoFilters } from "$lib/utils/file-dialogs";
 import type { SupportedGame } from "./bindings/SupportedGame";
-import { invoke_rpc } from "./rpc";
-
-interface InstallationOutput {
-  msg: string | null;
-  success: boolean;
-}
-
-function failed(msg: string): InstallationOutput {
-  return { success: false, msg };
-}
+import { invoke_rpc, invoke_rpc2 } from "./rpc";
 
 export async function updateDataDirectory(
   gameName: string,
-): Promise<InstallationOutput> {
-  return await invoke_rpc("update_data_directory", { gameName }, () =>
-    failed("Failed to update data directory"),
-  );
+): Promise<string | null> {
+  return await invoke_rpc2("update_data_directory", { args: { gameName } });
 }
 
 export async function extractAndValidateISO(
   pathToIso: string,
   gameName: string,
-): Promise<InstallationOutput> {
-  return await invoke_rpc(
-    "extract_and_validate_iso",
-    { pathToIso, gameName },
-    () => failed("Failed to extract and validate ISO"),
-  );
+): Promise<string | null> {
+  return await invoke_rpc2("extract_and_validate_iso", {
+    args: { pathToIso, gameName },
+  });
 }
 
 export async function runDecompiler(
@@ -35,44 +22,44 @@ export async function runDecompiler(
   gameName: string,
   truncateLogs: boolean = false,
   useDecompSettings: boolean = false,
-): Promise<InstallationOutput> {
-  return await invoke_rpc(
-    "run_decompiler",
-    { pathToIso, gameName, truncateLogs, useDecompSettings },
-    () => failed("Failed to run decompiler"),
-  );
+): Promise<string | null> {
+  return await invoke_rpc2("run_decompiler", {
+    args: {
+      pathToIso,
+      gameName,
+      truncateLogs,
+      useDecompSettings,
+    },
+  });
 }
 
 export async function runCompiler(
   pathToIso: string | null,
   gameName: string,
   truncateLogs: boolean = false,
-): Promise<InstallationOutput> {
-  return await invoke_rpc(
-    "run_compiler",
-    { pathToIso, gameName, truncateLogs },
-    () => failed("Failed to run compiler"),
-  );
+): Promise<string | null> {
+  return await invoke_rpc2("run_compiler", {
+    args: {
+      pathToIso,
+      gameName,
+      truncateLogs,
+    },
+  });
 }
 
 export async function getLaunchGameString(gameName: string): Promise<string> {
-  return await invoke_rpc(
-    "get_launch_game_string",
-    { gameName },
-    () => "_mirror_",
-  );
+  return await invoke_rpc("get_launch_game_string", { args: { gameName } });
 }
 
 export async function launchGame(
   gameName: SupportedGame,
   inDebug: boolean,
 ): Promise<void> {
-  return await invoke_rpc(
-    "launch_game",
-    { gameName, inDebug, executableLocation: null },
-    () => {},
-    "_mirror_",
-  );
+  return await invoke_rpc("launch_game", {
+    gameName,
+    inDebug,
+    executableLocation: null,
+  });
 }
 
 export async function launchGameWithCustomExecutable(
@@ -81,20 +68,14 @@ export async function launchGameWithCustomExecutable(
   // Get custom executable location
   const customExecutable = await filePromptNoFilters("Select custom 'gk'");
   if (customExecutable !== null) {
-    return await invoke_rpc(
-      "launch_game",
-      { gameName, inDebug: false, executableLocation: customExecutable },
-      () => {},
-      "_mirror_",
-    );
+    return await invoke_rpc("launch_game", {
+      gameName,
+      inDebug: false,
+      executableLocation: customExecutable,
+    });
   }
 }
 
 export async function openREPL(gameName: string): Promise<void> {
-  return await invoke_rpc(
-    "open_repl",
-    { gameName },
-    () => {},
-    "Unable to open REPL",
-  );
+  return await invoke_rpc("open_repl", { gameName });
 }

--- a/src/lib/rpc/binaries.ts
+++ b/src/lib/rpc/binaries.ts
@@ -31,7 +31,7 @@ export async function extractAndValidateISO(
 }
 
 export async function runDecompiler(
-  pathToIso: string,
+  pathToIso: string | null,
   gameName: string,
   truncateLogs: boolean = false,
   useDecompSettings: boolean = false,
@@ -44,7 +44,7 @@ export async function runDecompiler(
 }
 
 export async function runCompiler(
-  pathToIso: string,
+  pathToIso: string | null,
   gameName: string,
   truncateLogs: boolean = false,
 ): Promise<InstallationOutput> {

--- a/src/lib/rpc/cache.ts
+++ b/src/lib/rpc/cache.ts
@@ -2,7 +2,7 @@ import type { ModSourceData } from "./bindings/ModSourceData";
 import { invoke_rpc } from "./rpc";
 
 export async function refreshModSources(): Promise<void> {
-  return await invoke_rpc("refresh_mod_sources", {}, () => {});
+  return await invoke_rpc("refresh_mod_sources", {});
 }
 
 export async function getModSourcesData(): Promise<

--- a/src/lib/rpc/config.ts
+++ b/src/lib/rpc/config.ts
@@ -1,7 +1,5 @@
-import { toastStore } from "$lib/stores/ToastStore";
 import { locale as svelteLocale } from "svelte-i18n";
-import { errorLog } from "./logging";
-import { invoke_rpc } from "./rpc";
+import { invoke_rpc, invoke_rpc2 } from "./rpc";
 import { AVAILABLE_LOCALES, type Locale } from "$lib/i18n/i18n";
 import { exists } from "@tauri-apps/plugin-fs";
 import { appDataDir, join } from "@tauri-apps/api/path";
@@ -9,115 +7,63 @@ import { convertFileSrc } from "@tauri-apps/api/core";
 import type { SupportedGame } from "./bindings/SupportedGame";
 
 export async function resetLauncherSettingsToDefaults(): Promise<boolean> {
-  const success = await invoke_rpc(
-    "reset_to_defaults",
-    {},
-    () => false,
-    "Unable to reset settings",
-  );
-  return success != false;
+  return await invoke_rpc("reset_to_defaults", {});
 }
 
 export async function getInstallationDirectory(): Promise<string | null> {
-  return await invoke_rpc(
-    "get_setting_value",
-    { key: "install_directory" },
-    () => null,
-  );
+  return await invoke_rpc("get_setting_value", { key: "install_directory" });
 }
 
 export async function setInstallationDirectory(
   newDir: string,
 ): Promise<string | null> {
-  // TODO - not insanely crazy about this pattern (message in the response instead of the error)
-  // consider changing it
-  const errMsg = await invoke_rpc(
-    "set_install_directory",
-    { newDir: newDir },
-    () => "Unexpected error occurred",
-    "Invalid installation directory",
-  );
-
-  if (errMsg !== null) {
-    // for RPC errors the log and toast are done by invoke_rpc
-    // but this is a successful RPC, so we need to do it here
-    errorLog("Unable to set install directory");
-    toastStore.makeToast(errMsg, "error");
-  }
-
-  return errMsg;
+  return await invoke_rpc("set_install_directory", { newDir: newDir });
 }
 
 export async function isAVXRequirementMet(): Promise<boolean | undefined> {
-  return await invoke_rpc("is_avx_requirement_met", {}, () => undefined);
+  return await invoke_rpc("is_avx_requirement_met", {});
 }
 
 export async function isOpenGLRequirementMet(
   force: boolean,
 ): Promise<boolean | undefined> {
-  const result = await invoke_rpc(
-    "is_opengl_requirement_met",
-    { force },
-    () => {},
-    "_mirror_",
-  );
-
-  if (typeof result !== "boolean") {
-    return undefined;
-  }
-
-  return result;
+  return await invoke_rpc("is_opengl_requirement_met", { force });
 }
 
 export async function isDiskSpaceRequirementMet(
   gameName: string,
 ): Promise<boolean | undefined> {
-  return await invoke_rpc(
-    "is_diskspace_requirement_met",
-    { gameName },
-    () => undefined,
-    "_mirror_",
-  );
+  return await invoke_rpc("is_diskspace_requirement_met", { gameName });
 }
 
 export async function isMinimumVCCRuntimeInstalled(): Promise<boolean> {
-  return await invoke_rpc(
-    "is_minimum_vcc_runtime_installed",
-    {},
-    () => false,
-    "_mirror_",
-  );
+  return await invoke_rpc("is_minimum_vcc_runtime_installed", {});
 }
 
 export async function finalizeInstallation(
   gameName: string,
   installed = true,
 ): Promise<void> {
-  return await invoke_rpc(
-    "update_setting_value",
-    { key: "installed", val: installed, gameName },
-    () => {},
-  );
+  return await invoke_rpc("update_setting_value", {
+    key: "installed",
+    val: installed,
+    gameName,
+  });
 }
 
 export async function isGameInstalled(
   gameName: SupportedGame | string,
 ): Promise<boolean> {
-  return await invoke_rpc(
-    "get_setting_value",
-    { key: "installed", gameName },
-    () => false,
-  );
+  return await invoke_rpc("get_setting_value", { key: "installed", gameName });
 }
 
 export async function getInstalledVersion(
   gameName: string,
 ): Promise<String | undefined> {
-  return invoke_rpc(
-    "get_setting_value",
-    { key: "installed_version", gameName: gameName },
-    () => undefined,
-  );
+  return invoke_rpc("get_setting_value", {
+    key: "installed_version",
+    gameName: gameName,
+  });
 }
 
 export async function saveActiveVersionChange(
@@ -126,18 +72,12 @@ export async function saveActiveVersionChange(
   return invoke_rpc(
     "update_setting_value",
     { key: "active_version", val: newActiveVersion },
-    () => false,
-    "Couldn't save active version change",
     () => true,
   );
 }
 
 export async function getLocale(): Promise<string | null> {
-  return await invoke_rpc(
-    "get_setting_value",
-    { key: "locale" },
-    () => "en-US",
-  );
+  return await invoke_rpc("get_setting_value", { key: "locale" });
 }
 
 export async function localeSpecificFontAvailableForDownload(
@@ -167,8 +107,7 @@ export async function setLocale(localeId: string): Promise<void> {
   return await invoke_rpc(
     "update_setting_value",
     { key: "locale", val: localeId },
-    () => {},
-    undefined, // no toast
+    undefined,
     async () => {
       svelteLocale.set(localeId);
       // Update CSS variable if needed
@@ -217,144 +156,102 @@ export async function setLocale(localeId: string): Promise<void> {
 }
 
 export async function setAutoUpdateGames(value: boolean): Promise<void> {
-  return await invoke_rpc(
-    "update_setting_value",
-    { key: "auto_update_games", val: value },
-    () => {},
-  );
+  return await invoke_rpc("update_setting_value", {
+    key: "auto_update_games",
+    val: value,
+  });
 }
 
 export async function getAutoUpdateGames(): Promise<boolean> {
-  return await invoke_rpc(
-    "get_setting_value",
-    { key: "auto_update_games" },
-    () => false,
-  );
+  return await invoke_rpc("get_setting_value", { key: "auto_update_games" });
 }
 
 export async function setAutoUninstallOldVersions(
   value: boolean,
 ): Promise<void> {
-  return await invoke_rpc(
-    "update_setting_value",
-    { key: "delete_previous_versions", val: value },
-    () => {},
-  );
+  return await invoke_rpc("update_setting_value", {
+    key: "delete_previous_versions",
+    val: value,
+  });
 }
 
 export async function getAutoUninstallOldVersions(): Promise<boolean> {
-  return await invoke_rpc(
-    "get_setting_value",
-    { key: "delete_previous_versions" },
-    () => false,
-  );
+  return await invoke_rpc("get_setting_value", {
+    key: "delete_previous_versions",
+  });
 }
 
 export async function setBypassRequirements(bypass: boolean): Promise<void> {
-  return await invoke_rpc(
-    "update_setting_value",
-    { key: "bypass_requirements", val: bypass },
-    () => {},
-  );
+  return await invoke_rpc("update_setting_value", {
+    key: "bypass_requirements",
+    val: bypass,
+  });
 }
 
 export async function getBypassRequirements(): Promise<boolean> {
-  return await invoke_rpc(
-    "get_setting_value",
-    { key: "bypass_requirements" },
-    () => false,
-  );
+  return await invoke_rpc("get_setting_value", { key: "bypass_requirements" });
 }
 
 export async function setCheckForLatestModVersion(
   check_for_latest_mod_version: boolean,
 ): Promise<void> {
-  return await invoke_rpc(
-    "update_setting_value",
-    { key: "check_for_latest_mod_version", val: check_for_latest_mod_version },
-    () => {},
-  );
+  return await invoke_rpc("update_setting_value", {
+    key: "check_for_latest_mod_version",
+    val: check_for_latest_mod_version,
+  });
 }
 
 export async function getCheckForLatestModVersion(): Promise<boolean> {
-  return await invoke_rpc(
-    "get_setting_value",
-    { key: "check_for_latest_mod_version" },
-    () => false,
-  );
+  return await invoke_rpc("get_setting_value", {
+    key: "check_for_latest_mod_version",
+  });
 }
 
 export async function getEnabledTexturePacks(
   gameName: string,
 ): Promise<string[]> {
-  return await invoke_rpc(
-    "get_setting_value",
-    { key: "active_texture_packs", gameName: gameName },
-    () => [],
-  );
+  return await invoke_rpc("get_setting_value", {
+    key: "active_texture_packs",
+    gameName: gameName,
+  });
 }
 
 export async function cleanupEnabledTexturePacks(
   gameName: string,
   cleanupList: string[],
 ): Promise<void> {
-  return await invoke_rpc(
-    "cleanup_enabled_texture_packs",
-    {
-      gameName: gameName,
-      cleanupList: cleanupList,
-    },
-    () => {},
-  );
-}
-
-// TODO - just make this a generic interface for both binaries/feature jobs
-interface FeatureJobOutput {
-  msg: string | null;
-  success: boolean;
-}
-
-function failed(msg: string): FeatureJobOutput {
-  return { success: false, msg };
+  return await invoke_rpc("cleanup_enabled_texture_packs", {
+    gameName: gameName,
+    cleanupList: cleanupList,
+  });
 }
 
 export async function setEnabledTexturePacks(
   gameName: string,
   packs: string[],
-): Promise<FeatureJobOutput> {
-  return await invoke_rpc(
-    "update_mods_setting_value",
-    {
+): Promise<string | null> {
+  return await invoke_rpc2("update_mods_setting_value", {
+    args: {
       key: "add_texture_packs",
       gameName: gameName,
       texturePacks: packs,
     },
-    () => failed("Failed to update texture pack list"),
-    undefined,
-    () => {
-      return { success: true, msg: null };
-    },
-  );
+  });
 }
 
 export async function doesActiveToolingVersionSupportGame(
   gameName: string,
 ): Promise<boolean> {
-  return await invoke_rpc(
-    "does_active_tooling_version_support_game",
-    {
-      gameName: gameName,
-    },
-    () => false,
-  );
+  return await invoke_rpc("does_active_tooling_version_support_game", {
+    gameName: gameName,
+  });
 }
 
 export async function getPlaytime(gameName: string): Promise<number> {
-  return await invoke_rpc(
-    "get_setting_value",
-    { key: "seconds_played", gameName: gameName },
-    () => 0,
-  );
+  return await invoke_rpc("get_setting_value", {
+    key: "seconds_played",
+    gameName: gameName,
+  });
 }
 
 export async function doesActiveToolingVersionMeetMinimum(
@@ -362,87 +259,61 @@ export async function doesActiveToolingVersionMeetMinimum(
   minimumMinor: number,
   minimumPatch: number,
 ): Promise<boolean> {
-  return await invoke_rpc(
-    "does_active_tooling_version_meet_minimum",
-    {
-      minimumPatch: minimumPatch,
-      minimumMinor: minimumMinor,
-      minimumMajor: minimumMajor,
-    },
-    () => false,
-  );
+  return await invoke_rpc("does_active_tooling_version_meet_minimum", {
+    minimumPatch: minimumPatch,
+    minimumMinor: minimumMinor,
+    minimumMajor: minimumMajor,
+  });
 }
 
 export async function isRipLevelsEnabled(): Promise<boolean> {
-  return await invoke_rpc(
-    "get_setting_value",
-    { key: "rip_levels" },
-    () => false,
-  );
+  return await invoke_rpc("get_setting_value", { key: "rip_levels" });
 }
 
 export async function setRipLevelsEnabled(enabled: boolean): Promise<void> {
-  return await invoke_rpc(
-    "update_setting_value",
-    { key: "rip_levels", val: enabled },
-    () => {},
-  );
+  return await invoke_rpc("update_setting_value", {
+    key: "rip_levels",
+    val: enabled,
+  });
 }
 
 export async function isRipCollisionEnabled(): Promise<boolean> {
-  return await invoke_rpc(
-    "get_setting_value",
-    { key: "rip_collision" },
-    () => false,
-  );
+  return await invoke_rpc("get_setting_value", { key: "rip_collision" });
 }
 
 export async function setRipCollisionEnabled(enabled: boolean): Promise<void> {
-  return await invoke_rpc(
-    "update_setting_value",
-    { key: "rip_collision", val: enabled },
-    () => {},
-  );
+  return await invoke_rpc("update_setting_value", {
+    key: "rip_collision",
+    val: enabled,
+  });
 }
 
 export async function isRipTexturesEnabled(): Promise<boolean> {
-  return await invoke_rpc(
-    "get_setting_value",
-    { key: "rip_textures" },
-    () => false,
-  );
+  return await invoke_rpc("get_setting_value", { key: "rip_textures" });
 }
 
 export async function setRipTexturesEnabled(enabled: boolean): Promise<void> {
-  return await invoke_rpc(
-    "update_setting_value",
-    { key: "rip_textures", val: enabled },
-    () => {},
-  );
+  return await invoke_rpc("update_setting_value", {
+    key: "rip_textures",
+    val: enabled,
+  });
 }
 
 export async function isRipStreamedAudioEnabled(): Promise<boolean> {
-  return await invoke_rpc(
-    "get_setting_value",
-    { key: "rip_streamed_audio" },
-    () => false,
-  );
+  return await invoke_rpc("get_setting_value", { key: "rip_streamed_audio" });
 }
 
 export async function getProceedAfterSuccessfulOperation(): Promise<boolean> {
-  return await invoke_rpc(
-    "get_setting_value",
-    { key: "proceed_after_successful_operation" },
-    () => true,
-  );
+  return await invoke_rpc("get_setting_value", {
+    key: "proceed_after_successful_operation",
+  });
 }
 
 export async function setRipStreamedAudioEnabled(
   enabled: boolean,
 ): Promise<void> {
-  return await invoke_rpc(
-    "update_setting_value",
-    { key: "rip_streamed_audio", val: enabled },
-    () => {},
-  );
+  return await invoke_rpc("update_setting_value", {
+    key: "rip_streamed_audio",
+    val: enabled,
+  });
 }

--- a/src/lib/rpc/download.ts
+++ b/src/lib/rpc/download.ts
@@ -4,10 +4,5 @@ export async function downloadFile(
   url: String,
   destination: String,
 ): Promise<void> {
-  await invoke_rpc(
-    "download_file",
-    { url, destination },
-    () => {},
-    "Unable to download file",
-  );
+  await invoke_rpc("download_file", { url, destination });
 }

--- a/src/lib/rpc/features.ts
+++ b/src/lib/rpc/features.ts
@@ -18,10 +18,12 @@ export async function listExtractedTexturePackInfo(
 export async function extractNewTexturePack(
   gameName: string,
   pathToZip: string,
-): Promise<boolean | undefined> {
-  return await invoke_rpc("extract_new_texture_pack", {
-    gameName: gameName,
-    zipPath: pathToZip,
+): Promise<string | null> {
+  return await invoke_rpc2("extract_new_texture_pack", {
+    args: {
+      gameName: gameName,
+      zipPath: pathToZip,
+    },
   });
 }
 

--- a/src/lib/rpc/features.ts
+++ b/src/lib/rpc/features.ts
@@ -2,86 +2,56 @@ import { toastStore } from "$lib/stores/ToastStore";
 import type { ModInfo } from "./bindings/ModInfo";
 import type { ModSourceData } from "./bindings/ModSourceData";
 import { errorLog } from "./logging";
-import { invoke_rpc } from "./rpc";
+import { invoke_rpc, invoke_rpc2 } from "./rpc";
 import { unwrapFunctionStore, format } from "svelte-i18n";
 
 const $format = unwrapFunctionStore(format);
 
-// TODO - just make this a generic interface for both binaries/feature jobs
-interface FeatureJobOutput {
-  msg: string | null;
-  success: boolean;
-}
-
-function failed(msg: string): FeatureJobOutput {
-  toastStore.makeToast(msg, "error");
-  return { success: false, msg };
-}
-
 export async function listExtractedTexturePackInfo(
   gameName: string,
 ): Promise<any> {
-  return await invoke_rpc(
-    "list_extracted_texture_pack_info",
-    {
-      gameName: gameName,
-    },
-    () => [],
-  );
+  return await invoke_rpc("list_extracted_texture_pack_info", {
+    gameName: gameName,
+  });
 }
 
 export async function extractNewTexturePack(
   gameName: string,
   pathToZip: string,
 ): Promise<boolean | undefined> {
-  return await invoke_rpc(
-    "extract_new_texture_pack",
-    {
-      gameName: gameName,
-      zipPath: pathToZip,
-    },
-    () => undefined,
-  );
+  return await invoke_rpc("extract_new_texture_pack", {
+    gameName: gameName,
+    zipPath: pathToZip,
+  });
 }
 
 export async function updateTexturePackData(
   gameName: string,
-): Promise<FeatureJobOutput> {
-  return await invoke_rpc(
-    "update_texture_pack_data",
-    {
+): Promise<string | null> {
+  return await invoke_rpc2("update_texture_pack_data", {
+    args: {
       gameName: gameName,
     },
-    () => failed("Failed to delete texture packs"),
-    undefined,
-    () => {
-      return { success: true, msg: null };
-    },
-  );
+  });
 }
 
 export async function deleteTexturePacks(
   gameName: string,
   packs: string[],
-): Promise<FeatureJobOutput> {
-  return await invoke_rpc(
-    "delete_texture_packs",
-    {
+): Promise<string | null> {
+  return await invoke_rpc2("delete_texture_packs", {
+    args: {
       gameName: gameName,
       packs: packs,
     },
-    () => failed("Failed to delete texture packs"),
-    undefined,
-    () => {
-      return { success: true, msg: null };
-    },
-  );
+  });
 }
 
+// TODO: refactor, this function is doing too much we CAN and SHOULD handle the verification on the backend.
 export async function addModSource(
   url: string,
   currentSources: Record<string, ModSourceData>,
-): Promise<boolean> {
+): Promise<string | null> {
   // Check that the URL is valid, easiest to do this on the client-side
   try {
     const sourceResp = await fetch(url);
@@ -90,84 +60,53 @@ export async function addModSource(
         `${$format("toasts_modSourceUnreachable")} - Status ${sourceResp.status}`,
         "error",
       );
-      return false;
-    }
-    const newSourceData = await sourceResp.json();
-    // Make sure that we don't already have a mod source with the same display name
-    for (const [sourceUrl, sourceData] of Object.entries(currentSources)) {
-      if (sourceData.sourceName === newSourceData["sourceName"]) {
-        toastStore.makeToast(
-          `${$format("toasts_modSourceDuplicateName")}: ${sourceData.sourceName}@${sourceUrl}`,
-          "error",
-        );
-        return false;
-      }
+      return "invalid mod source";
     }
   } catch (e) {
     errorLog(`Unable to add mod source: ${e}`);
     toastStore.makeToast(`${$format("toasts_modSourceUnreachable")}`, "error");
-    return false;
+    return "Unable to add mod source";
   }
 
-  return await invoke_rpc(
-    "update_setting_value",
-    {
+  return await invoke_rpc2("update_setting_value", {
+    args: {
       key: "add_mod_source",
       val: url,
     },
-    () => false,
-    "Unable to add mod source",
-    () => true,
-  );
+  });
 }
 
 export async function removeModSource(modSource: string): Promise<void> {
-  await invoke_rpc(
-    "update_setting_value",
-    {
-      key: "remove_mod_source",
-      val: modSource,
-    },
-    () => {
-      toastStore.makeToast(
-        `${$format("toasts_couldNotRemoveModSource")}`,
-        "error",
-      );
-    },
-  );
+  await invoke_rpc("update_setting_value", {
+    key: "remove_mod_source",
+    val: modSource,
+  });
 }
 
 export async function getModSourceUrls(): Promise<string[]> {
-  return await invoke_rpc(
-    "get_setting_value",
-    { key: "mod_sources" },
-    () => [],
-  );
+  return await invoke_rpc("get_setting_value", { key: "mod_sources" });
 }
 
 export async function extractNewMod(
   gameName: string,
   bundlePath: string,
   modSource: string,
-): Promise<InstallationOutput> {
-  return await invoke_rpc(
-    "extract_new_mod",
-    { gameName, bundlePath, modSource },
-    () => failed("Failed to extract mod"),
-  );
+): Promise<string | null> {
+  return await invoke_rpc2("extract_new_mod", {
+    args: { gameName, bundlePath, modSource },
+  });
 }
 
+/** extract the file into `install_dir/features/<gameName>/<sourceName>/<modName>` */
 export async function downloadAndExtractNewMod(
   gameName: string,
   downloadUrl: string,
   modName: string,
   sourceName: string,
-): Promise<InstallationOutput> {
-  return await invoke_rpc(
-    "download_and_extract_new_mod",
-    { gameName, downloadUrl, modName, sourceName },
-    () => failed("Failed to download and extract mod"),
-  );
+): Promise<string | null> {
+  return await invoke_rpc2("download_and_extract_new_mod", {
+    args: { gameName, downloadUrl, modName, sourceName },
+  });
 }
 
 export async function getLocallyPersistedModInfo(
@@ -175,20 +114,15 @@ export async function getLocallyPersistedModInfo(
   modName: string,
   sourceName: string,
 ): Promise<ModInfo | undefined> {
-  return await invoke_rpc(
-    "get_locally_persisted_mod_info",
-    { gameName, modName, sourceName },
-    () => undefined,
-  );
+  return await invoke_rpc("get_locally_persisted_mod_info", {
+    gameName,
+    modName,
+    sourceName,
+  });
 }
 
 export async function baseGameIsoExists(gameName: string): Promise<boolean> {
-  return await invoke_rpc("base_game_iso_exists", { gameName }, () => false);
-}
-
-interface InstallationOutput {
-  msg: string | null;
-  success: boolean;
+  return await invoke_rpc("base_game_iso_exists", { gameName });
 }
 
 export async function extractIsoForModInstall(
@@ -196,36 +130,30 @@ export async function extractIsoForModInstall(
   modName: string | undefined,
   sourceName: string | undefined,
   pathToIso: string,
-): Promise<InstallationOutput> {
-  return await invoke_rpc(
-    "extract_iso_for_mod_install",
-    { gameName, modName, sourceName, pathToIso },
-    () => failed("Failed to extract and validate ISO"),
-  );
+): Promise<string | null> {
+  return await invoke_rpc2("extract_iso_for_mod_install", {
+    args: { gameName, modName, sourceName, pathToIso },
+  });
 }
 
 export async function decompileForModInstall(
   gameName: string,
   modName: string | undefined,
   sourceName: string | undefined,
-): Promise<InstallationOutput> {
-  return await invoke_rpc(
-    "decompile_for_mod_install",
-    { gameName, modName, sourceName },
-    () => failed("Failed to decompile"),
-  );
+): Promise<string | null> {
+  return await invoke_rpc2("decompile_for_mod_install", {
+    args: { gameName, modName, sourceName },
+  });
 }
 
 export async function compileForModInstall(
   gameName: string,
   modName: string | undefined,
   sourceName: string | undefined,
-): Promise<InstallationOutput> {
-  return await invoke_rpc(
-    "compile_for_mod_install",
-    { gameName, modName, sourceName },
-    () => failed("Failed to compile"),
-  );
+): Promise<string | null> {
+  return await invoke_rpc2("compile_for_mod_install", {
+    args: { gameName, modName, sourceName },
+  });
 }
 
 export async function saveModInstallInfo(
@@ -233,12 +161,10 @@ export async function saveModInstallInfo(
   modName: string | undefined,
   sourceName: string | undefined,
   versionName: string | undefined,
-): Promise<InstallationOutput> {
-  return await invoke_rpc(
-    "save_mod_install_info",
-    { gameName, modName, sourceName, versionName },
-    () => failed("Failed to save mod install info"),
-  );
+): Promise<string | null> {
+  return await invoke_rpc2("save_mod_install_info", {
+    args: { gameName, modName, sourceName, versionName },
+  });
 }
 
 export async function getInstalledMods(
@@ -247,10 +173,10 @@ export async function getInstalledMods(
   return await invoke_rpc(
     "get_setting_value",
     { key: "installed_mods", gameName },
-    () => {
-      let ret: Record<string, Record<string, string>> = {};
-      return ret;
-    },
+    // () => {
+    //   let ret: Record<string, Record<string, string>> = {};
+    //   return ret;
+    // },
   );
 }
 
@@ -260,24 +186,22 @@ export async function launchMod(
   modName: string,
   sourceName: string,
 ): Promise<void> {
-  return await invoke_rpc(
-    "launch_mod",
-    { gameName, inDebug, modName, sourceName },
-    () => {},
-    "_mirror_",
-  );
+  return await invoke_rpc("launch_mod", {
+    gameName,
+    inDebug,
+    modName,
+    sourceName,
+  });
 }
 
 export async function getLocalModThumbnailBase64(
   gameName: string,
   modName: string,
 ): Promise<string> {
-  return await invoke_rpc(
-    "get_local_mod_thumbnail_base64",
-    { gameName, modName },
-    () => "",
-    "_mirror_",
-  );
+  return await invoke_rpc("get_local_mod_thumbnail_base64", {
+    gameName,
+    modName,
+  });
 }
 
 export async function uninstallMod(
@@ -285,12 +209,7 @@ export async function uninstallMod(
   modName: string,
   sourceName: string,
 ): Promise<void> {
-  return await invoke_rpc(
-    "uninstall_mod",
-    { gameName, modName, sourceName },
-    () => {},
-    "_mirror_",
-  );
+  return await invoke_rpc("uninstall_mod", { gameName, modName, sourceName });
 }
 
 export async function resetModSettings(
@@ -298,12 +217,11 @@ export async function resetModSettings(
   modName: string,
   sourceName: string,
 ): Promise<void> {
-  return await invoke_rpc(
-    "reset_mod_settings",
-    { gameName, modName, sourceName },
-    () => {},
-    "Unable to reset mod settings",
-  );
+  return await invoke_rpc("reset_mod_settings", {
+    gameName,
+    modName,
+    sourceName,
+  });
 }
 
 export async function getLaunchModString(
@@ -311,11 +229,11 @@ export async function getLaunchModString(
   modName: string,
   sourceName: string,
 ): Promise<string> {
-  return await invoke_rpc(
-    "get_launch_mod_string",
-    { gameName, modName, sourceName },
-    () => "_mirror_",
-  );
+  return await invoke_rpc("get_launch_mod_string", {
+    gameName,
+    modName,
+    sourceName,
+  });
 }
 
 export async function openREPLForMod(
@@ -323,10 +241,9 @@ export async function openREPLForMod(
   modName: string,
   sourceName: string,
 ): Promise<void> {
-  return await invoke_rpc(
-    "open_repl_for_mod",
-    { gameName, modName, sourceName },
-    () => {},
-    "Unable to open REPL for mod",
-  );
+  return await invoke_rpc("open_repl_for_mod", {
+    gameName,
+    modName,
+    sourceName,
+  });
 }

--- a/src/lib/rpc/game.ts
+++ b/src/lib/rpc/game.ts
@@ -2,33 +2,17 @@ import { invoke_rpc } from "./rpc";
 import { toastStore } from "$lib/stores/ToastStore";
 
 export async function uninstallGame(gameName: string): Promise<boolean> {
-  return await invoke_rpc(
-    "uninstall_game",
-    { gameName },
-    () => false,
-    "Unable to uninstall game",
-  );
+  return await invoke_rpc("uninstall_game", { gameName });
 }
 
 export async function resetGameSettings(gameName: string): Promise<void> {
-  return await invoke_rpc(
-    "reset_game_settings",
-    { gameName },
-    () => {},
-    "_mirror_",
-    () => {
-      toastStore.makeToast(`${gameName} settings reset`, "info");
-    },
-  );
+  return await invoke_rpc("reset_game_settings", { gameName }, () => {
+    toastStore.makeToast(`${gameName} settings reset`, "info");
+  });
 }
 
 export async function getFurthestGameMilestone(
   gameName: string,
 ): Promise<String> {
-  return await invoke_rpc(
-    "get_furthest_game_milestone",
-    { gameName },
-    () => "geyser", // TODO - default for only jak 1 right now
-    "Unable to get furthest game milestone",
-  );
+  return await invoke_rpc("get_furthest_game_milestone", { gameName });
 }

--- a/src/lib/rpc/rpc.ts
+++ b/src/lib/rpc/rpc.ts
@@ -2,6 +2,8 @@ import { toastStore } from "$lib/stores/ToastStore";
 import { invoke, type InvokeArgs } from "@tauri-apps/api/core";
 import { errorLog, exceptionLog } from "./logging";
 
+// TODO: make args optional, add optional object encapsulating the optional params, this makes the call sites easier to read
+
 /**
  * Wrapper around Tauri invoke that logs all errors.
  * If the error is a string, it is also displayed as a toast.
@@ -14,30 +16,51 @@ import { errorLog, exceptionLog } from "./logging";
 export async function invoke_rpc<T>(
   cmd: string,
   args: InvokeArgs,
-  handleError: (error: unknown) => T,
-  toastOnError?: string,
+  onError?: (error: unknown) => T,
   onSuccess?: (result: T) => T,
 ): Promise<T> {
   try {
     // this assumes the call is made in a way that does not trick the type inference
     const result: T = await invoke(cmd, args);
-    if (onSuccess) {
-      return onSuccess(result);
-    }
-    return result;
+    return onSuccess ? onSuccess(result) : result;
   } catch (e: any) {
     if (typeof e === "string") {
       errorLog(`Error calling '${cmd}': ${e}`);
     } else {
       exceptionLog(`Error calling '${cmd}'`, e);
     }
-    // TODO - this is a dumb hack but whatever for now
-    if (toastOnError === "_mirror_") {
-      toastStore.makeToast(e, "error");
+    toastStore.makeToast(String(e), "error");
+    return onError ? onError(e) : e;
+  }
+}
+
+// TODO: TEMPORARY SECOND INVOKE WRAPPER WHILE I EXPERIMENT WITH THE SYSTEM
+// used for any tauri::command with the return type: Result<(), Error>
+
+/**
+ * Wrapper around Tauri invoke that logs all errors.
+ * If the error is a string, it is also displayed as a toast.
+ *
+ * @param cmd The command to send to the backend
+ * @param args The arguments for the command
+ * @returns `null` on success, `string` on error
+ */
+export async function invoke_rpc2(
+  cmd: string,
+  options?: {
+    args?: InvokeArgs;
+  },
+): Promise<string | null> {
+  try {
+    await invoke(cmd, options?.args);
+    return null;
+  } catch (e: any) {
+    if (typeof e === "string") {
+      errorLog(`Error calling '${cmd}': ${e}`);
     } else {
-      const toastMessage = toastOnError ?? "An unexpected error occurred";
-      toastStore.makeToast(toastMessage, "error");
+      exceptionLog(`Error calling '${cmd}'`, e);
     }
-    return handleError(e);
+    toastStore.makeToast(String(e), "error");
+    return String(e);
   }
 }

--- a/src/lib/rpc/support.ts
+++ b/src/lib/rpc/support.ts
@@ -7,10 +7,5 @@ export async function generateSupportPackage(): Promise<void> {
     ["zip"],
     "opengoal-support-package.zip",
   );
-  return await invoke_rpc(
-    "generate_support_package",
-    { userPath },
-    () => {},
-    "Unable to create support package",
-  );
+  return await invoke_rpc("generate_support_package", { userPath });
 }

--- a/src/lib/rpc/util.ts
+++ b/src/lib/rpc/util.ts
@@ -1,5 +1,5 @@
 import { invoke_rpc } from "./rpc";
 
 export async function isMacOSVersion15OrAbove(): Promise<boolean | undefined> {
-  return await invoke_rpc("is_macos_version_15_or_above", {}, () => undefined);
+  return await invoke_rpc("is_macos_version_15_or_above", {});
 }

--- a/src/lib/rpc/versions.ts
+++ b/src/lib/rpc/versions.ts
@@ -17,20 +17,12 @@ export async function downloadOfficialVersion(
   return await invoke_rpc(
     "download_version",
     { version, url, versionFolder: "official" },
-    () => false,
-    "Unable to download official version",
     () => true,
   );
 }
 
 export async function removeVersion(version: String): Promise<boolean> {
-  return await invoke_rpc(
-    "remove_version",
-    { version },
-    () => false,
-    "Unable to remove version",
-    () => true,
-  );
+  return await invoke_rpc("remove_version", { version }, () => true);
 }
 
 export async function removeOldVersions(): Promise<boolean> {
@@ -50,18 +42,9 @@ export async function removeOldVersions(): Promise<boolean> {
 }
 
 export async function getActiveVersion(): Promise<string | undefined> {
-  return await invoke_rpc(
-    "get_setting_value",
-    { key: "active_version" },
-    () => undefined,
-  );
+  return await invoke_rpc("get_setting_value", { key: "active_version" });
 }
 
 export async function ensureActiveVersionStillExists(): Promise<boolean> {
-  return await invoke_rpc(
-    "ensure_active_version_still_exists",
-    {},
-    () => false,
-    "Error checking that active version exists",
-  );
+  return await invoke_rpc("ensure_active_version_still_exists", {});
 }

--- a/src/lib/rpc/window.ts
+++ b/src/lib/rpc/window.ts
@@ -1,5 +1,5 @@
 import { invoke_rpc } from "./rpc";
 
 export async function openMainWindow(): Promise<boolean> {
-  return await invoke_rpc("open_main_window", {}, () => false);
+  return await invoke_rpc("open_main_window", {});
 }

--- a/src/routes/settings/versions/OfficialVersions.svelte
+++ b/src/routes/settings/versions/OfficialVersions.svelte
@@ -103,8 +103,8 @@
   }
 
   async function saveOfficialVersionChange(version: string) {
-    const success = await saveActiveVersionChange(version);
-    if (success) {
+    const error = await saveActiveVersionChange(version);
+    if (!error) {
       toastStore.makeToast($_("toasts_savedToolingVersion"), "info");
     }
   }
@@ -116,27 +116,8 @@
         ? { ...release, pendingAction: true }
         : release,
     );
-    const success = await downloadOfficialVersion(version, downloadUrl);
-    if (success) {
-      versionState.activeToolingVersion = version;
-      // Then mark it as downloaded
-      releases = releases.map((release) => {
-        if (release.version !== version) return release;
-
-        const isLatest = version === releases[0]?.version;
-
-        if ($UpdateStore.selectedTooling.updateAvailable && isLatest) {
-          $UpdateStore.selectedTooling.updateAvailable = false;
-        }
-
-        return {
-          ...release,
-          pendingAction: false,
-          isDownloaded: success,
-        };
-      });
-      await saveActiveVersionChange(version);
-    } else {
+    const error = await downloadOfficialVersion(version, downloadUrl);
+    if (error) {
       // ensure the version folder is removed if it failed
       await onRemoveVersion(version);
       releases = releases.map((release) =>
@@ -144,7 +125,22 @@
           ? { ...release, pendingAction: false }
           : release,
       );
+      return;
     }
+
+    versionState.activeToolingVersion = version;
+    const isLatest = version === releases[0]?.version;
+
+    if ($UpdateStore.selectedTooling.updateAvailable && isLatest) {
+      $UpdateStore.selectedTooling.updateAvailable = false;
+    }
+
+    releases = releases.map((release) =>
+      release.version === version
+        ? { ...release, pendingAction: false, isDownloaded: true }
+        : release,
+    );
+    await saveOfficialVersionChange(version);
   }
 
   async function onRemoveVersion(version: string) {
@@ -154,26 +150,27 @@
         ? { ...release, pendingAction: true }
         : release,
     );
-    const success = await removeVersion(version);
-    if (success) {
-      // Update the store, if we removed the active version
-      if (versionState.activeToolingVersion === version) {
-        versionState.activeToolingVersion = undefined;
-      }
-
-      // Then mark it as not downloaded
-      releases = releases.map((release) =>
-        release.version === version
-          ? { ...release, pendingAction: false, isDownloaded: false }
-          : release,
-      );
-    } else {
+    const error = await removeVersion(version);
+    if (error) {
       releases = releases.map((release) =>
         release.version === version
           ? { ...release, pendingAction: false }
           : release,
       );
+      return;
     }
+
+    // Update the store, if we removed the active version
+    if (versionState.activeToolingVersion === version) {
+      versionState.activeToolingVersion = undefined;
+    }
+
+    // Then mark it as not downloaded
+    releases = releases.map((release) =>
+      release.version === version
+        ? { ...release, pendingAction: false, isDownloaded: false }
+        : release,
+    );
   }
 </script>
 


### PR DESCRIPTION
The scope of this pull request grew beyond my original desire. That being said here's a quick recap of what this pull request entails:

New:
- `fn format_exit_code` on Windows this converts error codes from `gk.exe` to hex. For example: previously users would see: `-1073740791`, now users see: `-1073740791 (0xc0000409)`. Given the abundance of discord support threads containing the old exit codes, I decided to keep the original error code in addition to the hex code. This breaks from my personal design standard of "assume this is the first time our end-user is touching a PC and avoid overwhelming them with information."
- `function invoke_rpc2` used for any `tauri::command` that returns `Result<(), Error>`
- Add quotes around the executable_path when generating launch game strings for shortcut/steam.

Removed:
- `struct InstallStepOutput` any Rust function that previously returned this now returns `Result<(), Error>`. This simplifies front-end control flow. Functions with this return type return `null` on success, or `string` on error. This change led to the explosion in scope.
- `struct ToastPayload` similar to above, I want to keep the back-end Result types agnostic to the front-end. This also no longer serves a purpose because all errors are pushed through our toast.
- `_mirror_` in `function invoke_rpc` for propagating Rust errors to toast. Errors are now propagated by default.
- Commented out `packAddingError` on `TexturePacks.svelte` in favor of propagating errors to the toast.

Future considerations:
- handle errors better on the front-end using a dedicated error screen. SvelteKit offers great Error page support.
- abstract out the repeated pattern in `gameJob.ts`
- make the args optional for `invoke_rpc` by wrapping them in an `options: {}` object.

