### PR TITLE
fix startup routing issue

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -41,7 +41,7 @@ export const { p, navigate, isActive, route } = createRouter({
     beforeLoad({ pathname }) {
       if (pathname === "/") {
         // simple redirect to default game
-        throw navigate("/jak1" as any);
+        throw navigate("/:game_name/", { params: { game_name: "jak1" } });
       }
     },
   },
@@ -73,16 +73,16 @@ export const { p, navigate, isActive, route } = createRouter({
             return;
           }
 
-          const currentRequirements =
-            await requirementsStore.refresh(activeGame);
-          if (!currentRequirements.requirementsMet) {
-            throw navigate("/:game_name/requirements", {
+          if (!versionState.activeToolingVersion) {
+            throw navigate("/:game_name/tools-not-set", {
               params: { game_name: params.game_name },
             });
           }
 
-          if (versionState.activeToolingVersion === null) {
-            throw navigate("/:game_name/tools-not-set", {
+          const currentRequirements =
+            await requirementsStore.refresh(activeGame);
+          if (!currentRequirements.requirementsMet) {
+            throw navigate("/:game_name/requirements", {
               params: { game_name: params.game_name },
             });
           }


### PR DESCRIPTION
this pull request reorders the startup routing control flow because:
1. the requirements check is dependent on an active tooling version being set
2. prior to this pull request the user would see the game installed screen despite having no active tooling version

additionally, this reverts a regression i introduced in my previous `router.ts` pull request