### PR TITLE
fix: getActiveVersion in router

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -20,8 +20,6 @@
 
   // Events
   onMount(async () => {
-    versionState.activeToolingVersion = await getActiveVersion();
-
     // Set locale from settings
     const locale = await getLocale();
     if (locale !== null) {

--- a/src/components/header/Header.svelte
+++ b/src/components/header/Header.svelte
@@ -9,7 +9,6 @@
   import { isInDebugMode } from "$lib/utils/common";
   import {
     downloadOfficialVersion,
-    getActiveVersion,
     listDownloadedVersions,
     removeOldVersions,
   } from "$lib/rpc/versions";
@@ -49,7 +48,6 @@
   onMount(async () => {
     // Get current versions
     launcherVersion = `v${await getVersion()}`;
-    versionState.activeToolingVersion = await getActiveVersion();
 
     // Check for a launcher update
     if (!isInDebugMode()) {

--- a/src/lib/rpc/config.ts
+++ b/src/lib/rpc/config.ts
@@ -6,7 +6,7 @@ import { appDataDir, join } from "@tauri-apps/api/path";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import type { SupportedGame } from "./bindings/SupportedGame";
 
-export async function resetLauncherSettingsToDefaults(): Promise<string | null> {
+export async function resetLauncherSettings(): Promise<string | null> {
   return await invoke_rpc("reset_to_defaults", {});
 }
 

--- a/src/lib/rpc/config.ts
+++ b/src/lib/rpc/config.ts
@@ -6,7 +6,7 @@ import { appDataDir, join } from "@tauri-apps/api/path";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import type { SupportedGame } from "./bindings/SupportedGame";
 
-export async function resetLauncherSettingsToDefaults(): Promise<boolean> {
+export async function resetLauncherSettingsToDefaults(): Promise<string | null> {
   return await invoke_rpc("reset_to_defaults", {});
 }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -29,7 +29,7 @@ import {
   getInstalledVersion,
   isGameInstalled,
 } from "$lib/rpc/config";
-import { ensureActiveVersionStillExists } from "$lib/rpc/versions";
+import { ensureActiveVersionStillExists, getActiveVersion } from "$lib/rpc/versions";
 import { toSupportedGame } from "$lib/rpc/bindings/utils/SupportedGame";
 import Requirements from "./components/job/Requirements.svelte";
 import { requirementsStore } from "./state/requirements-store";
@@ -73,6 +73,7 @@ export const { p, navigate, isActive, route } = createRouter({
             return;
           }
 
+          versionState.activeToolingVersion = await getActiveVersion();
           if (!versionState.activeToolingVersion) {
             throw navigate("/:game_name/tools-not-set", {
               params: { game_name: params.game_name },

--- a/src/router.ts
+++ b/src/router.ts
@@ -29,7 +29,10 @@ import {
   getInstalledVersion,
   isGameInstalled,
 } from "$lib/rpc/config";
-import { ensureActiveVersionStillExists, getActiveVersion } from "$lib/rpc/versions";
+import {
+  ensureActiveVersionStillExists,
+  getActiveVersion,
+} from "$lib/rpc/versions";
 import { toSupportedGame } from "$lib/rpc/bindings/utils/SupportedGame";
 import Requirements from "./components/job/Requirements.svelte";
 import { requirementsStore } from "./state/requirements-store";

--- a/src/routes/settings/General.svelte
+++ b/src/routes/settings/General.svelte
@@ -211,10 +211,8 @@
           $_("settings_general_button_resetSettings_confirmation"),
         );
         if (confirmed) {
-          const result = await resetLauncherSettingsToDefaults();
-          if (result) {
-            versionState.activeToolingVersion = await getActiveVersion();
-          }
+          const error = await resetLauncherSettingsToDefaults();
+          versionState.activeToolingVersion = await getActiveVersion();
         }
       }}>{$_("settings_general_button_resetSettings")}</Button
     >

--- a/src/routes/settings/General.svelte
+++ b/src/routes/settings/General.svelte
@@ -5,7 +5,7 @@
     getInstallationDirectory,
     getLocale,
     localeSpecificFontAvailableForDownload,
-    resetLauncherSettingsToDefaults,
+    resetLauncherSettings,
     setAutoUpdateGames,
     getAutoUpdateGames,
     setBypassRequirements,
@@ -211,7 +211,7 @@
           $_("settings_general_button_resetSettings_confirmation"),
         );
         if (confirmed) {
-          const error = await resetLauncherSettingsToDefaults();
+          const error = await resetLauncherSettings();
           versionState.activeToolingVersion = await getActiveVersion();
         }
       }}>{$_("settings_general_button_resetSettings")}</Button


### PR DESCRIPTION
The router loads before `App.svelte` and `Header.svelte`, two files we previously used to load `activeVersion`. This pull request removes the `getActiveVersion` in both of those files and moves it into the router to prevent routing the users to `tool-not-set` despite having an `activeVersion`.