### PR TITLE
Fix misc UI bugs

### DIFF
--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -227,7 +227,7 @@
   "features_mods_go_back": "Back",
   "features_mods_versions": "Versions",
   "features_mods_filter_placeholder": "Filter Mods..",
-  "features_mods_authors": "Author(s)",
+  "features_mods_authors": "By",
   "features_mods_tags": "Tag(s)",
   "toasts_copiedToClipboard": "Copied to clipboard",
   "toasts_savedToolingVersion": "Saved tooling version",

--- a/src/components/games/GameBetaAlert.svelte
+++ b/src/components/games/GameBetaAlert.svelte
@@ -4,7 +4,10 @@
   let { activeGame } = $props();
 </script>
 
-<Alert rounded={false} class="border-t-4 text-red-400">
+<Alert
+  rounded={false}
+  class="bg-white dark:bg-slate-900 border-t-4 text-red-400"
+>
   {#if activeGame === "jak2"}
     <span class="font-bold">{$_("gameControls_beta_headerA")}</span>
   {:else}
@@ -15,7 +18,7 @@
     <li>
       {$_("gameControls_beta_issueTracker_linkPreText")}
       <a
-        class="text-blue-400"
+        class="text-blue-600"
         href="https://github.com/open-goal/jak-project/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A{activeGame}"
         target="_blank"
         rel="noopener noreferrer"
@@ -25,7 +28,7 @@
     <li>
       {$_("gameControls_beta_bugReport_linkPreText")}
       <a
-        class="text-blue-400"
+        class="text-blue-600"
         href="https://github.com/open-goal/jak-project/issues/new?template={activeGame}-bug-report.yml"
         target="_blank"
         rel="noopener noreferrer"

--- a/src/components/games/GameControls.svelte
+++ b/src/components/games/GameControls.svelte
@@ -76,20 +76,20 @@
   <Playtime {activeGame}></Playtime>
   <div class="flex flex-row gap-2">
     <Button
-      class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
+      class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 hover:border-slate-800 text-sm text-white font-semibold px-5 py-2"
       onclick={async () => {
         launchGame(activeGame, false);
       }}>{$_("gameControls_button_play")}</Button
     >
     <Button
-      class="text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center justify-center px-2 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800"
+      class="text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center justify-center px-2 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 hover:border-slate-800"
       >{$_("gameControls_button_features")}</Button
     >
     <Dropdown
       simple
       trigger="hover"
       placement="top"
-      class="!bg-slate-900 dark:text-white **:w-full"
+      class="dark:!bg-slate-900 dark:text-white **:w-full"
     >
       <DropdownItem
         hidden={!textureSupportEnabled}
@@ -111,7 +111,7 @@
       </DropdownItem>
     </Dropdown>
     <Button
-      class="text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center px-2 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800"
+      class="text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center px-2 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 hover:border-slate-800"
     >
       {$_("gameControls_button_advanced")}
     </Button>
@@ -119,7 +119,7 @@
       simple
       trigger="hover"
       placement="top"
-      class="!bg-slate-900 dark:text-white **:w-full"
+      class="dark:!bg-slate-900 dark:text-white **:w-full"
     >
       <DropdownItem
         onclick={async () => {
@@ -149,7 +149,7 @@
         }}
         >{$_("gameControls_button_decompile")}
         <!-- NOTE - this is a bug in flowbite-svelte, it's not replacing the default class but just appending -->
-        <Helper class="!text-neutral-400 !text-xs"
+        <Helper class="dark:!text-neutral-400 !text-xs"
           >{$_("gameControls_button_decompile_helpText")}</Helper
         ></DropdownItem
       >
@@ -165,7 +165,7 @@
         }}
         >{$_("gameControls_button_compile")}
         <!-- NOTE - this is a bug in flowbite-svelte, it's not replacing the default class but just appending -->
