### PR TITLE
use minimumSystemVersion in tauri config to ensure macos >= 15

### DIFF
--- a/src-tauri/src/commands/util.rs
+++ b/src-tauri/src/commands/util.rs
@@ -3,8 +3,6 @@ use crate::config::SupportedGame;
 use anyhow::anyhow;
 use log::warn;
 use sysinfo::Disks;
-#[cfg(target_os = "macos")]
-use sysinfo::System;
 
 use super::CommandError;
 
@@ -71,21 +69,6 @@ pub async fn is_avx_supported() -> bool {
 #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 pub async fn is_avx_supported() -> bool {
   false
-}
-
-#[cfg(not(target_os = "macos"))]
-#[tauri::command]
-pub async fn is_macos_version_15_or_above() -> bool {
-  false
-}
-
-#[cfg(target_os = "macos")]
-#[tauri::command]
-pub async fn is_macos_version_15_or_above() -> bool {
-  System::os_version()
-    .and_then(|v| v.split('.').next()?.parse::<u32>().ok())
-    .map(|major| major >= 15)
-    .unwrap_or(false)
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -214,7 +214,6 @@ fn main() {
       commands::support::generate_support_package,
       commands::util::frontend_log,
       commands::util::is_diskspace_requirement_met,
-      commands::util::is_macos_version_15_or_above,
       commands::util::is_minimum_vcc_runtime_installed,
       commands::versions::download_version,
       commands::versions::ensure_active_version_still_exists,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,8 @@
       "timestampUrl": ""
     },
     "macOS": {
-      "signingIdentity": "-"
+      "signingIdentity": "-",
+      "minimumSystemVersion": "15.0"
     },
     "icon": [
       "icons/32x32.png",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -10,7 +10,6 @@
   } from "$lib/rpc/config";
   import { listen } from "@tauri-apps/api/event";
   import { toastStore, type ToastLevel } from "$lib/stores/ToastStore";
-  import { isMacOSVersion15OrAbove } from "$lib/rpc/util";
   import { getActiveVersion } from "$lib/rpc/versions.ts";
   import { versionState } from "./state/VersionState.svelte.ts";
   import { systemInfoState } from "./state/SystemInfoState.svelte.ts";
@@ -28,7 +27,6 @@
 
     systemInfoState.isMinVCCRuntimeInstalled =
       await isMinimumVCCRuntimeInstalled();
-    systemInfoState.isMinMacOSVersion = await isMacOSVersion15OrAbove();
 
     toastListener = await listen(
       "toast_msg",

--- a/src/components/job/Requirements.svelte
+++ b/src/components/job/Requirements.svelte
@@ -73,22 +73,6 @@
           >{$_("requirements_armNotSupportedOutsideMacOS")}</span
         >
       </Alert>
-    {:else if !systemInfoState.isMinMacOSVersion}
-      <Alert
-        class="w-full text-start"
-        rounded={false}
-        color={alertColor(systemInfoState.isMinMacOSVersion)}
-      >
-        {#if systemInfoState.isMinMacOSVersion === undefined}
-          <span class="font-bold"
-            >{$_("requirements_macos_unableToCheckVersion")}</span
-          >
-        {:else}
-          <span class="font-bold"
-            >{$_("requirements_macos_notAtleastVersion15")}</span
-          >
-        {/if}
-      </Alert>
     {/if}
 
     {#if !$currentRequirements?.isOpenGLMet}

--- a/src/lib/rpc/util.ts
+++ b/src/lib/rpc/util.ts
@@ -1,5 +1,0 @@
-import { invoke_rpc } from "./rpc";
-
-export async function isMacOSVersion15OrAbove(): Promise<boolean | undefined> {
-  return await invoke_rpc("is_macos_version_15_or_above", {});
-}

--- a/src/state/SystemInfoState.svelte.ts
+++ b/src/state/SystemInfoState.svelte.ts
@@ -1,9 +1,7 @@
 interface SystemInfoState {
   isMinVCCRuntimeInstalled: boolean;
-  isMinMacOSVersion: boolean | undefined;
 }
 
 export const systemInfoState: SystemInfoState = $state({
   isMinVCCRuntimeInstalled: false,
-  isMinMacOSVersion: undefined,
 });

--- a/src/state/requirements-store.ts
+++ b/src/state/requirements-store.ts
@@ -49,10 +49,7 @@ async function evaluateRequirements(
     if (osType !== "macos") {
       requirementsMet = false;
     } else {
-      requirementsMet =
-        Boolean(systemInfoState.isMinMacOSVersion) &&
-        Boolean(isOpenGLMet) &&
-        Boolean(isDiskSpaceMet);
+      requirementsMet = Boolean(isOpenGLMet) && Boolean(isDiskSpaceMet);
     }
   } else {
     if (osType === "windows") {


### PR DESCRIPTION
Inspired by a discord support thread where a user was running the unsupported MacOS version 11. I removed the runtime MacOS version checking and moved it into the tauri config. Now, when a user downloads the launcher on an unsupported MacOS version they will be greeted with the following message: `You can’t use this version of the application “OpenGOAL-Launcher” with this version of macOS.` This error is much easier to diagnose on our end.