### PR TITLE
fix support package not bundling new launcher logs

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,6 +7,7 @@ use directories::UserDirs;
 use tauri::{Manager, RunEvent};
 use tokio::sync::OnceCell;
 use tracing_appender::non_blocking::WorkerGuard;
+use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 use util::file::create_dir;
 
@@ -99,7 +100,12 @@ fn main() {
         .join("app");
       create_dir(&log_path)?;
 
-      let file_appender = tracing_appender::rolling::daily(&log_path, "launcher.log");
+      let file_appender = RollingFileAppender::builder()
+        .rotation(Rotation::DAILY)
+        .filename_prefix("launcher")
+        .filename_suffix("log")
+        .max_log_files(10)
+        .build(&log_path)?;
       let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
       let _ = LOG_GUARD.set(guard);
 
@@ -116,18 +122,6 @@ fn main() {
             .compact(),
         ) // file
         .init();
-
-      // Truncate rotated log files to '10'
-      let mut paths: Vec<_> = std::fs::read_dir(&log_path)?
-        .filter_map(Result::ok)
-        .collect();
-
-      paths.sort_by_key(|entry| std::cmp::Reverse(entry.path()));
-
-      for entry in paths.into_iter().skip(10) {
-        tracing::info!("deleting - {}", entry.path().display());
-        std::fs::remove_file(entry.path())?;
-      }
 
       // Load the config (or initialize it with defaults)
       //

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -102,7 +102,6 @@ fn main() {
 
       let file_appender = RollingFileAppender::builder()
         .rotation(Rotation::DAILY)
-        .filename_prefix("launcher")
         .filename_suffix("log")
         .max_log_files(10)
         .build(&log_path)?;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -60,7 +60,8 @@
       "assetProtocol": {
         "enable": true,
         "scope": [
-          "**"
+          "**",
+          "$APPDATA/**"
         ]
       },
       "capabilities": [

--- a/src/routes/Game.svelte
+++ b/src/routes/Game.svelte
@@ -6,6 +6,7 @@
   import { toSupportedGame } from "$lib/rpc/bindings/utils/SupportedGame";
   import type { SupportedGame } from "$lib/rpc/bindings/SupportedGame.ts";
   import GameBetaAlert from "../components/games/GameBetaAlert.svelte";
+  import { isInDebugMode } from "$lib/utils/common";
 
   const activeGame: SupportedGame | undefined = $derived(
     toSupportedGame(route.params.game_name),
@@ -18,7 +19,7 @@
   <div class="flex flex-col h-full p-5">
     <!-- Jak 2 & Jak 3 BETA warning -->
     <!-- Not shown on mod pages because mod bugs shouldn't be reported to the jak-projects repo -->
-    {#if (activeGame === "jak2" || activeGame === "jak3") && !modName}
+    {#if (activeGame === "jak2" || activeGame === "jak3") && !modName && !isInDebugMode()}
       <GameBetaAlert {activeGame}></GameBetaAlert>
     {/if}
     {#if modName && modSource}

--- a/src/routes/Settings.svelte
+++ b/src/routes/Settings.svelte
@@ -8,6 +8,7 @@
   import { route } from "../router";
   import Backgrounds from "./settings/Backgrounds.svelte";
   import { type } from "@tauri-apps/plugin-os"; // TODO: temporary while convertFileSrc is broken on linux
+  import { isInDebugMode } from "$lib/utils/common";
 
   let tab = route.params.tab;
 
@@ -58,7 +59,7 @@
       <Mods />
     </TabItem>
     <!-- TODO: temporary while convertFileSrc is broken on linux -->
-    {#if type() !== "linux"}
+    {#if type() !== "linux" || isInDebugMode()}
       <TabItem
         {activeClass}
         {inactiveClass}


### PR DESCRIPTION
support package code expects: `*.log`

the new logger was saving logs as: `launcher.log.yyyy-mm-dd`
the support package code was blind to this file

this change saves the logs as: `yyyy-mm-dd.log`
the support package code is happy again
`tracing_appender` also has built in log pruning that we're now using