-        <Helper class="!text-neutral-400 !text-xs"
+        <Helper class="dark:!text-neutral-400 !text-xs"
           >{$_("gameControls_button_compile_helpText")}
         </Helper></DropdownItem
       >
@@ -186,7 +186,7 @@
       >
     </Dropdown>
     <Button
-      class="text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center justify-center px-2 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800"
+      class="text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center justify-center px-2 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 hover:border-slate-800"
     >
       <IconCog />
     </Button>
@@ -194,7 +194,7 @@
       simple
       trigger="hover"
       placement="top-end"
-      class="!bg-slate-900 dark:text-white **:w-full"
+      class="dark:!bg-slate-900 dark:text-white **:w-full"
     >
       <!-- TODO - screenshot folder? how do we even configure where those go? -->
       <DropdownItem
@@ -219,7 +219,7 @@
           toastStore.makeToast($_("toasts_copiedToClipboard"), "info");
         }}
         >{$_("gameControls_button_copyExecutableCommand")}<Helper
-          class="!text-neutral-400 !text-xs"
+          class="dark:!text-neutral-400 !text-xs"
           >{$_("gameControls_button_copyExecutableCommand_helpText_1")}<br
           />{$_("gameControls_button_copyExecutableCommand_helpText_2")}</Helper
         ></DropdownItem
@@ -249,7 +249,7 @@
           }
         }}
         >{$_("gameControls_button_uninstall")}<Helper
-          class="!text-neutral-400 !text-xs"
+          class="dark:!text-neutral-400 !text-xs"
           >{$_("gameControls_button_uninstall_helpText")}</Helper
         ></DropdownItem
       >

--- a/src/components/games/GameControlsMod.svelte
+++ b/src/components/games/GameControlsMod.svelte
@@ -239,9 +239,10 @@
     >
       {modInfo.description}
     </h1>
-    <p class="pb-2 text-outline">
+    <!-- hiding this because it's bloat -->
+    <!-- <p class="pb-2 text-outline">
       {$_("features_mods_tags")}: {modInfo.tags}
-    </p>
+    </p> -->
     <p class="text-outline">
       {$_("features_mods_authors")}: {modInfo.authors}
     </p>
@@ -249,7 +250,7 @@
   <div class="flex flex-col justify-end items-end mt-3">
     <div class="flex flex-row gap-2">
       <Button
-        class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
+        class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 hover:border-slate-800 text-sm text-white font-semibold px-5 py-2"
         onclick={async () => {
           navigate(`/:game_name/mods`, { params: { game_name: activeGame } });
         }}><IconArrowLeft />&nbsp;{$_("features_mods_go_back")}</Button
