### PR TITLE
Refactor mods platform filtering

### DIFF
--- a/src-tauri/src/cache.rs
+++ b/src-tauri/src/cache.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use anyhow::{Context, Result};
 use log::error;
 use serde::{Deserialize, Serialize};
+use tauri_plugin_os::platform;
 use ts_rs::TS;
 
 use crate::{config::SupportedGame, util::network::download_json};
@@ -15,6 +16,16 @@ pub struct ModVersion {
   pub published_date: String,
   pub assets: HashMap<String, Option<String>>,
   pub supported_games: Option<Vec<SupportedGame>>,
+}
+
+impl ModVersion {
+  pub fn supports_platform(&self) -> bool {
+    self
+      .assets
+      .get(platform())
+      .and_then(|url| url.as_ref())
+      .is_some()
+  }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, TS)]
@@ -113,6 +124,44 @@ pub struct ModSourceData {
   pub texture_packs: HashMap<String, ModInfo>,
 }
 
+impl ModSourceData {
+  pub fn by_platform(&self) -> Self {
+    Self {
+      schema_version: self.schema_version.clone(),
+      source_name: self.source_name.clone(),
+      last_updated: self.last_updated.clone(),
+      mods: self
+        .mods
+        .iter()
+        .filter_map(|(name, info)| {
+          let mut info = info.clone();
+          info.versions.retain(|v| v.supports_platform());
+          if info.versions.is_empty() {
+            None
+          } else {
+            Some((name.clone(), info))
+          }
+        })
+        .map(|(name, info)| (name.clone(), info.clone()))
+        .collect(),
+      texture_packs: self
+        .texture_packs
+        .iter()
+        .filter_map(|(name, info)| {
+          let mut info = info.clone();
+          info.versions.retain(|v| v.supports_platform());
+          if info.versions.is_empty() {
+            None
+          } else {
+            Some((name.clone(), info))
+          }
+        })
+        .map(|(name, info)| (name.clone(), info.clone()))
+        .collect(),
+    }
+  }
+}
+
 pub struct ModCache {
   pub mod_sources: HashMap<String, ModSourceData>,
 }
@@ -167,5 +216,13 @@ impl ModCache {
         .await
         .unwrap_or_else(|err| error!("{err:#}"));
     }
+  }
+
+  pub fn by_platform(&self) -> HashMap<String, ModSourceData> {
+    self
+      .mod_sources
+      .iter()
+      .map(|(url, source)| (url.clone(), source.by_platform()))
+      .collect()
   }
 }

--- a/src-tauri/src/commands/cache.rs
+++ b/src-tauri/src/commands/cache.rs
@@ -24,5 +24,5 @@ pub async fn get_mod_sources_data(
   cache: tauri::State<'_, tokio::sync::Mutex<ModCache>>,
 ) -> Result<HashMap<String, ModSourceData>, CommandError> {
   let cache_lock = cache.lock().await;
-  Ok(cache_lock.mod_sources.clone())
+  Ok(cache_lock.by_platform())
 }

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -7,7 +7,7 @@ use std::{
   process::Stdio,
 };
 
-use anyhow::ensure;
+use anyhow::{Context, ensure};
 use tauri::Emitter;
 use tokio::process::Command;
 
@@ -76,7 +76,14 @@ pub async fn download_and_extract_new_mod(
     .join("mods")
     .join(&source_name)
     .join(&mod_name);
-  let download_path = &destination_dir.join(format!("{mod_name}.zip"));
+
+  let filename = download_url
+    .rsplit('/')
+    .next()
+    .filter(|s| !s.is_empty())
+    .context("Invalid URL: missing filename")?;
+
+  let download_path = &destination_dir.join(filename);
 
   delete_dir(&destination_dir)?;
   download_file(&download_url, &download_path).await?;

--- a/src/components/games/GameControlsMod.svelte
+++ b/src/components/games/GameControlsMod.svelte
@@ -17,7 +17,6 @@
     Indicator,
     Tooltip,
   } from "flowbite-svelte";
-  import { platform } from "@tauri-apps/plugin-os";
   import {
     getInstallationDirectory,
     setCheckForLatestModVersion,
@@ -35,10 +34,7 @@
   } from "$lib/rpc/features";
   import { exists } from "@tauri-apps/plugin-fs";
   import { getModSourcesData } from "$lib/rpc/cache";
-  import {
-    getModAssetUrl,
-    isVersionSupportedOnPlatform,
-  } from "$lib/features/mods";
+  import { getModAssetUrl } from "$lib/features/mods";
   import { navigate, route } from "/src/router";
   import type { SupportedGame } from "$lib/rpc/bindings/SupportedGame";
   import type { ModInfo } from "$lib/rpc/bindings/ModInfo";
@@ -61,7 +57,6 @@
   let modAssetUrlsSorted: string[] = $state([]);
   let currentlyInstalledVersion: string = $state("");
   let numberOfVersionsOutOfDate = $state(0);
-  let userPlatform: string = platform();
   let checkForLatestModVersionChecked = $state(false);
   let modInfo: ModInfo | undefined = $state(undefined);
 
