### PR TITLE
fix mod install bug

### DIFF
--- a/src-tauri/src/commands/features/mods.rs
+++ b/src-tauri/src/commands/features/mods.rs
@@ -419,7 +419,7 @@ pub async fn compile_for_mod_install(
   return Err(CommandError::GameFeatures(msg));
 }
 
-#[instrument(skip(config))]
+#[instrument(skip(config, app_handle))]
 #[tauri::command]
 pub async fn save_mod_install_info(
   config: tauri::State<'_, tokio::sync::Mutex<LauncherConfig>>,
@@ -427,6 +427,7 @@ pub async fn save_mod_install_info(
   mod_name: String,
   source_name: String,
   version_name: String,
+  app_handle: tauri::AppHandle,
 ) -> Result<(), CommandError> {
   let mut config_lock = config.lock().await;
   tracing::info!(
@@ -449,6 +450,7 @@ pub async fn save_mod_install_info(
       tracing::error!("Unable to remove mod source: {:?}", err);
       CommandError::Configuration("Unable to remove mod source".to_owned())
     })?;
+  app_handle.emit("config:saved", ())?;
   Ok(())
 }
 

--- a/src/lib/job/modJob.ts
+++ b/src/lib/job/modJob.ts
@@ -23,6 +23,25 @@ export async function setupModInstallation(
   jobTracker.init([
     {
       status: "queued",
+      label: $format("setup_download"),
+      task: async () => {
+        if (modDownloadUrl) {
+          let error = await downloadAndExtractNewMod(
+            activeGame,
+            modDownloadUrl,
+            modName,
+            modSourceName,
+          );
+          if (error) {
+            jobTracker.updateFailureReason(error);
+            return false;
+          }
+        }
+        return true;
+      },
+    },
+    {
+      status: "queued",
       label: $format("setup_extractAndVerify"),
       task: async () => {
         const isoAlreadyExtracted = await baseGameIsoExists(activeGame);
@@ -44,25 +63,6 @@ export async function setupModInstallation(
             }
           } else {
             jobTracker.updateFailureReason($format("setup_error_noISO"));
-            return false;
-          }
-        }
-        return true;
-      },
-    },
-    {
-      status: "queued",
-      label: $format("setup_download"),
-      task: async () => {
-        if (modDownloadUrl) {
-          let error = await downloadAndExtractNewMod(
-            activeGame,
-            modDownloadUrl,
-            modName,
-            modSourceName,
-          );
-          if (error) {
-            jobTracker.updateFailureReason(error);
             return false;
           }
         }


### PR DESCRIPTION
Changes the order of operations for mod installation to: download mod -> extract -> ... -> done.

This resolves the following error: `The directory name is invalid (os error 267)`
caused by: a fresh launcher install with no `iso_data`. The launcher would try to extract the iso contents using the mod extractor binary, however since we didn't have the mod binaries downloaded this would explode.

additional change: emit `config:saved` within `fn save_mod_install_info` for front-end reactivity.