### PR TITLE
fix textures route "File does not exist at path: null" error

### DIFF
--- a/src-tauri/src/commands/features/texture_packs.rs
+++ b/src-tauri/src/commands/features/texture_packs.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, fs, path::PathBuf};
 
 use anyhow::Context;
 use serde_json::Value;
-use tracing::instrument;
+use tracing::{info, instrument, warn};
 
 use crate::{
   commands::CommandError,
@@ -130,7 +130,7 @@ pub async fn list_extracted_texture_pack_info(
         ..metadata
       };
     } else {
-      tracing::error!(
+      warn!(
         "Unable to load texture pack metadata {}",
         metadata_path.display()
       );
@@ -208,7 +208,7 @@ pub async fn update_texture_pack_data(
         .join(game_name.to_string())
         .join("texture_replacements");
 
-      tracing::info!("Appending textures from: {}", texture_pack_dir.display());
+      info!("Appending textures from: {}", texture_pack_dir.display());
       overwrite_dir(&texture_pack_dir, &game_texture_pack_dir)?
     }
     return Ok(());
@@ -233,7 +233,7 @@ pub async fn delete_texture_packs(
   };
 
   for pack in packs {
-    tracing::info!("Deleting texture pack: {}", pack);
+    info!("Deleting texture pack: {}", pack);
     delete_dir(texture_pack_dir.join(&pack))?;
   }
 

--- a/src/components/games/features/texture-packs/TexturePackCard.svelte
+++ b/src/components/games/features/texture-packs/TexturePackCard.svelte
@@ -14,6 +14,7 @@
   import IconDelete from "~icons/mdi/delete";
   import { _ } from "svelte-i18n";
   import { onMount } from "svelte";
+  import placeholder from "$assets/images/mod-thumbnail-placeholder.webp";
 
   let {
     packIndex,
@@ -83,13 +84,15 @@
       return "gray";
     }
   }
+
+  const coverImg = $derived(
+    packMetadata?.coverImagePath
+      ? convertFileSrc(packMetadata.coverImagePath)
+      : placeholder,
+  );
 </script>
 
-<Card
-  horizontal={true}
-  img={convertFileSrc(packMetadata.coverImagePath)}
-  size="xl"
->
+<Card horizontal={true} img={coverImg} size="xl">
   <div class="w-full pl-4 py-2">
     <h2 class="text-xl font-bold tracking-tight text-white">
       {packMetadata.name}


### PR DESCRIPTION
when a user installed texture pack doesn't contain `metadata.json` and the frontend tries `convertFileSrc(packMetadata.coverImagePath)`, it results in the following error: `[tauri::protocol::asset][ERROR] File does not exist at path: null`.

this is now fixed.
additionally, i changed the backend logging to a warning instead of an error because it's trivial.