### PR TITLE
Misc warnings

### DIFF
--- a/src-tauri/src/commands/support.rs
+++ b/src-tauri/src/commands/support.rs
@@ -12,11 +12,12 @@ use tempfile::NamedTempFile;
 use walkdir::WalkDir;
 use zip::write::SimpleFileOptions;
 
+#[cfg(windows)]
+use crate::util::os::get_installed_vcc_runtime;
 use crate::{
   config::{LauncherConfig, SupportedGame},
-  util::{
-    os::get_installed_vcc_runtime,
-    zip::{append_dir_contents_to_zip, append_file_to_zip, check_if_zip_contains_top_level_entry},
+  util::zip::{
+    append_dir_contents_to_zip, append_file_to_zip, check_if_zip_contains_top_level_entry,
   },
 };
 

--- a/src-tauri/src/util/os.rs
+++ b/src-tauri/src/util/os.rs
@@ -1,8 +1,3 @@
-#[cfg(not(target_os = "windows"))]
-pub fn get_installed_vcc_runtime() -> anyhow::Result<semver::Version> {
-  anyhow::bail!("VCC runtime is only available on Windows");
-}
-
 #[cfg(target_os = "windows")]
 pub fn get_installed_vcc_runtime() -> anyhow::Result<semver::Version> {
   use anyhow::Context;

--- a/src/components/job/Requirements.svelte
+++ b/src/components/job/Requirements.svelte
@@ -12,8 +12,9 @@
   import { toSupportedGame } from "$lib/rpc/bindings/utils/SupportedGame";
   import type { SupportedGame } from "$lib/rpc/bindings/SupportedGame";
 
-  const gameParam = $derived(route.params.game_name);
-  const activeGame: SupportedGame | undefined = toSupportedGame(gameParam);
+  const activeGame: SupportedGame | undefined = $derived(
+    toSupportedGame(route.params.game_name),
+  );
 
   function alertColor(val: boolean | undefined) {
     if (val === undefined) {

--- a/src/routes/Game.svelte
+++ b/src/routes/Game.svelte
@@ -8,8 +8,9 @@
   import type { SupportedGame } from "$lib/rpc/bindings/SupportedGame.ts";
   import GameBetaAlert from "../components/games/GameBetaAlert.svelte";
 
-  const gameParam = $derived(route.params.game_name);
-  const activeGame: SupportedGame | undefined = toSupportedGame(gameParam);
+  const activeGame: SupportedGame | undefined = $derived(
+    toSupportedGame(route.params.game_name),
+  );
   let modName: string | undefined = $derived(route.params.mod_name);
   let modSource: string | undefined = $derived(route.params.source_name);
 </script>


### PR DESCRIPTION
removes unix implementation of `get_installed_vcc_runtime` because it's no longer being used
uses svelte `$derived(...)` rune to ensure `activeGame` updates when url param changes