### PR TITLE
change bundle category to "Game"

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
       "icons/icon.ico"
     ],
     "copyright": "",
-    "category": "DeveloperTool",
+    "category": "Game",
     "shortDescription": "",
     "longDescription": "",
     "createUpdaterArtifacts": false


### PR DESCRIPTION
`DeveloperTool` -> `Game`

When a user presses the Playstation button on their controller Launchpad opens and displays applications in the Games category.

Before:
<img width="2048" height="1323" alt="before" src="https://github.com/user-attachments/assets/9db1fc6a-f150-4326-982f-4a50c842370f" />
After:
<img width="3456" height="2234" alt="after" src="https://github.com/user-attachments/assets/e5e8b082-5672-4af1-b693-1e37b9953b39" />
