### PR TITLE
Refactor support.rs

### DIFF
--- a/src-tauri/src/commands/binaries.rs
+++ b/src-tauri/src/commands/binaries.rs
@@ -137,7 +137,7 @@ pub async fn extract_and_validate_iso(
   let config_lock = config.lock().await;
   let config_info = config_lock.common_prelude()?;
   let data_folder = get_data_dir(&config_info, game_name, true)?;
-  let exec_info = config_info.get_exec_location("extractor")?;
+  let exec_info = config_info.get_exec_location("extractor");
 
   log::info!(
     "extracting using data folder: {}",
@@ -216,7 +216,7 @@ pub async fn run_decompiler(
   let config_lock = config.lock().await;
   let config_info = config_lock.common_prelude()?;
   let data_folder = get_data_dir(&config_info, game_name, false)?;
-  let exec_info = config_info.get_exec_location("extractor")?;
+  let exec_info = config_info.get_exec_location("extractor");
 
   log::info!(
     "decompiling using data folder: {}",
@@ -324,7 +324,7 @@ pub async fn run_compiler(
 ) -> Result<(), CommandError> {
   let config_lock = config.lock().await;
   let config_info = config_lock.common_prelude()?;
-  let exec_info = config_info.get_exec_location("extractor")?;
+  let exec_info = config_info.get_exec_location("extractor");
   let data_folder = get_data_dir(&config_info, game_name, false)?;
 
   log::info!(
@@ -405,7 +405,7 @@ pub async fn open_repl(
   let config_lock = config.lock().await;
   let config_info = config_lock.common_prelude()?;
   let data_folder = get_data_dir(&config_info, game_name, false)?;
-  let exec_info = config_info.get_exec_location("goalc")?;
+  let exec_info = config_info.get_exec_location("goalc");
   let mut command;
   #[cfg(windows)]
   {
@@ -500,7 +500,7 @@ pub async fn get_launch_game_string(
 ) -> Result<String, CommandError> {
   let config_lock = config.lock().await;
   let config_info = config_lock.common_prelude()?;
-  let exec_info = config_info.get_exec_location("gk")?;
+  let exec_info = config_info.get_exec_location("gk");
   let args = generate_launch_game_string(&config_info, game_name, false, true)?;
 
   Ok(format!(
@@ -527,7 +527,7 @@ pub async fn launch_game(
       executable_path: exec_path,
     }
   } else {
-    config_info.get_exec_location("gk")?
+    config_info.get_exec_location("gk")
   };
 
   let args = generate_launch_game_string(&config_info, game_name, in_debug, false)?;

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -7,7 +7,7 @@ use std::{
   process::Stdio,
 };
 
-use anyhow::{Context, ensure};
+use anyhow::Context;
 use tauri::Emitter;
 use tokio::process::Command;
 
@@ -169,7 +169,7 @@ fn get_mod_exec_location(
   game_name: SupportedGame,
   mod_name: &str,
   source_name: &str,
-) -> anyhow::Result<ExecutableLocation> {
+) -> ExecutableLocation {
   let exec_dir = install_path
     .join("features")
     .join(game_name.to_string())
@@ -183,16 +183,10 @@ fn get_mod_exec_location(
   #[cfg(not(windows))]
   let exec_path = exec_dir.join(executable_name);
 
-  ensure!(
-    exec_path.exists(),
-    "Executable not found at expected path: {}",
-    exec_path.display()
-  );
-
-  Ok(ExecutableLocation {
+  ExecutableLocation {
     executable_dir: exec_dir,
     executable_path: exec_path,
-  })
+  }
 }
 
 #[tauri::command]
@@ -215,7 +209,7 @@ pub async fn extract_iso_for_mod_install(
     game_name,
     &mod_name,
     &source_name,
-  )?;
+  );
 
   let iso_extraction_dir = install_path
     .join("active")
@@ -289,7 +283,7 @@ pub async fn decompile_for_mod_install(
     game_name,
     &mod_name,
     &source_name,
-  )?;
+  );
 
   let iso_dir = install_path
     .join("active")
@@ -356,7 +350,7 @@ pub async fn compile_for_mod_install(
     game_name,
     &mod_name,
     &source_name,
-  )?;
+  );
 
   let iso_dir = install_path
     .join("active")
@@ -486,7 +480,7 @@ pub async fn launch_mod(
     .join(&source_name)
     .join("_settings")
     .join(&mod_name);
-  let exec_info = get_mod_exec_location(&install_path, "gk", game_name, &mod_name, &source_name)?;
+  let exec_info = get_mod_exec_location(&install_path, "gk", game_name, &mod_name, &source_name);
   let args = generate_launch_mod_args(game_name, in_debug, config_dir, false)?;
 
   log::info!("Launching gk args: {:?}", args);
@@ -615,7 +609,7 @@ pub async fn get_launch_mod_string(
     let config_lock = config.lock().await;
     config_lock.install_dir()?
   };
-  let exec_info = get_mod_exec_location(&install_path, "gk", game_name, &mod_name, &source_name)?;
+  let exec_info = get_mod_exec_location(&install_path, "gk", game_name, &mod_name, &source_name);
   let config_dir = install_path
     .join("features")
     .join(game_name.to_string())
@@ -657,8 +651,7 @@ pub async fn open_repl_for_mod(
     .join("iso_data")
     .join(game_name.to_string());
 
-  let exec_info =
-    get_mod_exec_location(&install_path, "goalc", game_name, &mod_name, &source_name)?;
+  let exec_info = get_mod_exec_location(&install_path, "goalc", game_name, &mod_name, &source_name);
   let mut command;
   #[cfg(windows)]
   {

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -131,15 +131,16 @@ pub async fn get_locally_persisted_mod_info(
     .join(&mod_name)
     .join("_metadata.json");
 
-  if metadata_path.exists() {
-    let file = fs::File::open(metadata_path)?;
-    let mod_info = serde_json::from_reader(file)
-      .map_err(|e| anyhow::anyhow!("Unable to deserialize local mod metadata: {}", e))?;
-    return Ok(mod_info);
-  }
-  Err(anyhow::anyhow!(
-    "Locally persisted mod metadata does not exist"
-  ))?
+  let file = fs::File::open(metadata_path).map_err(|e| {
+    anyhow::anyhow!(
+      "Unable to open local mod metadata at {}: {}",
+      metadata_path.display(),
+      e
+    )
+  })?;
+  let mod_info = serde_json::from_reader(file)
+    .map_err(|e| anyhow::anyhow!("Unable to deserialize local mod metadata: {}", e))?;
+  return Ok(mod_info);
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/support.rs
+++ b/src-tauri/src/commands/support.rs
@@ -1,4 +1,4 @@
-use log::info;
+use log::{error, info};
 use serde::{Deserialize, Serialize};
 use std::{fs, path::Path};
 use strum::IntoEnumIterator;
@@ -378,14 +378,16 @@ pub async fn generate_support_package(
 
   // Per Game Info
   for game in SupportedGame::iter() {
-    dump_per_game_info(
+    if let Err(e) = dump_per_game_info(
       &config_lock,
       &app_handle,
       &mut package,
       &mut zip_file,
       install_path,
       game,
-    )?;
+    ) {
+      error!("Failed to dump support info for {game}: {e}");
+    }
   }
 
   // Dump High Level Info

--- a/src-tauri/src/commands/support.rs
+++ b/src-tauri/src/commands/support.rs
@@ -1,10 +1,6 @@
 use log::info;
 use serde::{Deserialize, Serialize};
-use std::{
-  fs,
-  io::{BufWriter, Write},
-  path::Path,
-};
+use std::{fs, path::Path};
 use strum::IntoEnumIterator;
 use sysinfo::{Disks, System};
 use tauri::Manager;
@@ -272,14 +268,7 @@ pub async fn generate_support_package(
 ) -> Result<(), CommandError> {
   let mut package = SupportPackage::default();
   let config_lock = config.lock().await;
-  let install_path = match &config_lock.installation_dir {
-    None => {
-      return Err(CommandError::Support(
-        "No installation directory set, can't generate the support package".to_owned(),
-      ));
-    }
-    Some(path) => Path::new(path),
-  };
+  let install_path = &config_lock.install_dir()?;
 
   // System Information
   let mut system_info = System::new_all();
@@ -292,26 +281,19 @@ pub async fn generate_support_package(
   package.cpu_name = system_info.cpus()[0].name().to_string();
   package.cpu_vendor = system_info.cpus()[0].vendor_id().to_string();
   package.cpu_brand = system_info.cpus()[0].brand().to_string();
-  package.os_name = System::os_version().unwrap_or("unknown".to_string());
-  package.os_name_long = System::long_os_version().unwrap_or("unknown".to_string());
-  package.os_kernel_ver = System::kernel_version().unwrap_or("unknown".to_string());
+  package.os_name = System::os_version().unwrap_or_else(|| "unknown".to_string());
+  package.os_name_long = System::long_os_version().unwrap_or_else(|| "unknown".to_string());
+  package.os_kernel_ver = System::kernel_version().unwrap_or_else(|| "unknown".to_string());
   package.launcher_version = app_handle.package_info().version.to_string();
   package.active_tooling_version = config_lock
     .active_version
     .clone()
     .unwrap_or("unset".to_string());
-  if config_lock.installation_dir.is_none() {
-    package.install_dir = "Not Set".to_string();
-  } else {
-    package.install_dir = config_lock
-      .installation_dir
-      .clone()
-      .unwrap()
-      .to_string_lossy()
-      .to_string();
-  }
+  package.install_dir = install_path.to_string_lossy().to_string();
+
   if let Some(active_version) = &config_lock.active_version {
-    if cfg!(windows) {
+    #[cfg(windows)]
+    {
       package.extractor_binary_exists = install_path
         .join("versions")
         .join("official")
@@ -324,7 +306,10 @@ pub async fn generate_support_package(
         .join(active_version)
         .join("gk.exe")
         .exists();
-    } else {
+    }
+
+    #[cfg(not(windows))]
+    {
       package.extractor_binary_exists = install_path
         .join("versions")
         .join("official")
@@ -370,45 +355,29 @@ pub async fn generate_support_package(
 
   // Create zip file
   let save_path = Path::new(&user_path);
-  let save_file = NamedTempFile::new().map_err(|_| {
-    CommandError::Support("Failed to create temp file and unable to create support file".to_owned())
+  let save_file = NamedTempFile::new().map_err(|e| {
+    CommandError::Support(format!(
+      "Failed to create temp file and unable to create support file: {e}"
+    ))
   })?;
   let mut zip_file = zip::ZipWriter::new(save_file.as_file());
 
   // Save Launcher config folder
-  let launcher_config_dir = match app_handle.path().app_config_dir() {
-    Ok(path) => path,
-    Err(_) => {
-      return Err(CommandError::Support(
-        "Couldn't determine launcher config directory".to_owned(),
-      ));
-    }
-  };
-  let launcher_log_dir = match app_handle.path().app_log_dir() {
-    Ok(path) => path,
-    Err(_) => {
-      return Err(CommandError::Support(
-        "Couldn't determine launcher log directory".to_owned(),
-      ));
-    }
-  };
+  let launcher_config_dir = app_handle.path().app_config_dir()?;
+  let launcher_log_dir = app_handle.path().app_log_dir()?;
+
   append_dir_contents_to_zip(
     &mut zip_file,
     &launcher_log_dir,
     "Launcher Settings and Logs/logs",
     vec!["log"],
-  )
-  .map_err(|_| {
-    CommandError::Support("Unable to append launcher logs to the support package".to_owned())
-  })?;
+  )?;
+
   append_file_to_zip(
     &mut zip_file,
     &launcher_config_dir.join("settings.json"),
     "Launcher Settings and Logs/settings.json",
-  )
-  .map_err(|_| {
-    CommandError::Support("Unable to append launcher settings to the support package".to_owned())
-  })?;
+  )?;
 
   // Per Game Info
   for game in SupportedGame::iter() {
@@ -419,12 +388,7 @@ pub async fn generate_support_package(
       &mut zip_file,
       install_path,
       game,
-    )
-    .map_err(|_| {
-      CommandError::Support(format!(
-        "Unable to dump per game info for {game} to the support package",
-      ))
-    })?;
+    )?;
   }
 
   // Dump High Level Info
@@ -432,31 +396,32 @@ pub async fn generate_support_package(
     .compression_method(zip::CompressionMethod::Deflated)
     .compression_level(Some(9))
     .unix_permissions(0o755);
+
   zip_file
     .start_file("support-info.json", options)
-    .map_err(|_| {
-      CommandError::Support("Create high level support info entry in support package".to_owned())
+    .map_err(|e| {
+      CommandError::Support(format!(
+        "Create high level support info entry in support package: {e}"
+      ))
     })?;
-  let mut json_buffer = Vec::new();
-  let json_writer = BufWriter::new(&mut json_buffer);
-  serde_json::to_writer_pretty(json_writer, &package).map_err(|_| {
-    CommandError::Support(
-      "Unable to write high-level support info to the support package".to_owned(),
-    )
+
+  serde_json::to_writer_pretty(&mut zip_file, &package).map_err(|e| {
+    CommandError::Support(format!(
+      "Unable to write high-level support info to the support package: {e}"
+    ))
   })?;
-  zip_file.write_all(&json_buffer).map_err(|_| {
-    CommandError::Support(
-      "Unable to write high-level support info to the support package".to_owned(),
-    )
-  })?;
+
   zip_file
     .finish()
-    .map_err(|_| CommandError::Support("Unable to finalize zip file".to_owned()))?;
+    .map_err(|e| CommandError::Support(format!("Unable to finalize zip file: {e}")))?;
 
   // Sanity check that the zip file was actually made correctly
+  // TODO: really hate Result<bool> get rid of it
   let info_found =
-    check_if_zip_contains_top_level_entry(&save_file, "support-info.json").map_err(|_| {
-      CommandError::Support("Support package was unable to be written properly".to_owned())
+    check_if_zip_contains_top_level_entry(&save_file, "support-info.json").map_err(|e| {
+      CommandError::Support(format!(
+        "Support package was unable to be written properly: {e}"
+      ))
     })?;
   if !info_found {
     return Err(CommandError::Support(
@@ -466,15 +431,13 @@ pub async fn generate_support_package(
   // Seems good, move it to the user's intended destination
   fs::copy(save_file.path(), save_path).map_err(|e| {
     CommandError::Support(format!(
-      "Support package was unable to be moved from its temporary file location: {:?}",
-      e
+      "Support package was unable to be moved from its temporary file location: {e}"
     ))
   })?;
 
   fs::remove_file(save_file.path()).map_err(|e| {
     CommandError::Support(format!(
-      "Support package was copied but the original file could not be removed: {:?}",
-      e
+      "Support package was copied but the original file could not be removed: {e}"
     ))
   })?;
   Ok(())

--- a/src-tauri/src/commands/support.rs
+++ b/src-tauri/src/commands/support.rs
@@ -9,7 +9,6 @@ use strum::IntoEnumIterator;
 use sysinfo::{Disks, System};
 use tauri::Manager;
 use tempfile::NamedTempFile;
-use walkdir::WalkDir;
 use zip::write::SimpleFileOptions;
 
 #[cfg(windows)]
@@ -117,173 +116,148 @@ fn dump_per_game_info(
   zip_file: &mut zip::ZipWriter<&std::fs::File>,
   install_path: &Path,
   game_name: SupportedGame,
-) -> Result<(), CommandError> {
+) -> anyhow::Result<()> {
+  let game = game_name.to_string();
   // Save OpenGOAL config folder (this includes saves and settings)
-  let game_config_dir = match app_handle.path().config_dir() {
-    Ok(path) => path.join("OpenGOAL"),
-    Err(_) => {
-      return Err(CommandError::Support(
-        "Couldn't determine application config directory".to_owned(),
-      ));
-    }
-  };
+  let game_config_dir = app_handle.path().config_dir()?.join("OpenGOAL").join(&game);
+
   append_dir_contents_to_zip(
     zip_file,
-    &game_config_dir.join(game_name.to_string()).join("settings"),
-    format!("Game Settings and Saves/{game_name}/settings").as_str(),
+    &game_config_dir.join("settings"),
+    &format!("Game Settings and Saves/{game}/settings"),
     vec!["gc", "json"],
-  )
-  .map_err(|_| {
-    CommandError::Support("Unable to append game settings to the support package".to_owned())
-  })?;
+  )?;
+
   append_dir_contents_to_zip(
     zip_file,
-    &game_config_dir.join(game_name.to_string()).join("misc"),
-    format!("Game Settings and Saves/{game_name}/misc").as_str(),
+    &game_config_dir.join("misc"),
+    &format!("Game Settings and Saves/{game}/misc"),
     vec!["gc", "json"],
-  )
-  .map_err(|_| {
-    CommandError::Support("Unable to append game misc settings to the support package".to_owned())
-  })?;
+  )?;
+
   append_dir_contents_to_zip(
     zip_file,
-    &game_config_dir.join(game_name.to_string()).join("saves"),
-    format!("Game Settings and Saves/{game_name}/saves").as_str(),
+    &game_config_dir.join("saves"),
+    &format!("Game Settings and Saves/{game}/saves"),
     vec!["bin"],
-  )
-  .map_err(|_| {
-    CommandError::Support("Unable to append game saves to the support package".to_owned())
-  })?;
+  )?;
 
   // Save Logs
-  let active_version_dir = install_path.join("active");
-  let game_log_dir = active_version_dir
-    .join(game_name.to_string())
-    .join("data")
-    .join("log");
+  let active_game_data_dir = install_path.join("active").join(&game).join("data");
+  let game_log_dir = &active_game_data_dir.join("log");
+
   append_dir_contents_to_zip(
     zip_file,
     &game_log_dir,
-    format!("Game Logs and ISO Info/{game_name}").as_str(),
+    &format!("Game Logs and ISO Info/{game}"),
     vec!["log", "json", "txt"],
-  )
-  .map_err(|_| CommandError::Support("Unable to append game logs to support package".to_owned()))?;
+  )?;
 
-  let texture_repl_dir = active_version_dir
-    .join(game_name.to_string())
-    .join("data")
-    .join("texture_replacements");
-  package.game_info.get_game_info(game_name).has_texture_packs =
-    texture_repl_dir.exists() && texture_repl_dir.read_dir().unwrap().next().is_some();
-  let build_info_path = active_version_dir
-    .join(game_name.to_string())
-    .join("data")
+  let texture_repl_dir = active_game_data_dir.join("texture_replacements");
+
+  package.game_info.get_game_info(game_name).has_texture_packs = fs::read_dir(&texture_repl_dir)
+    .map(|mut it| it.next().is_some())
+    .unwrap_or(false);
+
+  let build_info_path = active_game_data_dir
     .join("iso_data")
-    .join(game_name.to_string())
+    .join(&game)
     .join("buildinfo.json");
+
   append_file_to_zip(
     zip_file,
     &build_info_path,
-    format!("Game Logs and ISO Info/{game_name}/buildinfo.json").as_str(),
-  )
-  .map_err(|_| {
-    CommandError::Support("Unable to append iso metadata to support package".to_owned())
-  })?;
+    &format!("Game Logs and ISO Info/{game}/buildinfo.json"),
+  )?;
 
-  if config_lock.active_version.is_some() {
-    let data_dir = active_version_dir.join(game_name.to_string()).join("data");
+  if let Some(active_version) = &config_lock.active_version {
     let version_data_dir = install_path
       .join("versions")
       .join("official")
-      .join(config_lock.active_version.as_ref().unwrap())
+      .join(active_version)
       .join("data");
-    package
-      .game_info
-      .get_game_info(game_name)
-      .release_integrity
-      .decompiler_folder_state =
-      get_game_info_folder_diff_state(&version_data_dir, &data_dir, "decompiler");
-    package
-      .game_info
-      .get_game_info(game_name)
-      .release_integrity
-      .game_folder_state = get_game_info_folder_diff_state(&version_data_dir, &data_dir, "game");
-    package
-      .game_info
-      .get_game_info(game_name)
-      .release_integrity
-      .goal_src_state = get_game_info_folder_diff_state(&version_data_dir, &data_dir, "goal_src");
+
+    let game_info = package.game_info.get_game_info(game_name);
+    game_info.release_integrity.decompiler_folder_state =
+      get_game_info_folder_diff_state(&version_data_dir, &active_game_data_dir, "decompiler");
+    game_info.release_integrity.game_folder_state =
+      get_game_info_folder_diff_state(&version_data_dir, &active_game_data_dir, "game");
+    game_info.release_integrity.goal_src_state =
+      get_game_info_folder_diff_state(&version_data_dir, &active_game_data_dir, "goal_src");
   }
 
   // Append mod settings and logs
-  let mod_directory = install_path
-    .join("features")
-    .join(game_name.to_string())
-    .join("mods");
-  info!("Scanning mod directory {mod_directory:?}");
-  if mod_directory.exists() {
-    let mod_source_iter = WalkDir::new(mod_directory)
-      .into_iter()
-      .filter_map(|e| e.ok());
-    for source_entry in mod_source_iter {
-      let mod_source_path = source_entry.path();
-      let mod_source_name = mod_source_path.file_name().unwrap().to_string_lossy(); // TODO
-      if mod_source_path.is_dir() {
-        let mod_iter = WalkDir::new(mod_source_path)
-          .max_depth(0)
-          .into_iter()
-          .filter_map(|e| e.ok());
-        for mod_entry in mod_iter {
-          let mod_path = mod_entry.path();
-          if mod_path.is_dir() {
-            let folder_name = mod_path.file_name().unwrap().to_string_lossy();
-            // Check for settings
-            if folder_name.eq("_settings") {
-              if mod_path.exists() {
-                append_dir_contents_to_zip(
-                  zip_file,
-                  mod_path,
-                  format!("Game Settings and Saves/{game_name}/mods/{mod_source_name}/settings")
-                    .as_str(),
-                  vec!["gc", "json"],
-                )
-                .map_err(|_| {
-                  CommandError::Support(
-                    "Unable to append mod settings to support package".to_owned(),
-                  )
-                })?;
-                append_dir_contents_to_zip(
-                  zip_file,
-                  mod_path,
-                  format!("Game Settings and Saves/{game_name}/mods/{mod_source_name}/saves")
-                    .as_str(),
-                  vec!["bin"],
-                )
-                .map_err(|_| {
-                  CommandError::Support("Unable to append mod saves to support package".to_owned())
-                })?;
-              }
-            } else {
-              // Get logs for each individual mod
-              let mod_log_folder = mod_path.join("data").join("log");
-              if mod_log_folder.exists() {
-                append_dir_contents_to_zip(
-                  zip_file,
-                  &mod_log_folder,
-                  format!(
-                    "Game Logs and ISO Info/{game_name}/mods/{mod_source_name}/{folder_name}/logs"
-                  )
-                  .as_str(),
-                  vec!["log", "json", "txt"],
-                )
-                .map_err(|_| {
-                  CommandError::Support("Unable to append mod logs to support package".to_owned())
-                })?;
-              }
-            }
-          }
-        }
+  let mods_dir = install_path.join("features").join(&game).join("mods");
+  info!("Scanning mod directory {mods_dir:?}");
+
+  let Ok(mod_sources) = fs::read_dir(&mods_dir) else {
+    return Ok(());
+  };
+
+  for source_entry in mod_sources {
+    let source_entry = match source_entry {
+      Ok(entry) => entry,
+      Err(_) => continue,
+    };
+
+    let source_path = source_entry.path();
+    if !source_path.is_dir() {
+      continue;
+    }
+
+    let source_name = source_path
+      .file_name()
+      .map(|s| s.to_string_lossy().into_owned())
+      .unwrap_or_else(|| "unknown".to_string());
+
+    let Ok(mods) = fs::read_dir(&source_path) else {
+      continue;
+    };
+
+    for mod_entry in mods {
+      let mod_entry = match mod_entry {
+        Ok(entry) => entry,
+        Err(_) => continue,
+      };
+
+      let mod_path = mod_entry.path();
+      if !mod_path.is_dir() {
+        continue;
       }
+
+      let folder_name = match mod_path.file_name() {
+        Some(name) => name.to_string_lossy().into_owned(),
+        None => continue,
+      };
+
+      if folder_name == "_settings" {
+        append_dir_contents_to_zip(
+          zip_file,
+          &mod_path,
+          &format!("Game Settings and Saves/{game}/mods/{source_name}/settings"),
+          vec!["gc", "json"],
+        )?;
+
+        append_dir_contents_to_zip(
+          zip_file,
+          &mod_path,
+          &format!("Game Settings and Saves/{game}/mods/{source_name}/saves"),
+          vec!["bin"],
+        )?;
+        continue;
+      }
+
+      let mod_log_dir = mod_path.join("data").join("log");
+      if !mod_log_dir.exists() {
+        continue;
+      }
+
+      append_dir_contents_to_zip(
+        zip_file,
+        &mod_log_dir,
+        &format!("Game Logs and ISO Info/{game}/mods/{source_name}/{folder_name}/logs"),
+        vec!["log", "json", "txt"],
+      )?;
     }
   }
 

--- a/src-tauri/src/commands/support.rs
+++ b/src-tauri/src/commands/support.rs
@@ -83,26 +83,23 @@ pub struct SupportPackage {
 }
 
 fn get_game_info_folder_diff_state(
-  base_data_dir: &std::path::PathBuf,
-  base_active_version_dir: &std::path::PathBuf,
+  base_data_dir: &Path,
+  base_active_version_dir: &Path,
   sub_dir: &str,
 ) -> String {
   // The data_dir is always guaranteed to be there (it's just the extracted tooling)
   // however, the active version folder may or may not exist (might not be installed)
   let active_version_dir = base_active_version_dir.join(sub_dir);
-  let data_dir = base_data_dir.join(sub_dir);
-  if active_version_dir.exists() {
-    let diff_result = dir_diff::is_different(active_version_dir, data_dir);
-    if diff_result.is_err() {
-      return "Unknown".to_string();
-    }
-    if diff_result.is_ok() && diff_result.unwrap() {
-      return "Different".to_string();
-    } else {
-      return "Match".to_string();
-    }
+  if !active_version_dir.exists() {
+    return "Not Installed".to_string();
   }
-  return "Not Installed".to_string();
+
+  let data_dir = base_data_dir.join(sub_dir);
+  match dir_diff::is_different(active_version_dir, data_dir) {
+    Ok(true) => "Different".to_string(),
+    Ok(false) => "Match".to_string(),
+    Err(_) => "Unknown".to_string(),
+  }
 }
 
 fn dump_per_game_info(

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -157,10 +157,7 @@ pub struct CommonConfigData {
 }
 
 impl CommonConfigData {
-  pub fn get_exec_location(
-    &self,
-    executable_name: &str,
-  ) -> Result<ExecutableLocation, CommandError> {
+  pub fn get_exec_location(&self, executable_name: &str) -> ExecutableLocation {
     let exec_dir = self
       .install_path
       .join("versions")
@@ -172,17 +169,10 @@ impl CommonConfigData {
       exec_path.set_extension("exe");
     }
 
-    if !exec_path.exists() {
-      return Err(CommandError::BinaryExecution(format!(
-        "Could not find the required binary '{}', can't perform operation",
-        exec_path.to_string_lossy()
-      )));
-    }
-
-    Ok(ExecutableLocation {
+    ExecutableLocation {
       executable_dir: exec_dir,
       executable_path: exec_path,
-    })
+    }
   }
 }
 

--- a/src-tauri/src/util/game_tests.rs
+++ b/src-tauri/src/util/game_tests.rs
@@ -22,7 +22,7 @@ pub async fn run_game_gpu_test(
 ) -> Result<GPUTestOutput> {
   let config_info = config_lock.common_prelude()?;
 
-  let exec_info = config_info.get_exec_location("gk")?;
+  let exec_info = config_info.get_exec_location("gk");
   let result_path = app_handle.path().app_data_dir()?;
   create_dir(&result_path)?;
   let result_path = result_path.join("gpu-test-result.json");

--- a/src-tauri/src/util/zip.rs
+++ b/src-tauri/src/util/zip.rs
@@ -14,9 +14,9 @@ pub fn append_dir_contents_to_zip(
   dir: &Path,
   internal_folder: &str,
   allowed_extensions: Vec<&str>,
-) -> zip::result::ZipResult<()> {
+) -> Result<()> {
   if !dir.exists() {
-    return Result::Ok(());
+    return Ok(());
   }
 
   let iter = WalkDir::new(dir).into_iter().filter_map(|e| e.ok());
@@ -62,14 +62,14 @@ pub fn append_dir_contents_to_zip(
       zip_file.add_directory_from_path(&name, options)?;
     }
   }
-  Result::Ok(())
+  Ok(())
 }
 
 pub fn append_file_to_zip(
   zip_file: &mut zip::ZipWriter<&File>,
   src: &Path,
   path_in_zip: &str,
-) -> zip::result::ZipResult<()> {
+) -> Result<()> {
   if !src.exists() || src.is_dir() {
     log::warn!("'{}', doesnt exist", src.display());
     return Ok(());


### PR DESCRIPTION
- propagates underlying errors to the front-end in lieu of tossing them
- flattens conditional logic to improve code readability
- removes `.exists` checks that were secretly swallowing `Permission denied: (os error 13)`
- modified `generate_support_package` to generate something instead of nothing when `dump_per_game_info` fails for some reason