### PR TITLE
add a new component to the versions tab in settings

### DIFF
--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -144,6 +144,8 @@
   "settings_versions_icon_githubRelease_altText": "github release notes",
   "settings_versions_icon_openFolder_altText": "open version folder",
   "settings_versions_icon_redownloadVersion_altText": "Redownload Version",
+  "settings_versions_latest_release": "Latest Release",
+  "settings_versions_active_version": "Active Version",
   "settings_versions_icon_refresh_altText": "refresh version list",
   "settings_versions_icon_removeVersion_altText": "remove version",
   "settings_versions_icon_save_altText": "save version change",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -146,6 +146,7 @@
   "settings_versions_icon_redownloadVersion_altText": "Redownload Version",
   "settings_versions_latest_release": "Latest Release",
   "settings_versions_active_version": "Active Version",
+  "settings_versions_set_active_version": "Set as Active Version",
   "settings_versions_icon_refresh_altText": "refresh version list",
   "settings_versions_icon_removeVersion_altText": "remove version",
   "settings_versions_icon_save_altText": "save version change",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -146,6 +146,7 @@
   "settings_versions_icon_redownloadVersion_altText": "Redownload Version",
   "settings_versions_latest_release": "Latest Release",
   "settings_versions_active_version": "Active Version",
+  "settings_versions_released": "Released",
   "settings_versions_set_active_version": "Set as Active Version",
   "settings_versions_icon_refresh_altText": "refresh version list",
   "settings_versions_icon_removeVersion_altText": "remove version",

--- a/src/components/toast/Toast.svelte
+++ b/src/components/toast/Toast.svelte
@@ -23,7 +23,7 @@
     dismissable={false}
     position="top-right"
     class="z-50 top-12 right-4 text-wrap"
-    contentClass="w-full text-sm font-normal overflow-hidden"
+    classes={{ content: "w-full text-sm font-normal overflow-hidden" }}
     transition={fly}
     params={{ y: 200 }}
   >

--- a/src/routes/settings/Versions.svelte
+++ b/src/routes/settings/Versions.svelte
@@ -9,11 +9,18 @@
   import { listOfficialReleases, type ReleaseInfo } from "$lib/utils/github";
   import VersionList from "./versions/VersionList.svelte";
   import { UpdateStore } from "$lib/stores/AppStore";
-  import { saveActiveVersionChange } from "$lib/rpc/config";
+  import {
+    getInstallationDirectory,
+    saveActiveVersionChange,
+  } from "$lib/rpc/config";
   import { _ } from "svelte-i18n";
   import { toastStore } from "$lib/stores/ToastStore";
   import { versionState } from "/src/state/VersionState.svelte";
-  import { Alert, Spinner } from "flowbite-svelte";
+  import { Alert, Button, Spinner } from "flowbite-svelte";
+  import Latest from "./versions/Latest.svelte";
+  import { openPath } from "@tauri-apps/plugin-opener";
+  import IconFolderOpen from "~icons/mdi/folder-open";
+  import IconRefresh from "~icons/mdi/refresh";
 
   let loading = $state(true);
   let releases: ReleaseInfo[] = $state([]);
@@ -174,6 +181,8 @@
         : release,
     );
   }
+
+  const isPending = $derived(releases.some((r) => r.pendingAction));
 </script>
 
 <p class="text-sm mt-2 mb-2">{$_("settings_versions_header")}</p>
@@ -182,13 +191,43 @@
     <Spinner color="yellow" size="12" />
   </div>
 {:else if releases.length > 0}
+  <div class="flex items-center mb-2">
+    <div class="grow">
+      <p class="text-sm text-gray-300">
+        {$_("settings_versions_official_description")}
+      </p>
+    </div>
+    <div class="flex">
+      <Button
+        class="p-2! mr-2 rounded-md bg-orange-500 hover:bg-orange-600 text-slate-900"
+        onclick={refreshVersionList}
+        disabled={isPending}
+      >
+        <IconRefresh
+          aria-label={$_("settings_versions_icon_refresh_altText")}
+        />
+      </Button>
+      <Button
+        class="p-2! rounded-md bg-orange-500 hover:bg-orange-600 text-slate-900"
+        onclick={async () =>
+          openPath((await getInstallationDirectory()) + "/versions/official/")}
+      >
+        <IconFolderOpen
+          aria-label={$_("settings_versions_icon_openFolder_altText")}
+        />
+      </Button>
+    </div>
+  </div>
+
+  <Latest latest={releases[0]} {onRemoveVersion} {onDownloadVersion} {isPending}
+  ></Latest>
+
   <VersionList
