### PR TITLE
add context to command.spawn errors

### DIFF
--- a/src-tauri/src/commands/binaries.rs
+++ b/src-tauri/src/commands/binaries.rs
@@ -172,7 +172,7 @@ pub async fn extract_and_validate_iso(
   {
     command.creation_flags(0x08000000);
   }
-  let mut child = command.spawn()?;
+  let mut child = command.spawn().context("Failed to spawn extractor")?;
 
   // This is the first install step, reset the file
   let mut log_file =
@@ -279,7 +279,7 @@ pub async fn run_decompiler(
     command.creation_flags(0x08000000);
   }
 
-  let mut child = command.spawn()?;
+  let mut child = command.spawn().context("Failed to spawn decompiler")?;
 
   let mut log_file = create_log_file(
     &app_handle,
@@ -364,7 +364,7 @@ pub async fn run_compiler(
   {
     command.creation_flags(0x08000000);
   }
-  let mut child = command.spawn()?;
+  let mut child = command.spawn().context("Failed to spawn compiler")?;
 
   let mut log_file = create_log_file(
     &app_handle,
@@ -557,7 +557,7 @@ pub async fn launch_game(
     command.creation_flags(CREATE_NO_WINDOW);
   }
   drop(config_lock);
-  let mut child = command.spawn()?;
+  let mut child = command.spawn().context("Failed to spawn game")?;
   let handle = tokio::spawn(async move {
     let start_time = Instant::now();
     let status = match child.wait().await {

--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -239,7 +239,7 @@ pub async fn extract_iso_for_mod_install(
   {
     command.creation_flags(0x08000000);
   }
-  let mut child = command.spawn()?;
+  let mut child = command.spawn().context("Failed to spawn extractor")?;
 
   // This is the first install step, reset the file
   let mut log_file = create_log_file(
@@ -312,7 +312,7 @@ pub async fn decompile_for_mod_install(
   {
     command.creation_flags(0x08000000);
   }
-  let mut child = command.spawn()?;
+  let mut child = command.spawn().context("Failed to spawn decompiler")?;
 
   let mut log_file =
     create_log_file(&app_handle, format!("extractor-{game_name}.log"), false).await?;
@@ -379,7 +379,7 @@ pub async fn compile_for_mod_install(
   {
     command.creation_flags(0x08000000);
   }
-  let mut child = command.spawn()?;
+  let mut child = command.spawn().context("Failed to spawn compiler")?;
 
   let mut log_file =
     create_log_file(&app_handle, format!("extractor-{game_name}.log"), false).await?;
@@ -504,7 +504,7 @@ pub async fn launch_mod(
     command.creation_flags(0x08000000);
   }
   // Start the process here so if there is an error, we can return immediately
-  let _child = command.spawn()?;
+  let _child = command.spawn().context("Failed to spawn game")?;
   Ok(())
 }
 


### PR DESCRIPTION
The extractor error was rather ambiguous, potentially resulting in a user/helper incorrectly interpreting it to mean the iso couldn't be located. 

previously:
```
Error calling 'extract_and_validate_iso': The system cannot find the file specified. (os error 2)
```

now:
```
Error calling 'extract_and_validate_iso': Failed to spawn extractor: The system cannot find the file specified. (os error 2)
```