@@ -257,13 +258,13 @@
       {#if !currentlyInstalledVersion && modVersionListSorted.length == 0}
         <!-- show disabled Install button if no version installed and we have no version list (offline) -->
         <Button
-          class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
+          class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 hover:border-slate-800 text-sm text-white font-semibold px-5 py-2"
           disabled>{$_("gameControls_button_install")}</Button
         >
       {:else if !currentlyInstalledVersion}
         <!-- show Install button if no version installed but we're online -->
         <Button
-          class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
+          class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 hover:border-slate-800 text-sm text-white font-semibold px-5 py-2"
           onclick={async () => {
             await addModFromUrl(modAssetUrlsSorted[0], modVersionListSorted[0]);
           }}>{$_("gameControls_button_install")}</Button
@@ -271,7 +272,7 @@
       {:else if modVersionListSorted.length == 0 || modVersionListSorted[0] === currentlyInstalledVersion || !checkForLatestModVersionChecked}
         <!-- show Play button if we have no version list (offline), if we're up to date, or we dont want forced updates -->
         <Button
-          class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
+          class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 hover:border-slate-800 text-sm text-white font-semibold px-5 py-2"
           onclick={async () => {
             launchMod(activeGame, false, modName, modSource);
           }}>{$_("gameControls_button_play")}</Button
@@ -279,7 +280,7 @@
       {:else}
         <!-- otherwise show Update button -->
         <Button
-          class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
+          class="border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 hover:border-slate-800 text-sm text-white font-semibold px-5 py-2"
           onclick={async () => {
             await addModFromUrl(modAssetUrlsSorted[0], modVersionListSorted[0]);
           }}>{$_("gameControls_update_mod")}</Button
@@ -287,7 +288,7 @@
       {/if}
       {#if modVersionListSorted.length > 0}
         <Button
-          class="relative text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center justify-center px-2 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800"
+          class="relative text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center justify-center px-2 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 hover:border-slate-800"
         >
           {$_("features_mods_versions")}
           {#if numberOfVersionsOutOfDate > 0}
@@ -300,7 +301,7 @@
           simple
           trigger="hover"
           placement="top-end"
-          class="!bg-slate-900 overflow-y-auto p-2 max-h-[300px] rounded-none"
+          class="dark:!bg-slate-900 overflow-y-auto p-2 max-h-[300px] rounded"
         >
           <!-- wrap checkbox in div so that both box and text get tooltip -->
           <div id="checkbox_always_use_newest">
@@ -338,14 +339,14 @@
       {#if !currentlyInstalledVersion}
         <!-- Disabled "advanced" button if not installed -->
         <Button
-          class="text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center justify-center px-2 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800"
+          class="text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center justify-center px-2 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 hover:border-slate-800"
           disabled
         >
           {$_("gameControls_button_advanced")}
         </Button>
       {:else}
         <Button
-          class="text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center justify-center px-2 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800"
+          class="text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center justify-center px-2 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 hover:border-slate-800"
         >
           {$_("gameControls_button_advanced")}
         </Button>
@@ -353,7 +354,7 @@
           simple
           trigger="hover"
           placement="top-end"
-          class="!bg-slate-900 rounded-none **:w-full"
+          class="dark:!bg-slate-900 rounded **:w-full"
         >
           <DropdownItem
             onclick={async () => {
@@ -382,7 +383,7 @@
             }}
             >{$_("gameControls_button_decompile")}
             <!-- NOTE - this is a bug in flowbite-svelte, it's not replacing the default class but just appending -->
-            <Helper class="!text-neutral-400 !text-xs"
+            <Helper class="dark:!text-neutral-400 !text-xs"
               >{$_("gameControls_button_decompile_helpText")}</Helper
             ></DropdownItem
           >
@@ -402,7 +403,7 @@
             }}
             >{$_("gameControls_button_compile")}
             <!-- NOTE - this is a bug in flowbite-svelte, it's not replacing the default class but just appending -->
-            <Helper class="!text-neutral-400 !text-xs"
+            <Helper class="dark:!text-neutral-400 !text-xs"
               >{$_("gameControls_button_compile_helpText")}
             </Helper></DropdownItem
           >
@@ -427,14 +428,14 @@
       {#if !currentlyInstalledVersion}
         <!-- Disabled cog/settings button if not installed -->
         <Button
-          class="text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center justify-center px-2 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800"
+          class="text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center justify-center px-2 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 hover:border-slate-800"
           disabled
         >
           <IconCog />
         </Button>
       {:else}
         <Button
-          class="text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center justify-center px-2 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800"
+          class="text-center font-semibold focus:ring-0 focus:outline-none inline-flex items-center justify-center px-2 py-2 text-sm text-white border-solid border-2 border-slate-900 rounded bg-slate-900 hover:bg-slate-800 hover:border-slate-800"
         >
           <IconCog />
         </Button>
@@ -442,7 +443,7 @@
           simple
           trigger="hover"
           placement="top-end"
-          class="!bg-slate-900 **:w-full"
+          class="dark:!bg-slate-900 **:w-full"
         >
           <!-- TODO - screenshot folder? how do we even configure where those go? -->
           {#if settingsDir}
@@ -477,7 +478,7 @@
               toastStore.makeToast($_("toasts_copiedToClipboard"), "info");
             }}
             >{$_("gameControls_button_copyExecutableCommand")}<Helper
-              class="!text-neutral-400 !text-xs"
+              class="dark:!text-neutral-400 !text-xs"
               >{$_("gameControls_button_copyExecutableCommand_helpText_1")}<br
               />{$_(
                 "gameControls_button_copyExecutableCommand_helpText_2",
@@ -506,7 +507,7 @@
               }
             }}
             >{$_("gameControls_button_uninstall")}<Helper
-              class="!text-neutral-400 !text-xs"
+              class="dark:!text-neutral-400 !text-xs"
               >{$_("gameControls_button_uninstall_helpText")}</Helper
             ></DropdownItem
           >

--- a/src/components/games/Playtime.svelte
+++ b/src/components/games/Playtime.svelte
@@ -10,15 +10,29 @@
 
   onMount(() => {
     refreshPlaytime();
+
+    const unlistenPromise = listen("playtimeUpdated", async () => {
+      await refreshPlaytime();
+    });
+
+    return () => {
+      unlistenPromise.then((unlisten) => unlisten());
+    };
   });
 
-  listen<string>("playtimeUpdated", async (e) => {
-    await refreshPlaytime();
-  });
+  function formatPlaytime(totalSeconds: number): string {
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    return [hours, minutes, seconds]
+      .map((value) => value.toString().padStart(2, "0"))
+      .join(":");
+  }
 
   async function refreshPlaytime() {
-    let playtimeSec = await getPlaytime(activeGame);
-    playtime = new Date(playtimeSec * 1000).toISOString().slice(11, 19);
+    const playtimeSec = await getPlaytime(activeGame);
+    playtime = formatPlaytime(playtimeSec);
   }
 </script>
 

--- a/src/components/header/Header.svelte
+++ b/src/components/header/Header.svelte
@@ -96,7 +96,7 @@
 </script>
 
 <header
-  class="flex flex-row grow-0 shrink-0 bg-[#101010] pl-2 pr-4 pt-1 pb-1 items-center z-10"
+  class="flex flex-row grow-0 shrink-0 bg-[#101010] pl-2 pr-4 pt-1 pb-2 items-center z-10"
   data-tauri-drag-region
 >
   <div

--- a/src/routes/settings/Mods.svelte
+++ b/src/routes/settings/Mods.svelte
@@ -76,9 +76,9 @@
   <div class="mt-2">
     {#if pageLoaded && currentSources.length > 0}
       <Table>
-        <TableBody class="divide-y bg-slate-700">
+        <TableBody class="divide-y dark:bg-slate-700">
           {#each currentSources as source, i}
-            <TableBodyRow class="flex items-center bg-slate-700">
+            <TableBodyRow class="flex items-center dark:bg-slate-700">
               <TableBodyCell
                 class="px-4 whitespace-nowrap font-medium text-gray-900 dark:text-white text-wrap"
                 >{source}</TableBodyCell


### PR DESCRIPTION
fixes:
- light mode ui issues
- playtime wrapping over 24 hours (Closes #962) 

todo: 
- fix texture packs page going sicko mode when adding more than one pack

notes:
the first version with the texture pack route bug is `2.8.11`, the first release after migrating from `svelte-navigator` to `sv-router.` This means there's a couple places where this issue might arise. `Layout.svelte`, `TexturePacks.svelte`, and `TexturePackCard.svelte`

update: i've narrowed down the issue to `TexturePackCard.svelte`, it seems certain padding and margins are creating the issue. I thought i resolved it, but i decided to test my fix with a third texture pack and it was broken again. i've spent a little too long looking at this texture issue and i'm giving up for now.

[launcher repo at 2.8.10](https://github.com/open-goal/launcher/tree/6420c5304bfb97c4482dfbe718a369c053f9f1ca)
[launcher repo at 2.8.11](https://github.com/open-goal/launcher/tree/adc6c4118b3a1c9a927948c9c06ddf23c1b29c4d/)