### PR TITLE
fix iso_data update bug and improve version mismatch workflow

### DIFF
--- a/src/components/header/Header.svelte
+++ b/src/components/header/Header.svelte
@@ -60,42 +60,43 @@
         launcherUpdateAvailable = true;
       }
     }
-    await checkIfLatestVersionInstalled();
+    await checkForToolingUpdate();
   });
 
-  async function checkIfLatestVersionInstalled() {
+  async function checkForToolingUpdate() {
     const latestToolingVersion = await getLatestOfficialRelease();
-    if (
-      latestToolingVersion !== undefined &&
-      versionState.activeToolingVersion !== latestToolingVersion.version
-    ) {
-      // Check that we havn't already downloaded it
-      let alreadyHaveRelease = false;
-      const downloadedOfficialVersions = await listDownloadedVersions();
-      for (const releaseVersion of downloadedOfficialVersions) {
-        if (releaseVersion === latestToolingVersion.version) {
-          alreadyHaveRelease = true;
-          break;
-        }
-      }
-      if (!alreadyHaveRelease) {
-        let shouldAutoUpdate = await getAutoUpdateGames();
-        if (shouldAutoUpdate) {
-          await downloadLatestVersion(
-            latestToolingVersion.version,
-            latestToolingVersion.downloadUrl,
-          );
-          await removeOldVersions();
+    const latestVersion = latestToolingVersion?.version;
 
-          location.reload(); // TODO! this is hacky, when i refactor this will be done automatically
-        }
+    if (!latestVersion) return;
+    if (versionState.activeToolingVersion === latestVersion) return;
 
-        $UpdateStore.selectedTooling = {
-          updateAvailable: true,
-          versionNumber: latestToolingVersion.version,
-        };
-      }
-    }
+    // Check that we havn't already downloaded it
+    const downloadedOfficialVersions = await listDownloadedVersions();
+    if (downloadedOfficialVersions.includes(latestVersion)) return;
+
+    $UpdateStore.selectedTooling = {
+      updateAvailable: true,
+      versionNumber: latestVersion,
+    };
+  }
+
+  // TODO: handle this in the new startup route
+  // download the latest `jak-project` binaries
+  async function autoUpdateTooling() {
+    const shouldAutoUpdate = await getAutoUpdateGames();
+    if (!shouldAutoUpdate) return;
+
+    const latestToolingVersion = await getLatestOfficialRelease();
+    const latestVersion = latestToolingVersion?.version;
+
+    if (!latestVersion) return;
+
+    await downloadLatestVersion(
+      latestToolingVersion.version,
+      latestToolingVersion.downloadUrl,
+    );
+    // delete the existing `jak-project` binaries
+    await removeOldVersions();
   }
 </script>
 

--- a/src/components/job/GameUpdate.svelte
+++ b/src/components/job/GameUpdate.svelte
@@ -1,18 +1,25 @@
 <script lang="ts">
-  import { getAutoUpdateGames, getInstalledVersion } from "$lib/rpc/config";
+  import {
+    getAutoUpdateGames,
+    getInstallationDirectory,
+    getInstalledVersion,
+    saveActiveVersionChange,
+  } from "$lib/rpc/config";
   import { Button, Card } from "flowbite-svelte";
-  import { createEventDispatcher, onMount } from "svelte";
+  import { onMount } from "svelte";
   import { _ } from "svelte-i18n";
-  import { navigate } from "/src/router";
+  import { navigate, route } from "/src/router";
   import { versionState } from "/src/state/VersionState.svelte";
   import { asJobType } from "$lib/job/jobs";
   import type { SupportedGame } from "$lib/rpc/bindings/SupportedGame";
-  import { route } from "/src/router";
   import { toSupportedGame } from "$lib/rpc/bindings/utils/SupportedGame";
+  import { exists } from "@tauri-apps/plugin-fs";
+  import { join } from "@tauri-apps/api/path";
 
   const gameParam = $derived(route.params.game_name);
   let activeGame: SupportedGame | undefined = $state(undefined);
   let installedVersion: String | undefined = $state(undefined);
+  let isoDataExists = $state(false);
 
   $effect(() => {
     (async () => {
@@ -24,16 +31,57 @@
     })();
   });
 
-  const dispatch = createEventDispatcher();
-
   onMount(async () => {
-    let shouldAutoUpdate = await getAutoUpdateGames();
-    if (shouldAutoUpdate) {
-      dispatch("job", {
-        type: "updateGame",
-      });
-    }
+    const installDir = await getInstallationDirectory();
+    if (!installDir) return;
+    if (!activeGame) return;
+
+    const isoDataDir = await join(
+      installDir,
+      "active",
+      activeGame,
+      "data",
+      "iso_data",
+    );
+    isoDataExists = await exists(isoDataDir);
+    if (!isoDataExists) return;
+    await autoUpdate();
   });
+
+  async function autoUpdate() {
+    const shouldAutoUpdate = await getAutoUpdateGames();
+    if (!shouldAutoUpdate) return;
+
+    navigate("/job/:job_type", {
+      params: {
+        job_type: asJobType("updateGame"),
+      },
+      search: {
+        activeGame: `${activeGame}`,
+        returnTo: `/${activeGame}`,
+      } as any,
+    });
+  }
+
+  async function handleUpdate() {
+    if (!activeGame) return;
+    if (!isoDataExists) {
+      // user deleted their iso_data folder
+      // prevent them from pressing the update button and experiencing: https://github.com/open-goal/launcher/issues/638
+      navigate("/:game_name/setup", { params: { game_name: activeGame } });
+      return;
+    }
+
+    navigate("/job/:job_type", {
+      params: {
+        job_type: asJobType("updateGame"),
+      },
+      search: {
+        activeGame: `${activeGame}`,
+        returnTo: `/${activeGame}`,
+      } as any,
+    });
+  }
 </script>
 
 <div class="flex flex-col h-full justify-center items-center">
@@ -44,7 +92,7 @@
       {$_("gameUpdate_versionMismatch_title")}
     </h5>
     <p class="text-base text-gray-500 dark:text-gray-400 mb-1">
-      {$_("gameUpdate_versionMismatch_currentlyInstalled")}...
+      {$_("gameUpdate_versionMismatch_currentlyInstalled")}:
     </p>
     <ul class="list-disc list-inside mb-2">
       <li>
@@ -53,7 +101,7 @@
       </li>
     </ul>
     <p class="text-base text-gray-500 dark:text-gray-400 mb-1">
-      ...{$_("gameUpdate_versionMismatch_currentlySelected")}
+      {$_("gameUpdate_versionMismatch_currentlySelected")}
     </p>
     <ul class="list-disc list-inside mb-5">
       <li>
@@ -70,23 +118,16 @@
       <Button
         class="border-solid border-2 border-slate-500 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
         onclick={async () => {
-          navigate("/job/:job_type", {
-            params: {
-              job_type: asJobType("updateGame"),
-            },
-            search: {
-              activeGame: `${activeGame}`,
-              returnTo: `/${activeGame}`,
-            } as any,
-          });
+          await handleUpdate();
         }}>{$_("gameUpdate_versionMismatch_button_updateGame")}</Button
       >
       <Button
         class="border-solid border-2 border-slate-500 rounded bg-slate-900 hover:bg-slate-800 text-sm text-white font-semibold px-5 py-2"
         onclick={async () => {
-          navigate(`/settings/:tab`, {
-            params: { tab: "versions" },
-          });
+          const error = await saveActiveVersionChange(installedVersion!);
+          if (!error) {
+            navigate("/:game_name/", { params: { game_name: activeGame! } });
+          }
         }}>{$_("gameUpdate_versionMismatch_button_changeVersion")}</Button
       >
     </div>

--- a/src/routes/UpdateLauncher.svelte
+++ b/src/routes/UpdateLauncher.svelte
@@ -32,7 +32,7 @@
   let availableUpdateChangelog: Changelog = {
     changes: [],
   };
-  let showChanges = false;
+  let showChanges = true;
   let showDependencyChanges = false;
 
   // TODO - add the timestamp, tauri doesn't use an ISO timestamp!


### PR DESCRIPTION
Improvements:
- reintroduces the optional auto update feature when navigating to a game route
- modified the behavior of the `Change Version` button on `GameUpdate.svelte` so it does what it says, i dislike lying buttons
- minor function refactors

Fixes: 
- longstanding bug where trying to update the games using `iso_data` when the directory no longer exists would leave the users helpless. Closes #638 