### PR TITLE
use different minimum macos versions based on system architecture

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>LSMinimumSystemVersionByArchitecture</key>
+    <dict>
+      <key>x86_64</key>
+      <string>10.13</string>
+      <key>arm64</key>
+      <string>15.0</string>
+    </dict>
+  </dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,8 +14,7 @@
       "timestampUrl": ""
     },
     "macOS": {
-      "signingIdentity": "-",
-      "minimumSystemVersion": "15.0"
+      "signingIdentity": "-"
     },
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
I made a change previously that locked our x86_64 users out.
We have different `macOS` requirements based on architecture:
`arm64: minimumSystemVersion >=15.0`
`x86_64: minimumSystemVersion >= I don't know so I used Tauri minimum (10.13)`

I would prefer if we could specify a `minimumSystemVersion` for both system architectures in `tauri.conf.json`, but unless I contribute it myself then it's likely not going to happen.