-    description={$_("settings_versions_official_description")}
-    releaseList={releases}
+    releaseList={releases.slice(1)}
     onVersionChange={saveOfficialVersionChange}
     {onRemoveVersion}
-    onRefreshVersions={refreshVersionList}
     {onDownloadVersion}
+    {isPending}
   />
 {:else}
   <Alert class="bg-slate-900 grow text-red-400">

--- a/src/routes/settings/Versions.svelte
+++ b/src/routes/settings/Versions.svelte
@@ -219,7 +219,12 @@
     </div>
   </div>
 
-  <Latest latest={releases[0]} {onRemoveVersion} {onDownloadVersion} {isPending}
+  <Latest
+    latest={releases[0]}
+    onVersionChange={saveOfficialVersionChange}
+    {onRemoveVersion}
+    {onDownloadVersion}
+    {isPending}
   ></Latest>
 
   <VersionList

--- a/src/routes/settings/versions/Latest.svelte
+++ b/src/routes/settings/versions/Latest.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+  import { Button, Badge } from "flowbite-svelte";
+  import type { ReleaseInfo } from "$lib/utils/github";
+  import { versionState } from "/src/state/VersionState.svelte";
+  import IconDeleteForever from "~icons/mdi/delete-forever";
+  import IconDownload from "~icons/mdi/download";
+  import IconCalendar from "~icons/mdi/CalendarMonth";
+  import IconRefresh from "~icons/mdi/refresh";
+  import IconGitHub from "~icons/mdi/github";
+  import IconCheck from "~icons/mdi/CheckBold";
+  import IconStar from "~icons/mdi/Star";
+  import { _ } from "svelte-i18n";
+  import { getLocale } from "$lib/rpc/config";
+  import { onMount } from "svelte";
+
+  let locale = $state("en-US");
+
+  onMount(async () => {
+    const res = await getLocale();
+    if (res) locale = res;
+  });
+
+  let {
+    latest,
+    onRemoveVersion,
+    onDownloadVersion,
+    isPending,
+  }: {
+    latest: ReleaseInfo;
+    onRemoveVersion: (version: string) => Promise<void>;
+    onDownloadVersion: (version: string, downloadUrl: string) => Promise<void>;
+    isPending: boolean;
+  } = $props();
+
+  const cleanDate = $derived.by(() => {
+    if (!latest?.date) return "N/A";
+    const date = new Date(latest.date);
+    return date.toLocaleString(locale, {
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+      timeZone: "UTC",
+    });
+  });
+
+  const installed = $derived.by(() => {
+    if (!latest?.version) return false;
+    return latest.version === versionState.activeToolingVersion;
+  });
+
+  const handleRemove = async () => {
+    await onRemoveVersion(latest.version);
+  };
+
+  const handleRedownload = async () => {
+    if (latest.downloadUrl) {
+      await onRemoveVersion(latest.version);
+      await onDownloadVersion(latest.version, latest.downloadUrl);
+    }
+  };
+
+  const handleDownload = async () => {
+    if (!latest.downloadUrl) return;
+    await onDownloadVersion(latest.version, latest.downloadUrl);
+  };
+</script>
+
+<div
+  class="flex items-center justify-between my-4 p-6 min-h-48 border border-green-500/40 rounded-md bg-green-800/15"
+>
+  <div class="flex flex-col gap-4">
+    <Badge color="green" class="w-fit gap-1 tracking-wide">
+      {#if installed}
+        <IconCheck /> {$_("settings_versions_active_version")}
+      {:else}
+        <IconStar /> {$_("settings_versions_latest_release")}
+      {/if}
+    </Badge>
+
+    <h1 class="text-4xl font-bold tracking-wide text-gray-200">
+      {latest?.version}
+    </h1>
+
+    <p class="flex items-center gap-1 tracking-wide text-gray-300 text-sm">
+      <IconCalendar /> Released {cleanDate}
+    </p>
+
+    <a
+      href={latest.githubLink}
+      target="_blank"
+      rel="noreferrer"
+      class="flex items-center gap-1 cursor-pointer tracking-wide text-gray-300 hover:text-white text-sm capitalize"
+    >
+      <IconGitHub />
+      {$_("settings_versions_icon_githubRelease_altText")}
+    </a>
+  </div>
+
+  <div class="flex flex-col items-end gap-2">
+    {#if installed || isPending}
+      <div class="flex flex-col gap-4">
+        <Button
+          class="gap-1 capitalize text-md font-semibold rounded-sm bg-white/10 border border-white/15 hover:bg-white/15"
+          onclick={handleRedownload}
+          disabled={isPending}
+        >
+          <IconRefresh
+            class="text-xl"
+            aria-label={$_("settings_versions_icon_redownloadVersion_altText")}
+          />
+          {$_("settings_versions_icon_redownloadVersion_altText")}
+        </Button>
+
+        <Button
+          class="gap-1 capitalize text-md font-semibold rounded-sm border border-white/15 bg-red-600/60 hover:bg-red-700"
+          onclick={handleRemove}
+          disabled={isPending}
+        >
+          <IconDeleteForever
+            class="text-xl"
+            color="white"
+            aria-label={$_("settings_versions_icon_removeVersion_altText")}
+          />{$_("settings_versions_icon_removeVersion_altText")}
+        </Button>
+      </div>
+    {:else}
+      <Button
+        class="px-8 py-3 text-lg gap-1 font-semibold rounded-sm text-gray-200 bg-green-500 hover:bg-green-600"
+        onclick={handleDownload}
+        disabled={isPending}
+      >
+        <IconDownload />
+        <span class="capitalize">
+          {$_("settings_versions_icon_downloadVersion_altText")}
+        </span>
+        {latest?.version}
+      </Button>
+    {/if}
+  </div>
+</div>

--- a/src/routes/settings/versions/Latest.svelte
+++ b/src/routes/settings/versions/Latest.svelte
@@ -97,7 +97,7 @@
   </div>
 
   <div class="flex flex-col items-end gap-2">
-    {#if installed || isPending}
+    {#if installed || latest.pendingAction}
       <div class="flex flex-col gap-4">
         <Button
           class="gap-1 capitalize text-md font-semibold rounded-sm bg-white/10 border border-white/15 hover:bg-white/15"

--- a/src/routes/settings/versions/Latest.svelte
+++ b/src/routes/settings/versions/Latest.svelte
@@ -90,7 +90,9 @@
     </h1>
 
     <p class="flex items-center gap-1 tracking-wide text-gray-300 text-sm">
-      <IconCalendar /> Released {cleanDate}
+      <IconCalendar />
+      {$_("settings_versions_released")}
+      {cleanDate}
     </p>
 
     <a

--- a/src/routes/settings/versions/Latest.svelte
+++ b/src/routes/settings/versions/Latest.svelte
@@ -2,6 +2,7 @@
   import { Button, Badge } from "flowbite-svelte";
   import type { ReleaseInfo } from "$lib/utils/github";
   import { versionState } from "/src/state/VersionState.svelte";
+  import IconArrowUp from "~icons/mdi/arrow-up-circle-outline";
   import IconDeleteForever from "~icons/mdi/delete-forever";
   import IconDownload from "~icons/mdi/download";
   import IconCalendar from "~icons/mdi/CalendarMonth";
@@ -22,11 +23,13 @@
 
   let {
     latest,
+    onVersionChange,
     onRemoveVersion,
     onDownloadVersion,
     isPending,
   }: {
     latest: ReleaseInfo;
+    onVersionChange: (version: string) => Promise<void>;
     onRemoveVersion: (version: string) => Promise<void>;
     onDownloadVersion: (version: string, downloadUrl: string) => Promise<void>;
     isPending: boolean;
@@ -43,7 +46,7 @@
     });
   });
 
-  const installed = $derived.by(() => {
+  const isActive = $derived.by(() => {
     if (!latest?.version) return false;
     return latest.version === versionState.activeToolingVersion;
   });
@@ -63,14 +66,19 @@
     if (!latest.downloadUrl) return;
     await onDownloadVersion(latest.version, latest.downloadUrl);
   };
+
+  const handleVersionChange = async () => {
+    await onVersionChange(latest.version);
+    versionState.activeToolingVersion = latest.version;
+  };
 </script>
 
 <div
-  class="flex items-center justify-between my-4 p-6 min-h-48 border border-green-500/40 rounded-md bg-green-800/15"
+  class="flex items-end justify-between my-4 p-6 min-h-48 border border-green-500/40 rounded-md bg-green-800/15"
 >
   <div class="flex flex-col gap-4">
     <Badge color="green" class="w-fit gap-1 tracking-wide">
-      {#if installed}
+      {#if isActive}
         <IconCheck /> {$_("settings_versions_active_version")}
       {:else}
         <IconStar /> {$_("settings_versions_latest_release")}
@@ -97,7 +105,7 @@
   </div>
 
   <div class="flex flex-col items-end gap-2">
-    {#if installed || latest.pendingAction}
+    {#if isActive || latest.pendingAction}
       <div class="flex flex-col gap-4">
         <Button
           class="gap-1 capitalize text-md font-semibold rounded-sm bg-white/10 border border-white/15 hover:bg-white/15"
@@ -123,9 +131,20 @@
           />{$_("settings_versions_icon_removeVersion_altText")}
         </Button>
       </div>
+    {:else if latest.isDownloaded}
+      <Button
+        class="px-8 py-3 text-lg gap-1 font-semibold rounded-sm text-gray-200 bg-green-600 hover:bg-green-700"
+        onclick={handleVersionChange}
+        disabled={isPending}
+      >
+        <IconArrowUp />
+        <span>
+          {$_("settings_versions_set_active_version")}
+        </span>
+      </Button>
     {:else}
       <Button
-        class="px-8 py-3 text-lg gap-1 font-semibold rounded-sm text-gray-200 bg-green-500 hover:bg-green-600"
+        class="px-8 py-3 text-lg gap-1 font-semibold rounded-sm text-gray-200 bg-green-600 hover:bg-green-700"
         onclick={handleDownload}
         disabled={isPending}
       >

--- a/src/routes/settings/versions/Latest.svelte
+++ b/src/routes/settings/versions/Latest.svelte
@@ -106,9 +106,9 @@
 
   <div class="flex flex-col items-end gap-2">
     {#if isActive || latest.pendingAction}
-      <div class="flex flex-col gap-4">
+      <div class="flex flex-col items-stretch gap-4">
         <Button
-          class="gap-1 capitalize text-md font-semibold rounded-sm bg-white/10 border border-white/15 hover:bg-white/15"
+          class="gap-1 capitalize text-lg font-semibold rounded-sm bg-white/10 border border-white/15 hover:bg-white/15"
           onclick={handleRedownload}
           disabled={isPending}
         >
@@ -120,7 +120,7 @@
         </Button>
 
         <Button
-          class="gap-1 capitalize text-md font-semibold rounded-sm border border-white/15 bg-red-600/60 hover:bg-red-700"
+          class="gap-1 capitalize text-lg font-semibold rounded-sm border border-white/15 bg-red-600/60 hover:bg-red-700"
           onclick={handleRemove}
           disabled={isPending}
         >
@@ -132,28 +132,44 @@
         </Button>
       </div>
     {:else if latest.isDownloaded}
-      <Button
-        class="px-8 py-3 text-lg gap-1 font-semibold rounded-sm text-gray-200 bg-green-600 hover:bg-green-700"
-        onclick={handleVersionChange}
-        disabled={isPending}
-      >
-        <IconArrowUp />
-        <span>
-          {$_("settings_versions_set_active_version")}
-        </span>
-      </Button>
+      <div class="flex flex-col items-stretch gap-4">
+        <Button
+          class="gap-1 text-lg font-semibold rounded-sm text-gray-200 bg-green-600 hover:bg-green-700"
+          onclick={handleVersionChange}
+          disabled={isPending}
+        >
+          <IconArrowUp />
+          <span>
+            {$_("settings_versions_set_active_version")}
+          </span>
+        </Button>
+
+        <Button
+          class="gap-1 text-lg capitalize font-semibold rounded-sm border border-white/15 bg-red-600/60 hover:bg-red-700"
+          onclick={handleRemove}
+          disabled={isPending}
+        >
+          <IconDeleteForever
+            class="text-xl"
+            color="white"
+            aria-label={$_("settings_versions_icon_removeVersion_altText")}
+          />{$_("settings_versions_icon_removeVersion_altText")}
+        </Button>
+      </div>
     {:else}
-      <Button
-        class="px-8 py-3 text-lg gap-1 font-semibold rounded-sm text-gray-200 bg-green-600 hover:bg-green-700"
-        onclick={handleDownload}
-        disabled={isPending}
-      >
-        <IconDownload />
-        <span class="capitalize">
-          {$_("settings_versions_icon_downloadVersion_altText")}
-        </span>
-        {latest?.version}
-      </Button>
+      <div class="flex flex-col items-stretch gap-4">
+        <Button
+          class="gap-1 text-lg font-semibold rounded-sm text-gray-200 bg-green-600 hover:bg-green-700"
+          onclick={handleDownload}
+          disabled={isPending}
+        >
+          <IconDownload />
+          <span class="capitalize">
+            {$_("settings_versions_icon_downloadVersion_altText")}
+          </span>
+          {latest?.version}
+        </Button>
+      </div>
     {/if}
   </div>
 </div>

--- a/src/routes/settings/versions/VersionList.svelte
+++ b/src/routes/settings/versions/VersionList.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type { ReleaseInfo } from "$lib/utils/github";
   import IconRefresh from "~icons/mdi/refresh";
-  import IconFolderOpen from "~icons/mdi/folder-open";
   import IconGitHub from "~icons/mdi/github";
   import IconDownload from "~icons/mdi/download";
   import IconDeleteForever from "~icons/mdi/delete-forever";
@@ -17,24 +16,20 @@
     TableHeadCell,
   } from "flowbite-svelte";
   import { _ } from "svelte-i18n";
-  import { openPath } from "@tauri-apps/plugin-opener";
-  import { getInstallationDirectory } from "$lib/rpc/config";
   import { versionState } from "/src/state/VersionState.svelte";
 
   let {
-    description,
     releaseList,
     onVersionChange,
     onRemoveVersion,
-    onRefreshVersions,
     onDownloadVersion,
+    isPending,
   }: {
-    description: string;
     releaseList: ReleaseInfo[];
     onVersionChange: (version: string) => Promise<void>;
     onRemoveVersion: (version: string) => Promise<void>;
-    onRefreshVersions: () => Promise<void>;
     onDownloadVersion: (version: string, downloadUrl: string) => Promise<void>;
+    isPending: boolean;
   } = $props();
 
   const handleAction = async (release: ReleaseInfo) => {
@@ -52,31 +47,6 @@
     }
   };
 </script>
-
-<div class="flex items-center mb-2">
-  <div class="grow">
-    <p class="text-sm text-gray-300">
-      {description}
-    </p>
-  </div>
-  <div class="flex">
-    <Button
-      class="p-2! mr-2 rounded-md bg-orange-500 hover:bg-orange-600 text-slate-900"
-      onclick={() => onRefreshVersions()}
-    >
-      <IconRefresh aria-label={$_("settings_versions_icon_refresh_altText")} />
-    </Button>
-    <Button
-      class="p-2! rounded-md bg-orange-500 hover:bg-orange-600 text-slate-900"
-      onclick={async () =>
-        openPath((await getInstallationDirectory()) + "/versions/official/")}
-    >
-      <IconFolderOpen
-        aria-label={$_("settings_versions_icon_openFolder_altText")}
-      />
-    </Button>
-  </div>
-</div>
 
 <Table>
   <TableHead class="bg-slate-400">
@@ -111,7 +81,7 @@
         >
           <Button
             class="py-0 bg-transparent focus:ring-0 disabled:opacity-50"
-            disabled={release.pendingAction}
+            disabled={isPending}
             onclick={async () => handleAction(release)}
           >
             {#if release.isDownloaded}
@@ -135,7 +105,7 @@
           {#if release.isDownloaded}
             <Button
               class="py-0 bg-transparent focus:ring-0 disabled:opacity-50"
-              disabled={release.pendingAction}
+              disabled={isPending}
               onclick={() => handleRedownload(release)}
             >
               {#if release.pendingAction}

--- a/src/routes/settings/versions/VersionList.svelte
+++ b/src/routes/settings/versions/VersionList.svelte
@@ -48,20 +48,22 @@
   };
 </script>
 
-<Table>
-  <TableHead class="bg-slate-400">
-    <TableHeadCell></TableHeadCell>
-    <TableHeadCell></TableHeadCell>
+<Table divClass="pt-2 rounded-md bg-zinc-800 border border-zinc-600/70">
+  <TableHead class="bg-zinc-800! text-zinc-200!">
+    <TableHeadCell class="w-12"></TableHeadCell>
+    <TableHeadCell class="w-28"></TableHeadCell>
     <TableHeadCell>{$_("settings_versions_table_header_version")}</TableHeadCell
     >
     <TableHeadCell>{$_("settings_versions_table_header_date")}</TableHeadCell>
     <TableHeadCell>{$_("settings_versions_table_header_changes")}</TableHeadCell
     >
   </TableHead>
-  <TableBody class="divide-y *:text-white">
+  <TableBody class="divide-y divide-zinc-700/70!">
     {#each releaseList as release (release.version)}
-      <TableBodyRow class="bg-slate-700">
-        <TableBodyCell class="px-6 py-2 whitespace-nowrap font-medium">
+      <TableBodyRow
+        class="bg-zinc-800/80! text-white transition-colors hover:bg-zinc-700/80! border!"
+      >
+        <TableBodyCell class="px-6 py-3">
           <Radio
             bind:group={versionState.activeToolingVersion}
             value={release.version}
@@ -69,65 +71,68 @@
               onVersionChange(release.version);
             }}
             disabled={!release.isDownloaded}
-            color="orange"
-            class="disabled:cursor-not-allowed p-0"
+            color="green"
+            class="p-0 disabled:cursor-not-allowed"
           />
         </TableBodyCell>
-        <TableBodyCell
-          class="px-6 py-2 whitespace-nowrap font-medium"
-          style="line-height: 0;"
-        >
-          <Button
-            class="py-0 bg-transparent focus:ring-0 disabled:opacity-50"
-            disabled={isPending}
-            onclick={async () => handleAction(release)}
-          >
-            {#if release.isDownloaded}
-              <IconDeleteForever
-                class="text-xl"
-                color="red"
-                aria-label={$_("settings_versions_icon_removeVersion_altText")}
-              />
-            {:else if release.pendingAction}
-              <Spinner color="yellow" size="6" />
-            {:else}
-              <IconDownload
-                class="text-xl"
-                color="#00d500"
-                aria-label={$_(
-                  "settings_versions_icon_downloadVersion_altText",
-                )}
-              />
-            {/if}
-          </Button>
-          {#if release.isDownloaded}
+
+        <TableBodyCell class="px-6 py-2">
+          <div class="flex items-center gap-4">
             <Button
-              class="py-0 bg-transparent focus:ring-0 disabled:opacity-50"
+              class="p-0 bg-transparent focus:ring-0 disabled:opacity-50"
               disabled={isPending}
-              onclick={() => handleRedownload(release)}
+              onclick={async () => handleAction(release)}
             >
-              {#if release.pendingAction}
+              {#if release.isDownloaded}
+                <IconDeleteForever
+                  class="text-xl text-red-500"
+                  aria-label={$_(
+                    "settings_versions_icon_removeVersion_altText",
+                  )}
+                />
+              {:else if release.pendingAction}
                 <Spinner color="yellow" size="6" />
               {:else}
-                <IconRefresh
-                  class="text-xl"
+                <IconDownload
+                  class="text-xl text-green-500"
                   aria-label={$_(
-                    "settings_versions_icon_redownloadVersion_altText",
+                    "settings_versions_icon_downloadVersion_altText",
                   )}
                 />
               {/if}
             </Button>
-          {/if}
+
+            {#if release.isDownloaded}
+              <Button
+                class="py-0 bg-transparent focus:ring-0 disabled:opacity-50"
+                disabled={isPending}
+                onclick={() => handleRedownload(release)}
+              >
+                {#if release.pendingAction}
+                  <Spinner color="yellow" size="6" />
+                {:else}
+                  <IconRefresh
+                    class="text-xl"
+                    aria-label={$_(
+                      "settings_versions_icon_redownloadVersion_altText",
+                    )}
+                  />
+                {/if}
+              </Button>
+            {/if}
+          </div>
         </TableBodyCell>
-        <TableBodyCell class="px-6 py-2 whitespace-nowrap font-medium">
+
+        <TableBodyCell class="px-6 py-3 whitespace-nowrap font-bold">
           {release.version}
         </TableBodyCell>
-        <TableBodyCell class="px-6 py-2 whitespace-nowrap font-medium">
+        <TableBodyCell class="px-6 py-3 whitespace-nowrap font-medium">
           {#if release.date}
             {new Date(release.date).toLocaleDateString()}
           {/if}
         </TableBodyCell>
-        <TableBodyCell class="px-6 py-2 whitespace-nowrap font-medium">
+
+        <TableBodyCell class="px-6 py-3">
           {#if release.githubLink}
             <a href={release.githubLink} target="_blank" rel="noreferrer">
               <IconGitHub

--- a/src/routes/settings/versions/VersionList.svelte
+++ b/src/routes/settings/versions/VersionList.svelte
@@ -17,6 +17,15 @@
   } from "flowbite-svelte";
   import { _ } from "svelte-i18n";
   import { versionState } from "/src/state/VersionState.svelte";
+  import { onMount } from "svelte";
+  import { getLocale } from "$lib/rpc/config";
+
+  let locale = $state("en-US");
+
+  onMount(async () => {
+    const res = await getLocale();
+    if (res) locale = res;
+  });
 
   let {
     releaseList,
@@ -128,7 +137,11 @@
         </TableBodyCell>
         <TableBodyCell class="px-6 py-3 whitespace-nowrap font-medium">
           {#if release.date}
-            {new Date(release.date).toLocaleDateString()}
+            {new Date(release.date).toLocaleString(locale, {
+              month: "short",
+              day: "numeric",
+              year: "numeric",
+            })}
           {/if}
         </TableBodyCell>
 

--- a/src/routes/settings/versions/VersionList.svelte
+++ b/src/routes/settings/versions/VersionList.svelte
@@ -62,18 +62,16 @@
     {#each releaseList as release (release.version)}
       <TableBodyRow class="bg-slate-700">
         <TableBodyCell class="px-6 py-2 whitespace-nowrap font-medium">
-          {#if release.isDownloaded}
-            <Radio
-              bind:group={versionState.activeToolingVersion}
-              value={release.version}
-              onchange={() => {
-                onVersionChange(release.version);
-              }}
-              disabled={!release.isDownloaded}
-              color="orange"
-              class="disabled:cursor-not-allowed p-0"
-            />
-          {/if}
+          <Radio
+            bind:group={versionState.activeToolingVersion}
+            value={release.version}
+            onchange={() => {
+              onVersionChange(release.version);
+            }}
+            disabled={!release.isDownloaded}
+            color="orange"
+            class="disabled:cursor-not-allowed p-0"
+          />
         </TableBodyCell>
         <TableBodyCell
           class="px-6 py-2 whitespace-nowrap font-medium"

--- a/src/routes/settings/versions/VersionList.svelte
+++ b/src/routes/settings/versions/VersionList.svelte
@@ -70,7 +70,7 @@
   <TableBody class="divide-y divide-zinc-700/70!">
     {#each releaseList as release (release.version)}
       <TableBodyRow
-        class="bg-zinc-800/80! text-white transition-colors hover:bg-zinc-700/80! border!"
+        class="bg-zinc-800/80! text-white transition-colors hover:bg-zinc-700/80! border-y!"
       >
         <TableBodyCell class="px-6 py-3">
           <Radio


### PR DESCRIPTION
I was inspired to make this change after seeing https://lawsofux.com/ on hackernews today. The choice overload section was of particular interest to me. My intention for this design change is to make it abundantly clear to the users what to do. I haven't seen any users struggle with navigating this page but I'd like to make sure it definitely doesn't happen. I plan on revisiting this settings page in the future to redesign the versions table.

Not Installed:
<img width="1026" height="642" alt="image" src="https://github.com/user-attachments/assets/b58c510c-2453-4090-bfeb-20508e218c99" />

Installed and not Active:
<img width="1026" height="642" alt="image" src="https://github.com/user-attachments/assets/b13669d0-10c8-4151-895d-77d9bb8a0ad1" />

Installed and Active:
<img width="1026" height="642" alt="image" src="https://github.com/user-attachments/assets/dbe47a2e-63ae-4acf-bc1e-653fbee41ae6" />