### PR TITLE
fix: Launcher displays a incorrect Mod Version update in title bar

### DIFF
--- a/src/components/header/Header.svelte
+++ b/src/components/header/Header.svelte
@@ -160,7 +160,7 @@
         {/if}
       </span>
 
-      {#if $UpdateStore.selectedTooling.updateAvailable}
+      {#if $UpdateStore.selectedTooling.updateAvailable && !versionState.displayModVersion}
         <a
           class="pointer-events-auto text-green-500 hover:text-green-300 animate-pulse relative"
           href="/settings/versions"


### PR DESCRIPTION
hides vanilla tooling update icon and tooltip when on a mod route
closes #1020