### PR TITLE
Add back icon for external link for mod sites

### DIFF
--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -43,6 +43,7 @@
   "gameControls_button_uninstall_confirmation": "Are you sure you want to uninstall?",
   "gameControls_button_uninstall_helpText": "This will not delete any saves or settings",
   "gameControls_button_uninstall": "Uninstall",
+  "gameControls_button_openModWebsite": "Open Mod Website",
   "gameControls_noToolingSet_button_setVersion": "Set Version",
   "gameControls_noToolingSet_header": "No Tooling Version Configured!",
   "gameControls_noToolingSet_subheader": "Head over to the following settings page to download the latest release",

--- a/src/components/games/GameControlsMod.svelte
+++ b/src/components/games/GameControlsMod.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { openPath } from "@tauri-apps/plugin-opener";
   import IconArrowLeft from "~icons/mdi/arrow-left";
+  import OpenInNew from "~icons/mdi/open-in-new";
   import IconCog from "~icons/mdi/cog";
   import { join } from "@tauri-apps/api/path";
   import { onDestroy, onMount } from "svelte";
@@ -218,12 +219,12 @@
     <div class="flex flex-col items-end pl-2 z-10">
       {#if modInfo?.websiteUrl}
         <a
-          class="mt-2 gap-2 text-3xl font-semibold tracking-tight text-orange-500 hover:text-orange-600 drop-shadow-[0_2px_10px_rgba(0,0,0,0.95)]"
+          class="inline-flex mt-2 gap-2 text-3xl font-semibold tracking-tight text-orange-500 hover:text-orange-600 drop-shadow-[0_2px_10px_rgba(0,0,0,0.95)]"
           target="_blank"
           rel="noreferrer"
           href={modInfo.websiteUrl}
         >
-          {displayName}
+          {displayName}<OpenInNew />
         </a>
       {:else}
         <h1

--- a/src/components/games/GameControlsMod.svelte
+++ b/src/components/games/GameControlsMod.svelte
@@ -2,6 +2,7 @@
   import { openPath } from "@tauri-apps/plugin-opener";
   import IconArrowLeft from "~icons/mdi/arrow-left";
   import IconCog from "~icons/mdi/cog";
+  import OpenInNew from "~icons/mdi/open-in-new";
   import { join } from "@tauri-apps/api/path";
   import { onDestroy, onMount } from "svelte";
   import { writeText } from "@tauri-apps/plugin-clipboard-manager";
@@ -250,6 +251,17 @@
               : modInfo.tags}
           </span>
         {/if}
+        {#if modInfo?.websiteUrl}
+          <span class="h-5 w-px bg-white/30"></span>
+          <a
+            class="pointer-events-auto hover:*:text-orange-300"
+            target="_blank"
+            rel="noreferrer"
+            title={$_("gameControls_button_openModWebsite")}
+            href={modInfo.websiteUrl}
+            ><OpenInNew />
+          </a>
+        {/if}
       </div>
     </div>
   </div>
@@ -494,14 +506,6 @@
               )}</Helper
             ></DropdownItem
           >
-          {#if modInfo?.websiteUrl}
-            <DropdownItem
-              href={modInfo.websiteUrl}
-              target="_blank"
-              rel="noreferrer"
-              >{$_("gameControls_button_openModWebsite")}
-            </DropdownItem>
-          {/if}
           <DropdownDivider />
           <DropdownItem
             onclick={async () => {

--- a/src/components/games/GameControlsMod.svelte
+++ b/src/components/games/GameControlsMod.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { openPath } from "@tauri-apps/plugin-opener";
   import IconArrowLeft from "~icons/mdi/arrow-left";
-  import OpenInNew from "~icons/mdi/open-in-new";
   import IconCog from "~icons/mdi/cog";
   import { join } from "@tauri-apps/api/path";
   import { onDestroy, onMount } from "svelte";
@@ -217,22 +216,11 @@
     class="mt-auto ml-auto mb-2 pr-4 max-w-xl text-right border-r-2 border-orange-500/80 bg-linear-to-l from-black/75 via-black/40 via-90% to-transparent mask-y-from-95%"
   >
     <div class="flex flex-col items-end pl-2 z-10">
-      {#if modInfo?.websiteUrl}
-        <a
-          class="inline-flex mt-2 gap-2 text-3xl font-semibold tracking-tight text-orange-500 hover:text-orange-600 drop-shadow-[0_2px_10px_rgba(0,0,0,0.95)]"
-          target="_blank"
-          rel="noreferrer"
-          href={modInfo.websiteUrl}
-        >
-          {displayName}<OpenInNew />
-        </a>
-      {:else}
-        <h1
-          class="mt-2 text-3xl font-semibold tracking-tight text-orange-500 pointer-events-none drop-shadow-[0_2px_10px_rgba(0,0,0,0.95)]"
-        >
-          {displayName}
-        </h1>
-      {/if}
+      <h1
+        class="mt-2 text-3xl font-semibold tracking-tight text-orange-500 pointer-events-none drop-shadow-[0_2px_10px_rgba(0,0,0,0.95)]"
+      >
+        {displayName}
+      </h1>
 
       <p
         class="mt-2 max-w-150 text-[1.05rem] font-light tracking-tight leading-6 text-white/88 pointer-events-none drop-shadow-[0_2px_10px_rgba(0,0,0,0.95)]"
@@ -506,6 +494,14 @@
               )}</Helper
             ></DropdownItem
           >
+          {#if modInfo?.websiteUrl}
+            <DropdownItem
+              href={modInfo.websiteUrl}
+              target="_blank"
+              rel="noreferrer"
+              >{$_("gameControls_button_openModWebsite")}
+            </DropdownItem>
+          {/if}
           <DropdownDivider />
           <DropdownItem
             onclick={async () => {


### PR DESCRIPTION
adds back the "open in new" icon next to mod name, when the mod website is available
<img width="1282" height="802" alt="image" src="https://github.com/user-attachments/assets/9fc0b438-ec07-4447-973d-1870c624e63f" />