@@ -170,13 +165,12 @@
         });
         for (const version of versions) {
           if (
-            isVersionSupportedOnPlatform(userPlatform, version) &&
             version.supportedGames !== null &&
             version.supportedGames.includes(activeGame)
           ) {
             modVersionListSorted = [...modVersionListSorted, version.version];
-            const assetUrl = getModAssetUrl(userPlatform, version);
-            if (assetUrl !== undefined) {
+            const assetUrl = getModAssetUrl(version);
+            if (assetUrl) {
               modAssetUrlsSorted.push(assetUrl);
             }
           }

--- a/src/components/games/features/mods/ModCard.svelte
+++ b/src/components/games/features/mods/ModCard.svelte
@@ -3,8 +3,6 @@
   import type { SupportedGame } from "$lib/rpc/bindings/SupportedGame";
   import { Indicator, Tooltip } from "flowbite-svelte";
   import IconGlobe from "~icons/mdi/globe";
-  import { platform } from "@tauri-apps/plugin-os";
-  import { isLatestVersionOfModSupportedOnCurrentPlatform } from "$lib/features/mods";
   import { navigate } from "/src/router";
   import { _ } from "svelte-i18n";
 
@@ -29,8 +27,6 @@
     thumbnailUrl: string;
     href: string | null;
   } = $props();
-
-  const userPlatform = platform();
 </script>
 
 {#if href !== null}
@@ -51,8 +47,6 @@
   </a>
 {:else}
   <button
-    disabled={!isInstalled &&
-      !isLatestVersionOfModSupportedOnCurrentPlatform(userPlatform, modInfo)}
     class="h-[200px] max-w-[160px] bg-cover p-1 flex justify-center items-end relative"
     style="background: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.6)), url('{thumbnailUrl}'); background-size: cover;"
     onclick={async () => {
@@ -78,11 +72,4 @@
       </Indicator>
     {/if}
   </button>
-  {#if !isInstalled && !isLatestVersionOfModSupportedOnCurrentPlatform(userPlatform, modInfo)}
-    <Tooltip placement="top"
-      >{$_("features_mods_not_supported_platform_1")} ({userPlatform})<br />{$_(
-        "features_mods_not_supported_platform_2",
-      )}</Tooltip
-    >
-  {/if}
 {/if}

--- a/src/lib/features/mods.ts
+++ b/src/lib/features/mods.ts
@@ -5,9 +5,7 @@ import thumbnailPlaceholder from "$assets/images/mod-thumbnail-placeholder.webp"
 import type { SupportedGame } from "$lib/rpc/bindings/SupportedGame";
 import { platform } from "@tauri-apps/plugin-os";
 
-export function getModAssetUrl(
-  version: ModVersion,
-): string | null | undefined {
+export function getModAssetUrl(version: ModVersion): string | null | undefined {
   return version.assets[platform()];
 }
 

--- a/src/lib/features/mods.ts
+++ b/src/lib/features/mods.ts
@@ -3,51 +3,12 @@ import type { ModSourceData } from "$lib/rpc/bindings/ModSourceData";
 import type { ModVersion } from "$lib/rpc/bindings/ModVersion";
 import thumbnailPlaceholder from "$assets/images/mod-thumbnail-placeholder.webp";
 import type { SupportedGame } from "$lib/rpc/bindings/SupportedGame";
-
-export function isVersionSupportedOnPlatform(
-  userPlatform: string,
-  version: ModVersion,
-): boolean {
-  return (
-    Object.hasOwn(version.assets, userPlatform) &&
-    version.assets[userPlatform] !== null
-  );
-}
+import { platform } from "@tauri-apps/plugin-os";
 
 export function getModAssetUrl(
-  userPlatform: string,
   version: ModVersion,
-): string | undefined {
-  if (version.assets[userPlatform] === null) {
-    return undefined;
-  }
-  return version.assets[userPlatform];
-}
-
-export function getModAssetUrlFromLatestVersion(
-  userPlatform: string,
-  modInfo: ModInfo,
-): string | undefined {
-  if (
-    modInfo.versions.length === 0 ||
-    modInfo.versions[0].assets[userPlatform] === null
-  ) {
-    return undefined;
-  }
-  return modInfo.versions[0].assets[userPlatform];
-}
-
-export function isLatestVersionOfModSupportedOnCurrentPlatform(
-  userPlatform: string,
-  modInfo: ModInfo | undefined,
-): boolean {
-  if (modInfo === undefined || modInfo.versions.length <= 0) {
-    return false;
-  }
-  return (
-    Object.hasOwn(modInfo.versions[0].assets, userPlatform) &&
-    modInfo.versions[0].assets[userPlatform] !== null
-  );
+): string | null | undefined {
+  return version.assets[platform()];
 }
 
 export function isModNotFiltered(


### PR DESCRIPTION
two changes:
- fixes a bug where we would append `.zip` to every mod `download_path` regardless of archive format resulting in failure to install the mod properly. this was likely introduced during my recent refactors. i changed it to take the filename from the `download_url` and use that for the temporary archive name.
- moves the `~doesModSupportOS` checks to rust. the rust back-end will **only** return mods that support the user operating system. this makes certain front-end conditional checks irrelevant, slimming down rendering logic in the svelte components.